### PR TITLE
Add server info tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Note: There is also a work-in-progress TypeScript implementation available in a 
 ## Key Features
 
 - **Galaxy Connection**: Connect to any Galaxy instance with a URL and API key
+- **Server Information**: Retrieve comprehensive server details including version, configuration, and capabilities
 - **Tools Management**: Search, view details, and execute Galaxy tools
 - **Workflow Integration**: Access and import workflows from the Interactive Workflow Composer (IWC)
 - **History Operations**: Manage Galaxy histories and datasets

--- a/mcp-server-galaxy-py/CHANGELOG.md
+++ b/mcp-server-galaxy-py/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2025-05-21
 
 ### Added
 

--- a/mcp-server-galaxy-py/CHANGELOG.md
+++ b/mcp-server-galaxy-py/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `get_server_info` MCP tool to retrieve comprehensive Galaxy server information including version, URL, and configuration details
+
 ## [0.1.0] - 2025-01-16
 
 ### Added

--- a/mcp-server-galaxy-py/DEVELOPMENT.md
+++ b/mcp-server-galaxy-py/DEVELOPMENT.md
@@ -55,6 +55,7 @@ uv run pre-commit autoupdate
 ```
 
 Pre-commit hooks include:
+
 - Trailing whitespace removal
 - End-of-file fixing
 - YAML/JSON/TOML validation
@@ -208,15 +209,15 @@ The project uses GitHub Actions for CI/CD:
 
 1. **Python Tests** (`python-tests.yml`)
 
-   - Runs on push/PR to main branch
-   - Tests on Python 3.10, 3.11, 3.12
-   - Includes linting, type checking, and coverage
-   - Uploads coverage to Codecov
+    - Runs on push/PR to main branch
+    - Tests on Python 3.10, 3.11, 3.12
+    - Includes linting, type checking, and coverage
+    - Uploads coverage to Codecov
 
 2. **Release** (`python-release.yml`)
-   - Triggered on GitHub release
-   - Builds and publishes to PyPI
-   - Optionally publishes to Test PyPI first
+    - Triggered on GitHub release
+    - Builds and publishes to PyPI
+    - Optionally publishes to Test PyPI first
 
 ### Local CI Simulation
 

--- a/mcp-server-galaxy-py/README.md
+++ b/mcp-server-galaxy-py/README.md
@@ -256,6 +256,7 @@ git commit --no-verify
 ```
 
 Pre-commit runs automatically on `git commit` and includes:
+
 - Code formatting with ruff
 - Linting with ruff
 - Trailing whitespace removal

