### PR TITLE
Add dataset content access tools: get_dataset_details and download_dataset

### DIFF
--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -518,8 +518,7 @@ def get_history_details(history_id: str) -> dict[str, Any]:
     Get detailed information about a specific history, including datasets
 
     Args:
-        history_id: ID of the history (the 'id' field from get_histories(),
-            not the entire history object)
+        history_id: Galaxy history ID (string hash)
 
     Returns:
         History details with datasets
@@ -527,24 +526,6 @@ def get_history_details(history_id: str) -> dict[str, Any]:
     ensure_connected()
 
     try:
-        # Check if the history_id looks like a dictionary string
-        if history_id.startswith("{") and history_id.endswith("}"):
-            # Try to parse it and extract the actual ID
-            import json
-
-            try:
-                history_dict = json.loads(history_id)
-                history_id = history_dict.get("id")
-                logger.warning(
-                    f"Received full history object instead of ID, extracting ID: {history_id}"
-                )
-            except json.JSONDecodeError as json_error:
-                logger.error(f"Invalid history_id format: {history_id}")
-                raise ValueError(
-                    "Invalid history_id: expected a history ID string, "
-                    "got what looks like a malformed dictionary"
-                ) from json_error
-
         logger.info(f"Getting details for history ID: {history_id}")
 
         # Get history details
@@ -560,8 +541,7 @@ def get_history_details(history_id: str) -> dict[str, Any]:
         logger.error(f"Failed to get history details for ID '{history_id}': {str(e)}")
         if "404" in str(e) or "No route" in str(e):
             raise ValueError(
-                f"History ID '{history_id}' not found. Make sure to pass just "
-                "the ID string from get_histories(), not the entire history object."
+                f"History ID '{history_id}' not found. Make sure to pass a valid history ID string."
             ) from e
         raise ValueError(f"Failed to get history details for ID '{history_id}': {str(e)}") from e
 
