### PR TITLE
Improve Galaxy Tool Filtering and Add Dataset Head Reader

### DIFF
--- a/mcp-server-galaxy-py/main.py
+++ b/mcp-server-galaxy-py/main.py
@@ -327,35 +327,6 @@ def get_datesets_by_history(history_id: str) -> dict[str, Any]:
         raise ValueError(f"Failed to get datasets by history: {str(e)}")
 
 
-def read_header_lines_from_file(file_path: str, nrows: int = 5) -> list[str]:
-    """
-    Helper function to read the first n rows from a local file.
-
-    Args:
-        file_path (str): Path to the file.
-        nrows (int): Number of lines to read.
-        
-    Returns:
-        List[str]: List of lines read from the file.
-    """
-    with open(file_path, "r") as file:
-        return list(islice(file, nrows))
-
-
-def read_header_lines_from_content(content: str, nrows: int = 5) -> list[str]:
-    """
-    Helper function to read the first n rows from file content.
-
-    Args:
-        content (str): The file content as a string.
-        nrows (int): Number of lines to read.
-
-    Returns:
-        List[str]: List of the first nrows lines from the content.
-    """
-    lines = content.splitlines()
-    return lines[:nrows]
-
 @mcp.tool()
 def read_dataset_head(
     dataset_path: Optional[str] = None,
@@ -387,7 +358,8 @@ def read_dataset_head(
 
     if dataset_path:
         try:
-            return read_header_lines_from_file(dataset_path, nrows)
+            with open(dataset_path, "r") as file:
+                return list(islice(file, nrows))
         except Exception as e:
             raise ValueError(f"Error reading local dataset at '{dataset_path}': {e}")
 
@@ -400,7 +372,7 @@ def read_dataset_head(
             
             # Download the dataset content from Galaxy.
             file_content = galaxy_state["gi"].datasets.download_dataset(dataset_id)
-            return read_header_lines_from_content(file_content, nrows)
+            return file_content.splitlines()[:nrows]
         except Exception as e:
             raise ValueError(f"Failed to read dataset from Galaxy for ID '{dataset_id}': {e}")
 

--- a/mcp-server-galaxy-py/main.py
+++ b/mcp-server-galaxy-py/main.py
@@ -5,6 +5,8 @@ from mcp.server.fastmcp import FastMCP
 from bioblend.galaxy import GalaxyInstance
 import requests
 from dotenv import load_dotenv, find_dotenv
+import concurrent.futures
+import threading
 
 # Try to load environment variables from .env file
 dotenv_path = find_dotenv(usecwd=True)
@@ -204,20 +206,25 @@ def create_history(history_name: str) -> dict[str, Any]:
 
 
 @mcp.tool()
-def filter_tools_by_dataset(dataset_type: str) -> dict[str, Any]:
+def filter_tools_by_dataset(dataset_type: list[str]) -> dict[str, Any]:
     """
-    Filter Galaxy tools that are potentially suitable 
-    for a given dataset type.
+    Filter Galaxy tools that are potentially suitable for a given dataset type.
 
     Args:
-        dataset_type: A keyword or file type
-        (e.g., "fasta", "csv", "vcf") that describes the dataset.
+        dataset_type (list[str]): A list of keywords or phrases describing the dataset type,
+                                e.g., ['csv', 'tsv']. if the dataset type is csv or tsv,
+                                please provide ['csv', 'tabular'] or ['tsv', 'tabular'].
 
     Returns:
-        A dictionary containing the list of 
-        recommended tools and the count.
+        dict: A dictionary containing the list of recommended tools and the total count.
     """
+
     ensure_connected()
+
+    lock = threading.Lock()
+
+    dataset_keywords = [dt.lower() for dt in dataset_type]
+
     try:
         tool_panel = galaxy_state["gi"].tools.get_tool_panel()
 
@@ -231,26 +238,71 @@ def filter_tools_by_dataset(dataset_type: str) -> dict[str, Any]:
                     for item in panel["elems"]:
                         tools.extend(flatten_tools(item))
                 else:
-                    # If no sub-elements, assume 
-                    # this dict represents a tool.
+                    # Assume this dict represents a tool if no sub-elements exist.
                     tools.append(panel)
             return tools
 
         all_tools = flatten_tools(tool_panel)
-
-        # Filter the tools by checking if the dataset_type 
-        # keyword appears in their name or description.
         recommended_tools = []
-        keyword = dataset_type.lower()
+
+        # Separate tools that already match by name/description.
+        tools_to_fetch = []
         for tool in all_tools:
             name = (tool.get("name") or "").lower()
             description = (tool.get("description") or "").lower()
-            if keyword in name or keyword in description:
+            if any(kw in name for kw in dataset_keywords) or any(kw in description for kw in dataset_keywords):
                 recommended_tools.append(tool)
+            else:
+                tools_to_fetch.append(tool)
 
-        return {"recommended_tools": recommended_tools, "count": len(recommended_tools)}
+        # Define a helper to check each tool's details.
+        def check_tool(tool):
+            tool_id = tool.get("id")
+            if not tool_id:
+                return None
+            if tool_id.endswith("_label"):
+                return None
+            try:
+                tool_details = galaxy_state["gi"].tools.show_tool(tool_id, io_details=True)
+                tool_inputs = tool_details.get("inputs", [{}])
+                for input_spec in tool_inputs:
+                    if not isinstance(input_spec, dict):
+                        continue
+                    fmt = input_spec.get("extensions", "")
+                    # 'extensions' might be a list or a string.
+                    if isinstance(fmt, list):
+                        for ext in fmt:
+                            if ext and any(kw in ext.lower() for kw in dataset_keywords):
+                                return tool
+                    elif isinstance(fmt, str):
+                        if fmt and any(kw in fmt.lower() for kw in dataset_keywords):
+                            return tool
+                return None
+            except Exception as e:    
+                return None
+                
+
+        # Use a thread pool to concurrently check tools that require detail retrieval.
+        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+            future_to_tool = {executor.submit(check_tool, tool): tool for tool in tools_to_fetch}
+            for future in concurrent.futures.as_completed(future_to_tool):
+                result = future.result()
+                if result is not None:
+                    # Use the lock to ensure thread-safe appending.
+                    with lock:
+                        recommended_tools.append(result)
+        
+        slim_tools = []
+        for tool in recommended_tools:
+            slim_tools.append({
+                "id": tool.get("id", ""),
+                "name": tool.get("name", ""),
+                "description": tool.get("description", ""),
+                "versions": tool.get("versions", [])
+            })
+        return {"recommended_tools": slim_tools, "count": len(slim_tools)}
     except Exception as e:
-        raise ValueError(f"Failed to filter tools based on dataset: {str(e)}")
+        return {"error": str(e)}
 
 
 @mcp.tool()

--- a/mcp-server-galaxy-py/main.py
+++ b/mcp-server-galaxy-py/main.py
@@ -328,56 +328,6 @@ def get_datesets_by_history(history_id: str) -> dict[str, Any]:
 
 
 @mcp.tool()
-def read_dataset_head(
-    dataset_path: Optional[str] = None,
-    dataset_id: Optional[str] = None,
-    nrows: int = 5,
-) -> list[str]:
-    """
-    Read the header (first few lines) of a dataset in Galaxy.
-
-    Either 'dataset_path' or 'dataset_id' must be provided.
-
-    Args:
-        dataset_path (Optional[str]): Local path to the dataset file.
-        dataset_id (Optional[str]): The ID of the dataset to read from Galaxy.
-        nrows (int): Number of lines to read from the top of the dataset.
-
-    Returns:
-        List[str]: List of the first nrows lines from the dataset.
-
-    Raises:
-        ValueError: If neither dataset_path nor dataset_id is provided, or if an error 
-                    occurs during dataset retrieval or file reading.
-    """
-    if nrows < 1:
-        raise ValueError("nrows must be greater than 0.")
-
-    if not dataset_path and not dataset_id:
-        raise ValueError("Either dataset_path or dataset_id must be provided.")
-
-    if dataset_path:
-        try:
-            with open(dataset_path, "r") as file:
-                return list(islice(file, nrows))
-        except Exception as e:
-            raise ValueError(f"Error reading local dataset at '{dataset_path}': {e}")
-
-    if dataset_id:
-        ensure_connected()
-        try:
-            dataset = galaxy_state["gi"].datasets.show_dataset(dataset_id=dataset_id)
-            if not dataset:
-                raise ValueError(f"Dataset with ID '{dataset_id}' not found in Galaxy.")
-            
-            # Download the dataset content from Galaxy.
-            file_content = galaxy_state["gi"].datasets.download_dataset(dataset_id)
-            return file_content.splitlines()[:nrows]
-        except Exception as e:
-            raise ValueError(f"Failed to read dataset from Galaxy for ID '{dataset_id}': {e}")
-
-
-@mcp.tool()
 def get_user() -> dict[str, Any]:
     """
     Get current user information


### PR DESCRIPTION
improve Galaxy tool filtering

- Changed dataset_type to a list to handle cases where multiple types apply (e.g., Tabular also works for CSV).
- Used threading to speed up the filtering process, as I added match detection for tool input parameters.

a tool for reading the dataset head allowing the LLM to recommend Galaxy tools based on dataset content