--- a/mcp-server-galaxy-py/USAGE_EXAMPLES.md
+++ b/mcp-server-galaxy-py/USAGE_EXAMPLES.md
@@ -17,6 +17,26 @@ connect()
 connect(url="https://your-galaxy-instance.org", api_key="your-api-key")
 ```
 
+#### Get server information
+
+Once connected, you can retrieve comprehensive information about the Galaxy server:
+
+```python
+server_info = get_server_info()
+# Returns: {
+#   "url": "https://your-galaxy-instance.org/",
+#   "version": {"version_major": "23.1", "version_minor": "1", ...},
+#   "config": {
+#     "brand": "Galaxy",
+#     "allow_user_creation": true,
+#     "enable_quotas": false,
+#     "ftp_upload_site": "ftp.galaxy.org",
+#     "support_url": "https://help.galaxyproject.org/",
+#     ...
+#   }
+# }
+```
+
 ### 2. Working with Histories
 
 #### List all histories
@@ -166,17 +186,17 @@ if target_history:
 
 1. **"History ID invalid" error**
 
-   - Problem: Passing the entire history object instead of just the ID
-   - Solution: Use `history["id"]` not `history`
+    - Problem: Passing the entire history object instead of just the ID
+    - Solution: Use `history["id"]` not `history`
 
 2. **"Not connected to Galaxy" error**
 
-   - Problem: Trying to use tools before connecting
-   - Solution: Always call `connect()` first
+    - Problem: Trying to use tools before connecting
+    - Solution: Always call `connect()` first
 
 3. **"Tool not found" error**
-   - Problem: Using incorrect tool ID format
-   - Solution: Use the full tool ID from `search_tools()` or `get_tool_panel()`
+    - Problem: Using incorrect tool ID format
+    - Solution: Use the full tool ID from `search_tools()` or `get_tool_panel()`
 
 ## Best Practices
 

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -347,6 +347,54 @@ def filter_tools_by_dataset(dataset_type: str) -> dict[str, Any]:
 
 
 @mcp.tool()
+def get_server_info() -> dict[str, Any]:
+    """
+    Get Galaxy server information including version, URL, and configuration details
+
+    Returns:
+        Server information including version, URL, and other configuration details
+    """
+    ensure_connected()
+
+    try:
+        # Get server configuration info
+        config_info = galaxy_state["gi"].config.get_config()
+
+        # Get server version info
+        version_info = galaxy_state["gi"].config.get_version()
+
+        # Build comprehensive server info response
+        server_info = {
+            "url": galaxy_state["url"],
+            "version": version_info,
+            "config": {
+                "brand": config_info.get("brand", "Galaxy"),
+                "logo_url": config_info.get("logo_url"),
+                "welcome_url": config_info.get("welcome_url"),
+                "support_url": config_info.get("support_url"),
+                "citation_url": config_info.get("citation_url"),
+                "terms_url": config_info.get("terms_url"),
+                "allow_user_creation": config_info.get("allow_user_creation"),
+                "allow_user_deletion": config_info.get("allow_user_deletion"),
+                "enable_quotas": config_info.get("enable_quotas"),
+                "ftp_upload_site": config_info.get("ftp_upload_site"),
+                "wiki_url": config_info.get("wiki_url"),
+                "screencasts_url": config_info.get("screencasts_url"),
+                "library_import_dir": config_info.get("library_import_dir"),
+                "user_library_import_dir": config_info.get("user_library_import_dir"),
+                "allow_library_path_paste": config_info.get("allow_library_path_paste"),
+                "enable_unique_workflow_defaults": config_info.get(
+                    "enable_unique_workflow_defaults"
+                ),
+            },
+        }
+
+        return server_info
+    except Exception as e:
+        raise ValueError(f"Failed to get server information: {str(e)}") from e
+
+
+@mcp.tool()
 def get_user() -> dict[str, Any]:
     """
     Get current user information

--- a/mcp-server-galaxy-py/tests/README.md
+++ b/mcp-server-galaxy-py/tests/README.md
@@ -72,13 +72,13 @@ These tests can be integrated into CI/CD pipelines. Example GitHub Actions workf
 name: Tests
 on: [push, pull_request]
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-      - run: pip install -r requirements.txt -r requirements-test.txt
-      - run: pytest --cov=main
+    test:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: "3.11"
+            - run: pip install -r requirements.txt -r requirements-test.txt
+            - run: pytest --cov=main
 ```

--- a/mcp-server-galaxy-py/tests/TEST_STRATEGY.md
+++ b/mcp-server-galaxy-py/tests/TEST_STRATEGY.md
@@ -16,10 +16,10 @@ The best approach for writing integration tests for the Galaxy MCP server is to 
 ### Test Infrastructure
 
 - **conftest.py**: Contains shared fixtures for:
-  - Mock Galaxy instance with pre-configured responses
-  - Test environment variables
-  - Auto-reset of galaxy state between tests
-  - Mock MCP context for tool testing
+    - Mock Galaxy instance with pre-configured responses
+    - Test environment variables
+    - Auto-reset of galaxy state between tests
+    - Mock MCP context for tool testing
 
 ### Test Organization
 
@@ -38,24 +38,24 @@ tests/
 
 1. **Mock Galaxy API Responses**:
 
