### PR TITLE
Update get_job_details to accept dataset ID instead of job ID

### DIFF
--- a/mcp-server-galaxy-py/tests/test_job_operations.py
+++ b/mcp-server-galaxy-py/tests/test_job_operations.py
@@ -1,0 +1,138 @@
+"""Tests for job operations"""
+
+import json
+
+import pytest
+import responses
+from galaxy_mcp.server import galaxy_state
+
+from tests.test_helpers import get_job_details_fn
+
+
+class TestJobOperations:
+    def setup_method(self):
+        """Set up test environment before each test"""
+        galaxy_state["connected"] = True
+        galaxy_state["gi"] = type("MockGI", (), {})()
+        galaxy_state["url"] = "http://localhost:8080/"
+        galaxy_state["api_key"] = "test_key"
+
+    def teardown_method(self):
+        """Clean up after each test"""
+        galaxy_state["connected"] = False
+        galaxy_state["gi"] = None
+
+    @responses.activate
+    def test_get_job_details_with_provenance(self):
+        """Test getting job details using dataset provenance"""
+        dataset_id = "dataset123"
+        job_id = "job456"
+
+        # Mock the bioblend provenance call
+        mock_gi = type("MockGI", (), {})()
+        mock_histories = type("MockHistories", (), {})()
+        mock_histories.show_dataset_provenance = lambda history_id, dataset_id: {"job_id": job_id}
+        mock_gi.histories = mock_histories
+        galaxy_state["gi"] = mock_gi
+
+        # Mock the Galaxy API job details call
+        responses.add(
+            responses.GET,
+            f"http://localhost:8080/api/jobs/{job_id}",
+            json={"id": job_id, "tool_id": "test_tool", "state": "ok"},
+            status=200,
+        )
+
+        result = get_job_details_fn(dataset_id)
+
+        assert result["job"]["id"] == job_id
+        assert result["dataset_id"] == dataset_id
+        assert result["job_id"] == job_id
+
+    @responses.activate
+    def test_get_job_details_fallback_to_dataset_details(self):
+        """Test fallback to dataset details when provenance fails"""
+        dataset_id = "dataset123"
+        job_id = "job456"
+
+        # Mock the bioblend calls
+        mock_gi = type("MockGI", (), {})()
+        mock_histories = type("MockHistories", (), {})()
+        mock_datasets = type("MockDatasets", (), {})()
+
+        # Provenance fails
+        mock_histories.show_dataset_provenance = lambda history_id, dataset_id: None
+        # Dataset details has creating_job
+        mock_datasets.show_dataset = lambda dataset_id: {"creating_job": job_id}
+
+        mock_gi.histories = mock_histories
+        mock_gi.datasets = mock_datasets
+        galaxy_state["gi"] = mock_gi
+
+        # Mock the Galaxy API job details call
+        responses.add(
+            responses.GET,
+            f"http://localhost:8080/api/jobs/{job_id}",
+            json={"id": job_id, "tool_id": "test_tool", "state": "ok"},
+            status=200,
+        )
+
+        result = get_job_details_fn(dataset_id)
+
+        assert result["job"]["id"] == job_id
+        assert result["dataset_id"] == dataset_id
+        assert result["job_id"] == job_id
+
+    def test_get_job_details_no_job_found(self):
+        """Test error when no job information is found"""
+        dataset_id = "dataset123"
+
+        # Mock the bioblend calls to return no job info
+        mock_gi = type("MockGI", (), {})()
+        mock_histories = type("MockHistories", (), {})()
+        mock_datasets = type("MockDatasets", (), {})()
+
+        mock_histories.show_dataset_provenance = lambda history_id, dataset_id: {}
+        mock_datasets.show_dataset = lambda dataset_id: {}
+
+        mock_gi.histories = mock_histories
+        mock_gi.datasets = mock_datasets
+        galaxy_state["gi"] = mock_gi
+
+        with pytest.raises(ValueError, match="No job information found"):
+            get_job_details_fn(dataset_id)
+
+    @responses.activate
+    def test_get_job_details_with_dict_string(self):
+        """Test handling dataset_id as JSON string"""
+        dataset_dict = {"id": "dataset123", "name": "test"}
+        dataset_id_str = json.dumps(dataset_dict)
+        job_id = "job456"
+
+        # Mock the bioblend provenance call
+        mock_gi = type("MockGI", (), {})()
+        mock_histories = type("MockHistories", (), {})()
+        mock_histories.show_dataset_provenance = lambda history_id, dataset_id: {"job_id": job_id}
+        mock_gi.histories = mock_histories
+        galaxy_state["gi"] = mock_gi
+
+        # Mock the Galaxy API job details call
+        responses.add(
+            responses.GET,
+            f"http://localhost:8080/api/jobs/{job_id}",
+            json={"id": job_id, "tool_id": "test_tool", "state": "ok"},
+            status=200,
+        )
+
+        result = get_job_details_fn(dataset_id_str)
+
+        assert result["job"]["id"] == job_id
+        assert result["dataset_id"] == "dataset123"  # Extracted from JSON
+        assert result["job_id"] == job_id
+
+    def test_get_job_details_not_connected(self):
+        """Test error when not connected to Galaxy"""
+        galaxy_state["connected"] = False
+
+        with pytest.raises(ValueError, match="Not connected to Galaxy"):
+            get_job_details_fn("dataset123")

--- a/mcp-server-galaxy-py/uv.lock
+++ b/mcp-server-galaxy-py/uv.lock
@@ -654,7 +654,7 @@ wheels = [
 
 [[package]]
 name = "galaxy-mcp"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "bioblend" },


### PR DESCRIPTION
The method now takes a dataset ID as input and uses bioblend's show_dataset_provenance() to find the job that created the dataset, which is the more common use case. Added comprehensive tests covering provenance lookup, fallback to dataset details, and error handling scenarios.

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Check the relevant boxes -->
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ⬆️ Dependency update
- [ ] 🧰 Maintenance/chore

## Checklist
- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Related Issues
<!-- Link to related issues if any -->
Closes #