@@ -572,7 +552,7 @@ def get_job_details(dataset_id: str, history_id: str | None = None) -> dict[str,
     Get detailed information about the job that created a specific dataset
 
     Args:
-        dataset_id: ID of the dataset (will find the job that created it)
+        dataset_id: Galaxy dataset ID (string hash) to find the creating job for
         history_id: ID of the history containing the dataset (optional, for optimization)
 
     Returns:
@@ -581,22 +561,6 @@ def get_job_details(dataset_id: str, history_id: str | None = None) -> dict[str,
     ensure_connected()
 
     try:
-        # Check if dataset_id looks like a dictionary string and extract the ID
-        if dataset_id.startswith("{") and dataset_id.endswith("}"):
-            import json
-
-            try:
-                dataset_dict = json.loads(dataset_id)
-                dataset_id = dataset_dict.get("id")
-                logger.warning(
-                    f"Received full dataset object instead of ID, extracting ID: {dataset_id}"
-                )
-            except json.JSONDecodeError as json_error:
-                raise ValueError(
-                    "Invalid dataset_id: expected a dataset ID string, "
-                    "got what looks like a malformed dictionary"
-                ) from json_error
-
         # Get dataset provenance to find the creating job
         try:
             provenance = galaxy_state["gi"].histories.show_dataset_provenance(

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -653,7 +653,7 @@ def get_dataset_details(
     Get detailed information about a specific dataset, optionally including a content preview
 
     Args:
-        dataset_id: ID of the dataset
+        dataset_id: Galaxy dataset ID (string hash)
         include_preview: Whether to include a preview of the dataset content (default: True)
         preview_lines: Number of lines to include in preview (default: 10)
 
@@ -663,22 +663,6 @@ def get_dataset_details(
     ensure_connected()
 
     try:
-        # Check if dataset_id looks like a dictionary string and extract the ID
-        if dataset_id.startswith("{") and dataset_id.endswith("}"):
-            import json
-
-            try:
-                dataset_dict = json.loads(dataset_id)
-                dataset_id = dataset_dict.get("id")
-                logger.warning(
-                    f"Received full dataset object instead of ID, extracting ID: {dataset_id}"
-                )
-            except json.JSONDecodeError as json_error:
-                raise ValueError(
-                    "Invalid dataset_id: expected a dataset ID string, "
-                    "got what looks like a malformed dictionary"
-                ) from json_error
-
         # Get dataset details using bioblend
         dataset_info = galaxy_state["gi"].datasets.show_dataset(dataset_id)
 
@@ -744,7 +728,7 @@ def download_dataset(
     Download a dataset from Galaxy to the local filesystem
 
     Args:
-        dataset_id: ID of the dataset to download
+        dataset_id: Galaxy dataset ID (string hash) to download
         file_path: Local file path to save the dataset (optional)
         use_default_filename: Use Galaxy's default filename if file_path not provided
         require_ok_state: Only download if dataset state is 'ok' (default: True)
@@ -755,22 +739,6 @@ def download_dataset(
     ensure_connected()
 
     try:
-        # Check if dataset_id looks like a dictionary string and extract the ID
-        if dataset_id.startswith("{") and dataset_id.endswith("}"):
-            import json
-
-            try:
-                dataset_dict = json.loads(dataset_id)
-                dataset_id = dataset_dict.get("id")
-                logger.warning(
-                    f"Received full dataset object instead of ID, extracting ID: {dataset_id}"
-                )
-            except json.JSONDecodeError as json_error:
-                raise ValueError(
-                    "Invalid dataset_id: expected a dataset ID string, "
-                    "got what looks like a malformed dictionary"
-                ) from json_error
-
         # Get dataset info first to check state and get metadata
         dataset_info = galaxy_state["gi"].datasets.show_dataset(dataset_id)
 

--- a/mcp-server-galaxy-py/tests/test_dataset_operations.py
+++ b/mcp-server-galaxy-py/tests/test_dataset_operations.py
@@ -2,7 +2,6 @@
 Test dataset-related operations
 """
 
-import json
 from unittest.mock import patch
 
 import pytest
@@ -190,21 +189,6 @@ class TestDatasetOperations:
         with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
             with pytest.raises(ValueError, match="Dataset .* is in state 'running', not 'ok'"):
                 download_dataset_fn(dataset_id)
-
-    def test_dataset_operations_with_json_string(self, mock_galaxy_instance):
-        """Test dataset operations handle JSON string input"""
-        dataset_dict = {"id": "dataset123", "name": "test"}
-        dataset_id_str = json.dumps(dataset_dict)
-
-        mock_dataset_info = {"id": "dataset123", "name": "test_data.txt", "state": "ok"}
-
-        mock_galaxy_instance.datasets.show_dataset.return_value = mock_dataset_info
-
-        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
-            result = get_dataset_details_fn(dataset_id_str, include_preview=False)
-
-            assert result["dataset_id"] == "dataset123"  # Extracted from JSON
-            mock_galaxy_instance.datasets.show_dataset.assert_called_once_with("dataset123")
 
     def test_dataset_operations_not_connected(self):
         """Test dataset operations fail when not connected"""

--- a/mcp-server-galaxy-py/tests/test_dataset_operations.py
+++ b/mcp-server-galaxy-py/tests/test_dataset_operations.py
@@ -2,11 +2,12 @@
 Test dataset-related operations
 """
 
+import json
 from unittest.mock import patch
 
 import pytest
 
-from .test_helpers import galaxy_state, upload_file_fn
+from .test_helpers import download_dataset_fn, galaxy_state, get_dataset_details_fn, upload_file_fn
 
 
 class TestDatasetOperations:
@@ -33,23 +34,186 @@ class TestDatasetOperations:
                 with pytest.raises(ValueError, match="File not found"):
                     upload_file_fn("/nonexistent/file.txt", "test_history_1")
 
-    def test_download_dataset(self, mock_galaxy_instance):
-        """Test dataset download"""
-        # Download functionality doesn't exist in current implementation
-        # This test is a placeholder for future functionality
-        pass
+    def test_get_dataset_details_with_preview(self, mock_galaxy_instance):
+        """Test getting dataset details with preview"""
+        dataset_id = "dataset123"
 
-    def test_get_dataset_details(self, mock_galaxy_instance):
-        """Test getting dataset details"""
-        # Dataset details functionality doesn't exist in current implementation
-        # This test is a placeholder for future functionality
-        pass
+        # Mock dataset info
+        mock_dataset_info = {
+            "id": dataset_id,
+            "name": "test_data.txt",
+            "state": "ok",
+            "extension": "txt",
+            "file_size": 1024,
+        }
+
+        # Mock dataset content for preview
+        mock_content = b"line1\nline2\nline3\nline4\nline5\n"
+
+        mock_galaxy_instance.datasets.show_dataset.return_value = mock_dataset_info
+        mock_galaxy_instance.datasets.download_dataset.return_value = mock_content
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = get_dataset_details_fn(dataset_id, include_preview=True, preview_lines=3)
+
+            assert result["dataset_id"] == dataset_id
+            assert result["dataset"]["name"] == "test_data.txt"
+            assert result["preview"]["lines"] == "line1\nline2\nline3"
+            assert result["preview"]["total_lines"] == 6  # 5 lines + empty line at end
+            assert result["preview"]["truncated"] is True
+
+            mock_galaxy_instance.datasets.show_dataset.assert_called_once_with(dataset_id)
+
+    def test_get_dataset_details_no_preview(self, mock_galaxy_instance):
+        """Test getting dataset details without preview"""
+        dataset_id = "dataset123"
+
+        mock_dataset_info = {
+            "id": dataset_id,
+            "name": "test_data.txt",
+            "state": "ok",
+            "extension": "txt",
+        }
+
+        mock_galaxy_instance.datasets.show_dataset.return_value = mock_dataset_info
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = get_dataset_details_fn(dataset_id, include_preview=False)
+
+            assert result["dataset_id"] == dataset_id
+            assert result["dataset"]["name"] == "test_data.txt"
+            assert "preview" not in result
+
+            # Should not call download_dataset for preview
+            mock_galaxy_instance.datasets.download_dataset.assert_not_called()
+
+    def test_get_dataset_details_binary_file(self, mock_galaxy_instance):
+        """Test getting dataset details with binary content"""
+        dataset_id = "dataset123"
+
+        mock_dataset_info = {
+            "id": dataset_id,
+            "name": "test_data.bin",
+            "state": "ok",
+            "extension": "bin",
+        }
+
+        # Binary content that can't be decoded as UTF-8
+        mock_content = b"\x89PNG\r\n\x1a\n\x00\x00\x00"
+
+        mock_galaxy_instance.datasets.show_dataset.return_value = mock_dataset_info
+        mock_galaxy_instance.datasets.download_dataset.return_value = mock_content
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = get_dataset_details_fn(dataset_id, include_preview=True)
+
+            assert result["dataset_id"] == dataset_id
+            assert "[Binary content" in result["preview"]["lines"]
+            assert "hex:" in result["preview"]["lines"]
+
+    def test_download_dataset_with_file_path(self, mock_galaxy_instance):
+        """Test dataset download to specific file path"""
+        dataset_id = "dataset123"
+        file_path = "/tmp/test_download.txt"
+
+        mock_dataset_info = {
+            "id": dataset_id,
+            "name": "test_data.txt",
+            "state": "ok",
+            "extension": "txt",
+            "file_size": 1024,
+        }
+
+        mock_galaxy_instance.datasets.show_dataset.return_value = mock_dataset_info
+        mock_galaxy_instance.datasets.download_dataset.return_value = file_path
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            with patch("os.path.exists", return_value=True):
+                with patch("os.path.getsize", return_value=1024):
+                    result = download_dataset_fn(dataset_id, file_path=file_path)
+
+                    assert result["dataset_id"] == dataset_id
+                    assert result["file_path"] == file_path
+                    assert result["file_size"] == 1024
+                    assert result["dataset_info"]["name"] == "test_data.txt"
+
+                    mock_galaxy_instance.datasets.download_dataset.assert_called_once_with(
+                        dataset_id,
+                        file_path=file_path,
+                        use_default_filename=False,
+                        require_ok_state=True,
+                    )
+
+    def test_download_dataset_default_filename(self, mock_galaxy_instance):
+        """Test dataset download with default filename"""
+        dataset_id = "dataset123"
+
+        mock_dataset_info = {
+            "id": dataset_id,
+            "name": "test_data",
+            "state": "ok",
+            "extension": "txt",
+            "file_size": 1024,
+        }
+
+        mock_content = b"test file content"
+
+        mock_galaxy_instance.datasets.show_dataset.return_value = mock_dataset_info
+        mock_galaxy_instance.datasets.download_dataset.return_value = mock_content
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            with patch("builtins.open", create=True) as mock_open:
+                with patch("os.path.exists", return_value=True):
+                    with patch("os.path.getsize", return_value=len(mock_content)):
+                        result = download_dataset_fn(dataset_id)
+
+                        assert result["dataset_id"] == dataset_id
+                        assert result["file_path"] == "test_data.txt"
+                        assert result["dataset_info"]["name"] == "test_data"
+
+                        # Verify file was written
+                        mock_open.assert_called_once_with("test_data.txt", "wb")
+
+    def test_download_dataset_not_ok_state(self, mock_galaxy_instance):
+        """Test download fails when dataset not in ok state"""
+        dataset_id = "dataset123"
+
+        mock_dataset_info = {
+            "id": dataset_id,
+            "name": "test_data.txt",
+            "state": "running",
+            "extension": "txt",
+        }
+
+        mock_galaxy_instance.datasets.show_dataset.return_value = mock_dataset_info
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            with pytest.raises(ValueError, match="Dataset .* is in state 'running', not 'ok'"):
+                download_dataset_fn(dataset_id)
+
+    def test_dataset_operations_with_json_string(self, mock_galaxy_instance):
+        """Test dataset operations handle JSON string input"""
+        dataset_dict = {"id": "dataset123", "name": "test"}
+        dataset_id_str = json.dumps(dataset_dict)
+
+        mock_dataset_info = {"id": "dataset123", "name": "test_data.txt", "state": "ok"}
+
+        mock_galaxy_instance.datasets.show_dataset.return_value = mock_dataset_info
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = get_dataset_details_fn(dataset_id_str, include_preview=False)
+
+            assert result["dataset_id"] == "dataset123"  # Extracted from JSON
+            mock_galaxy_instance.datasets.show_dataset.assert_called_once_with("dataset123")
 
     def test_dataset_operations_not_connected(self):
         """Test dataset operations fail when not connected"""
         with patch.dict(galaxy_state, {"connected": False}):
-            with pytest.raises(Exception):
+            with pytest.raises(ValueError, match="Not connected to Galaxy"):
                 upload_file_fn("/path/to/file.txt", "history_1")
 
-            # Download and get_dataset_details don't exist yet
-            pass
+            with pytest.raises(ValueError, match="Not connected to Galaxy"):
+                get_dataset_details_fn("dataset123")
+
+            with pytest.raises(ValueError, match="Not connected to Galaxy"):
+                download_dataset_fn("dataset123")

--- a/mcp-server-galaxy-py/tests/test_helpers.py
+++ b/mcp-server-galaxy-py/tests/test_helpers.py
@@ -4,9 +4,11 @@
 from galaxy_mcp.server import (
     connect,
     create_history,
+    download_dataset,
     ensure_connected,
     filter_tools_by_dataset,
     galaxy_state,
+    get_dataset_details,
     get_histories,
     get_history_details,
     get_invocations,
@@ -38,7 +40,9 @@ def get_function(tool_or_function):
 # Create function aliases for testing
 connect_fn = get_function(connect)
 create_history_fn = get_function(create_history)
+download_dataset_fn = get_function(download_dataset)
 filter_tools_by_dataset_fn = get_function(filter_tools_by_dataset)
+get_dataset_details_fn = get_function(get_dataset_details)
 get_histories_fn = get_function(get_histories)
 get_history_details_fn = get_function(get_history_details)
 get_iwc_workflows_fn = get_function(get_iwc_workflows)
@@ -60,7 +64,9 @@ upload_file_fn = get_function(upload_file)
 __all__ = [
     "connect_fn",
     "create_history_fn",
+    "download_dataset_fn",
     "filter_tools_by_dataset_fn",
+    "get_dataset_details_fn",
     "get_histories_fn",
     "get_history_details_fn",
     "get_iwc_workflows_fn",

--- a/mcp-server-galaxy-py/tests/test_history_operations.py
+++ b/mcp-server-galaxy-py/tests/test_history_operations.py
@@ -62,13 +62,14 @@ class TestHistoryOperations:
             assert len(result["contents"]) == 2
 
     def test_get_history_details_with_dict_string(self, mock_galaxy_instance):
-        """Test get_history_details handles dict string input"""
+        """Test get_history_details treats dict string as regular ID (should fail)"""
+        mock_galaxy_instance.histories.show_history.side_effect = Exception("404 Not Found")
+
         with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
-            # User passes string representation of dict
+            # User passes string representation of dict - should be treated as invalid ID
             dict_string = "{'id': 'test_history_1', 'name': 'Test History 1'}"
 
-            msg = "Invalid history_id: expected a history ID string"
-            with pytest.raises(ValueError, match=msg):
+            with pytest.raises(ValueError, match="History ID .* not found"):
                 get_history_details_fn(dict_string)
 
     def test_get_history_details_invalid_id(self, mock_galaxy_instance):

--- a/mcp-server-galaxy-py/tests/test_job_operations.py
+++ b/mcp-server-galaxy-py/tests/test_job_operations.py
@@ -1,7 +1,5 @@
 """Tests for job operations"""
 
-import json
-
 import pytest
 import responses
 from galaxy_mcp.server import galaxy_state
@@ -101,34 +99,6 @@ class TestJobOperations:
 
         with pytest.raises(ValueError, match="No job information found"):
             get_job_details_fn(dataset_id)
-
-    @responses.activate
-    def test_get_job_details_with_dict_string(self):
-        """Test handling dataset_id as JSON string"""
-        dataset_dict = {"id": "dataset123", "name": "test"}
-        dataset_id_str = json.dumps(dataset_dict)
-        job_id = "job456"
-
-        # Mock the bioblend provenance call
-        mock_gi = type("MockGI", (), {})()
-        mock_histories = type("MockHistories", (), {})()
-        mock_histories.show_dataset_provenance = lambda history_id, dataset_id: {"job_id": job_id}
-        mock_gi.histories = mock_histories
-        galaxy_state["gi"] = mock_gi
-
-        # Mock the Galaxy API job details call
-        responses.add(
-            responses.GET,
-            f"http://localhost:8080/api/jobs/{job_id}",
-            json={"id": job_id, "tool_id": "test_tool", "state": "ok"},
-            status=200,
-        )
-
-        result = get_job_details_fn(dataset_id_str)
-
-        assert result["job"]["id"] == job_id
-        assert result["dataset_id"] == "dataset123"  # Extracted from JSON
-        assert result["job_id"] == job_id
 
     def test_get_job_details_not_connected(self):
         """Test error when not connected to Galaxy"""


### PR DESCRIPTION
Implemented two new MCP tools for working with dataset content. The get_dataset_details function provides comprehensive dataset metadata with optional content preview including binary file support. The download_dataset function enables downloading datasets to local filesystem with flexible filename options and state validation.

Standardized parameter handling and reviewed and updated docstrings with better examples, to avoid parameter type confusion.

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Check the relevant boxes -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] ⬆️ Dependency update
- [ ] 🧰 Maintenance/chore

## Checklist
- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Related Issues
<!-- Link to related issues if any -->
Closes #