-   ```python
-   mock_galaxy_instance.histories.get_histories.return_value = [
-       {"id": "test_history_1", "name": "Test History 1"}
-   ]
-   ```
+    ```python
+    mock_galaxy_instance.histories.get_histories.return_value = [
+        {"id": "test_history_1", "name": "Test History 1"}
+    ]
+    ```
 
 2. **Test State Isolation**:
 
-   ```python
-   with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
-       # Test code here
-   ```
+    ```python
+    with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+        # Test code here
+    ```
 
 3. **Error Validation**:
-   ```python
-   with pytest.raises(ValueError, match="Expected error message"):
-       function_under_test(invalid_input)
-   ```
+    ```python
+    with pytest.raises(ValueError, match="Expected error message"):
+        function_under_test(invalid_input)
+    ```
 
 ## Running Tests
 

--- a/mcp-server-galaxy-py/tests/conftest.py
+++ b/mcp-server-galaxy-py/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from bioblend.galaxy import GalaxyInstance
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_galaxy_instance():
     """Mock GalaxyInstance for tests"""
     mock_gi = Mock(spec=GalaxyInstance)
@@ -53,6 +53,42 @@ def mock_galaxy_instance():
     mock_datasets.download_dataset.return_value = b"test content"
     mock_gi.datasets = mock_datasets
 
+    # Mock config
+    mock_config = Mock()
+    mock_config.get_config.return_value = {
+        "brand": "Galaxy",
+        "logo_url": None,
+        "welcome_url": None,
+        "support_url": None,
+        "citation_url": None,
+        "terms_url": None,
+        "allow_user_creation": True,
+        "allow_user_deletion": False,
+        "enable_quotas": True,
+        "ftp_upload_site": None,
+        "wiki_url": None,
+        "screencasts_url": None,
+        "library_import_dir": None,
+        "user_library_import_dir": None,
+        "allow_library_path_paste": False,
+        "enable_unique_workflow_defaults": False,
+    }
+    mock_config.get_version.return_value = {
+        "version_major": "23.1",
+        "version_minor": "1",
+        "extra": {},
+    }
+    mock_gi.config = mock_config
+
+    # Mock users
+    mock_users = Mock()
+    mock_users.get_current_user.return_value = {
+        "id": "user1",
+        "email": "test@example.com",
+        "username": "testuser",
+    }
+    mock_gi.users = mock_users
+
     return mock_gi
 
 
@@ -75,7 +111,7 @@ def _reset_galaxy_state():
     galaxy_state.update(original_state)
 
 
-@pytest.fixture()
+@pytest.fixture
 def _test_env():
     """Set up test environment variables"""
     original_env = os.environ.copy()
@@ -95,7 +131,7 @@ def _test_env():
     os.environ.update(original_env)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mcp_server_instance(mock_galaxy_instance, _test_env):
     """Create MCP server instance with mocked Galaxy"""
     # Import and reset galaxy state
@@ -121,7 +157,7 @@ def mcp_server_instance(mock_galaxy_instance, _test_env):
         galaxy_state.update(original_state)
 
 
-@pytest.fixture()
+@pytest.fixture
 def event_loop():
     """Create event loop for async tests"""
     loop = asyncio.new_event_loop()

--- a/mcp-server-galaxy-py/tests/test_connection.py
+++ b/mcp-server-galaxy-py/tests/test_connection.py
@@ -5,7 +5,8 @@ Test Galaxy connection and authentication
 from unittest.mock import patch
 
 import pytest
-from galaxy_mcp.server import ensure_connected, galaxy_state
+
+from galaxy_mcp.server import ensure_connected, galaxy_state, get_server_info
 
 
 @pytest.mark.usefixtures("_test_env")
@@ -57,3 +58,55 @@ class TestConnection:
             with patch.dict(galaxy_state, {"connected": False}):
                 # Without credentials, should not connect
                 assert not galaxy_state.get("connected", False)
