### PR TITLE
Add missing pre-commit dependency and tweak makefile targets

### DIFF
--- a/mcp-server-galaxy-py/Makefile
+++ b/mcp-server-galaxy-py/Makefile
@@ -8,7 +8,6 @@ help:
 	@echo "  make install-dev    Install development dependencies"
 	@echo "  make lint          Run linting checks (via pre-commit)"
 	@echo "  make format        Auto-format code (via pre-commit)"
-	@echo "  make format-quick  Quick format (ruff + prettier only)"
 	@echo "  make test          Run tests"
 	@echo "  make test-cov      Run tests with coverage"
 	@echo "  make test-watch    Run tests in watch mode"
@@ -37,11 +36,6 @@ format:
 	uv run pre-commit run --all-files
 	npx prettier --write "**/*.md"
 
-# Quick format (just ruff + prettier without other pre-commit hooks)
-format-quick:
-	uv run ruff format .
-	uv run ruff check --fix . --ignore PT004,PT019
-	npx prettier --write "**/*.md"
 
 # Run tests
 test:

--- a/mcp-server-galaxy-py/requirements-test.txt
+++ b/mcp-server-galaxy-py/requirements-test.txt
@@ -6,3 +6,4 @@ pytest-watch>=4.2.0
 responses>=0.25.0
 httpx>=0.27.0
 ruff>=0.11.10
+pre-commit>=4.0.0

--- a/mcp-server-galaxy-py/uv.lock
+++ b/mcp-server-galaxy-py/uv.lock
@@ -564,7 +564,7 @@ wheels = [
 
 [[package]]
 name = "galaxy-mcp"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "bioblend" },


### PR DESCRIPTION
- Adds pre-commit to requirements-test.txt to fix "make lint" command
- Removes redundant format-quick target in favor of comprehensive format command
  
  
## Type of Change
<!-- Check the relevant boxes -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ⬆️ Dependency update
- [ ] 🧰 Maintenance/chore

## Checklist
- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

## Related Issues
<!-- Link to related issues if any -->
Closes #
