### PR TITLE
Set User-Agent on Galaxy API requests

### DIFF
--- a/mcp-server-galaxy-py/tests/test_connection.py
+++ b/mcp-server-galaxy-py/tests/test_connection.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from galaxy_mcp import server
 from galaxy_mcp.auth import GalaxyCredentials
 
 from .test_helpers import connect_fn, ensure_connected, galaxy_state, get_server_info_fn
@@ -92,7 +93,9 @@ class TestConnection:
             == mock_galaxy_instance.users.get_current_user.return_value["username"]
         )
         mock_constructor.assert_called_once_with(
-            url=credentials.galaxy_url, key=credentials.api_key
+            url=credentials.galaxy_url,
+            key=credentials.api_key,
+            user_agent=server.USER_AGENT,
         )
 
     def test_get_server_info_success(self, mock_galaxy_instance):

--- a/mcp-server-galaxy-py/tests/test_oauth.py
+++ b/mcp-server-galaxy-py/tests/test_oauth.py
@@ -7,6 +7,7 @@ from starlette.applications import Starlette
 from starlette.responses import JSONResponse, PlainTextResponse
 from starlette.testclient import TestClient
 
+from galaxy_mcp import server
 from galaxy_mcp.auth import GalaxyCredentials
 from galaxy_mcp.server import _OAuthPublicRoutes, ensure_connected
 
@@ -38,7 +39,9 @@ def test_ensure_connected_prefers_oauth_session(mock_galaxy_instance):
     assert state["connected"] is True
     assert state["gi"] is mock_galaxy_instance
     assert state["url"] == credentials.galaxy_url
-    mock_constructor.assert_called_once_with(url=credentials.galaxy_url, key=credentials.api_key)
+    mock_constructor.assert_called_once_with(
+        url=credentials.galaxy_url, key=credentials.api_key, user_agent=server.USER_AGENT
+    )
 
 
 class _DummyProvider:


### PR DESCRIPTION
## Summary

- Sets a proper User-Agent (`galaxy-mcp/{version} bioblend/{version}`) on all BioBlend `GalaxyInstance` calls so Galaxy servers can distinguish agent-driven traffic from generic `python-requests` calls.
- Uses BioBlend's existing `user_agent` kwarg — no new dependencies or monkey-patching needed.
- All three `GalaxyInstance` creation sites covered: env-based init, OAuth session, and explicit `connect()`.

## Test plan

- [ ] `make lint` passes
- [ ] `make test` passes (all 97 tests green)
- [ ] Confirm User-Agent header appears in Galaxy server request logs