+
+    def test_get_server_info_success(self, mock_galaxy_instance):
+        """Test successful server info retrieval"""
+        # Mock server config and version responses
+        mock_config = {
+            "brand": "Test Galaxy",
+            "logo_url": "https://galaxy.test/logo.png",
+            "welcome_url": "https://galaxy.test/welcome",
+            "support_url": "https://galaxy.test/support",
+            "allow_user_creation": True,
+            "enable_quotas": False,
+            "ftp_upload_site": "ftp.galaxy.test",
+        }
+
+        mock_version = {"version_major": "23.1", "version_minor": "1", "extra": {}}
+
+        mock_galaxy_instance.config.get_config.return_value = mock_config
+        mock_galaxy_instance.config.get_version.return_value = mock_version
+
+        with patch.dict(
+            galaxy_state,
+            {"connected": True, "gi": mock_galaxy_instance, "url": "https://galaxy.test/"},
+        ):
+            result = get_server_info()
+
+            # Verify the structure and content
+            assert "url" in result
+            assert "version" in result
+            assert "config" in result
+
+            assert result["url"] == "https://galaxy.test/"
+            assert result["version"] == mock_version
+            assert result["config"]["brand"] == "Test Galaxy"
+            assert result["config"]["allow_user_creation"] is True
+
+            # Verify API calls were made
+            mock_galaxy_instance.config.get_config.assert_called_once()
+            mock_galaxy_instance.config.get_version.assert_called_once()
+
+    def test_get_server_info_not_connected(self):
+        """Test server info fails when not connected"""
+        with patch.dict(galaxy_state, {"connected": False}):
+            with pytest.raises(ValueError, match="Not connected to Galaxy"):
+                get_server_info()
+
+    def test_get_server_info_api_error(self, mock_galaxy_instance):
+        """Test server info handles API errors gracefully"""
+        mock_galaxy_instance.config.get_config.side_effect = Exception("API Error")
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            with pytest.raises(ValueError, match="Failed to get server information"):
+                get_server_info()

--- a/mcp-server-galaxy-py/tests/test_dataset_operations.py
+++ b/mcp-server-galaxy-py/tests/test_dataset_operations.py
@@ -5,6 +5,7 @@ Test dataset-related operations
 from unittest.mock import patch
 
 import pytest
+
 from galaxy_mcp.server import galaxy_state, upload_file
 
 

--- a/mcp-server-galaxy-py/tests/test_history_operations.py
+++ b/mcp-server-galaxy-py/tests/test_history_operations.py
@@ -5,6 +5,7 @@ Test history-related operations
 from unittest.mock import patch
 
 import pytest
+
 from galaxy_mcp.server import (
     galaxy_state,
     get_histories,

--- a/mcp-server-galaxy-py/tests/test_integration.py
+++ b/mcp-server-galaxy-py/tests/test_integration.py
@@ -5,6 +5,7 @@ Integration tests for complete workflows
 from unittest.mock import Mock, patch
 
 import pytest
+
 from galaxy_mcp.server import galaxy_state
 
 

--- a/mcp-server-galaxy-py/tests/test_tool_operations.py
+++ b/mcp-server-galaxy-py/tests/test_tool_operations.py
@@ -5,6 +5,7 @@ Test tool-related operations
 from unittest.mock import patch
 
 import pytest
+
 from galaxy_mcp.server import galaxy_state, run_tool, search_tools
 
 

--- a/mcp-server-galaxy-py/tests/test_workflow_operations.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_operations.py
@@ -5,6 +5,7 @@ Test workflow-related operations
 from unittest.mock import Mock, patch
 
 import pytest
+
 from galaxy_mcp.server import (
     galaxy_state,
     get_invocations,


### PR DESCRIPTION
## Description
Adds `get_server_info` MCP tool to retrieve comprehensive Galaxy server information including version, URL, and configuration details

## Type of Change
<!-- Check the relevant boxes -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] ⬆️ Dependency update
- [x] 🧰 Maintenance/chore

## Checklist
- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

