### PR TITLE
Add agent-friendly tool validation and execution contracts

### DIFF
--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -1,8 +1,10 @@
 # Galaxy MCP Server
 import concurrent.futures
 import importlib.metadata
+import json
 import logging
 import os
+import re
 import threading
 import types
 from functools import lru_cache
@@ -24,6 +26,11 @@ from galaxy_mcp.auth import (
     GalaxyOAuthProvider,
     configure_auth_provider,
     get_active_session,
+)
+from galaxy_mcp.tool_contract import (
+    build_agent_hints,
+    build_tool_contract,
+    validate_payload_against_contract,
 )
 
 _galaxy_mcp_version = importlib.metadata.version("galaxy-mcp")
@@ -510,6 +517,748 @@ def get_tool_details(tool_id: str, io_details: bool = False) -> GalaxyResult:
         ) from e
 
 
+def _validate_tool_inputs_internal(
+    gi: GalaxyInstance,
+    history_id: str,
+    tool_id: str,
+    inputs: dict[str, Any],
+    input_format: Literal["legacy", "21.01"],
+    require_explicit_conditionals: bool,
+    strict_unknown_keys: bool,
+) -> dict[str, Any]:
+    return _validate_tool_inputs_internal_with_preflight(
+        gi=gi,
+        history_id=history_id,
+        tool_id=tool_id,
+        inputs=inputs,
+        input_format=input_format,
+        require_explicit_conditionals=require_explicit_conditionals,
+        strict_unknown_keys=strict_unknown_keys,
+    )
+
+
+_REPEAT_SEGMENT_PATTERN = re.compile(r"^(?P<base>.+_repeat)_\d+$")
+_DATASET_ERROR_STATES = {"error", "discarded", "failed"}
+_DATASET_PENDING_STATES = {"new", "queued", "running", "upload", "setting_metadata", "deferred"}
+_COLLECTION_SRCS = {"hdca", "dataset_collection", "collection", "dca"}
+
+
+def _join_pipe_key(prefix: str, name: str) -> str:
+    return f"{prefix}|{name}" if prefix else name
+
+
+def _normalize_lookup_key(key: str) -> str:
+    normalized_parts: list[str] = []
+    for part in key.split("|"):
+        if part.isdigit():
+            continue
+        match = _REPEAT_SEGMENT_PATTERN.match(part)
+        normalized_parts.append(str(match.group("base")) if match else part)
+    return "|".join(normalized_parts)
+
+
+def _is_reference_dict(value: Any) -> bool:
+    return (
+        isinstance(value, dict)
+        and isinstance(value.get("src"), str)
+        and value.get("src") != ""
+        and isinstance(value.get("id"), str)
+        and value.get("id") != ""
+    )
+
+
+def _flatten_input_values(payload: Any, prefix: str = "") -> dict[str, Any]:
+    flattened: dict[str, Any] = {}
+
+    if isinstance(payload, dict):
+        for raw_key, value in payload.items():
+            key = _join_pipe_key(prefix, str(raw_key))
+            if _is_reference_dict(value):
+                flattened[key] = value
+                continue
+
+            if isinstance(value, dict):
+                if value:
+                    flattened.update(_flatten_input_values(value, key))
+                else:
+                    flattened[key] = value
+                continue
+
+            if isinstance(value, list):
+                if not value:
+                    flattened[key] = value
+                    continue
+                for idx, item in enumerate(value):
+                    item_key = _join_pipe_key(key, str(idx))
+                    if _is_reference_dict(item):
+                        flattened[item_key] = item
+                    elif isinstance(item, dict | list):
+                        flattened.update(_flatten_input_values(item, item_key))
+                    else:
+                        flattened[item_key] = item
+                continue
+
+            flattened[key] = value
+        return flattened
+
+    if isinstance(payload, list):
+        for idx, item in enumerate(payload):
+            item_key = _join_pipe_key(prefix, str(idx))
+            if _is_reference_dict(item):
+                flattened[item_key] = item
+            elif isinstance(item, dict | list):
+                flattened.update(_flatten_input_values(item, item_key))
+            else:
+                flattened[item_key] = item
+    return flattened
+
+
+def _pipe_values_to_nested(values: dict[str, Any]) -> dict[str, Any]:
+    nested: dict[str, Any] = {}
+    for key, value in sorted(values.items(), key=lambda item: item[0].count("|")):
+        parts = [part for part in key.split("|") if part]
+        if not parts:
+            continue
+        cursor = nested
+        for part in parts[:-1]:
+            existing = cursor.get(part)
+            if not isinstance(existing, dict):
+                existing = {}
+                cursor[part] = existing
+            cursor = existing
+        cursor[parts[-1]] = value
+    return nested
+
+
+def _collect_agent_explicit_values(
+    inputs: dict[str, Any], input_format: Literal["legacy", "21.01"]
+) -> dict[str, Any]:
+    if input_format == "legacy":
+        return {str(key): value for key, value in inputs.items()}
+    return _flatten_input_values(inputs)
+
+
+def _stable_payload_signature(values: dict[str, Any]) -> str:
+    serialized_items = []
+    for key, value in sorted(values.items()):
+        try:
+            rendered = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+        except Exception:
+            rendered = repr(value)
+        serialized_items.append((key, rendered))
+    return json.dumps(serialized_items, separators=(",", ":"))
+
+
+def _is_data_field_type(field_type: str) -> bool:
+    lowered = field_type.strip().lower()
+    if "column" in lowered:
+        return False
+    if "data_collection" in lowered or "datasetcollection" in lowered:
+        return True
+    return lowered in {"data", "hidden_data"} or "datatoolparameter" in lowered
+
+
+def _is_collection_src(src: str) -> bool:
+    return src.strip().lower() in _COLLECTION_SRCS
+
+
+def _extract_dataset_refs(value: Any) -> list[dict[str, str]]:
+    refs: list[dict[str, str]] = []
+    if _is_reference_dict(value):
+        refs.append({"src": str(value["src"]), "id": str(value["id"])})
+        return refs
+
+    if isinstance(value, dict):
+        if isinstance(value.get("values"), list):
+            for item in value["values"]:
+                refs.extend(_extract_dataset_refs(item))
+            return refs
+        for nested_value in value.values():
+            refs.extend(_extract_dataset_refs(nested_value))
+        return refs
+
+    if isinstance(value, list):
+        for item in value:
+            refs.extend(_extract_dataset_refs(item))
+    return refs
+
+
+def _collect_field_refs(
+    flat_values: dict[str, Any], fields: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    refs: list[dict[str, Any]] = []
+    for field in fields:
+        field_key = field.get("key")
+        if not isinstance(field_key, str) or not field_key:
+            continue
+
+        normalized_field_key = _normalize_lookup_key(field_key)
+        expected_extensions = field.get("extensions")
+        expected_collection_types = field.get("collection_types")
+
+        for input_key, value in flat_values.items():
+            if _normalize_lookup_key(input_key) != normalized_field_key:
+                continue
+            for ref in _extract_dataset_refs(value):
+                refs.append(
+                    {
+                        "field": field_key,
+                        "input_key": input_key,
+                        "src": ref["src"],
+                        "id": ref["id"],
+                        "expected_extensions": expected_extensions or [],
+                        "expected_collection_types": expected_collection_types or [],
+                    }
+                )
+    return refs
+
+
+def _iterative_build_with_immutable_agent_values(
+    gi: GalaxyInstance,
+    tool_id: str,
+    history_id: str,
+    original_inputs: dict[str, Any],
+    input_format: Literal["legacy", "21.01"],
+    max_rounds: int = 3,
+) -> dict[str, Any]:
+    warnings: list[dict[str, Any]] = []
+    agent_explicit_values = _collect_agent_explicit_values(original_inputs, input_format)
+    current_inputs = _pipe_values_to_nested(agent_explicit_values)
+    if not current_inputs:
+        current_inputs = {}
+
+    last_result: dict[str, Any] | None = None
+    last_state_inputs: dict[str, Any] = {}
+    rounds = 0
+    converged = False
+    seen_signatures: set[str] = set()
+    last_signature: str | None = None
+    oscillation_detected = False
+
+    for round_number in range(1, max_rounds + 1):
+        rounds = round_number
+        try:
+            build_result = gi.tools.build(tool_id, inputs=current_inputs, history_id=history_id)
+        except Exception as exc:
+            warnings.append(
+                {
+                    "code": "build_round_error",
+                    "field": None,
+                    "message": f"Galaxy build round {round_number} failed.",
+                    "details": {"round": round_number, "error": str(exc)},
+                }
+            )
+            return {
+                "warnings": warnings,
+                "rounds": rounds - 1,
+                "converged": False,
+                "oscillation_detected": False,
+                "final_inputs": current_inputs,
+                "resolved_state_inputs": last_state_inputs,
+                "build_result": last_result,
+            }
+
+        last_result = build_result
+        raw_state_inputs = build_result.get("state_inputs")
+        state_inputs = raw_state_inputs if isinstance(raw_state_inputs, dict) else {}
+        last_state_inputs = state_inputs
+        state_values = _flatten_input_values(state_inputs)
+
+        # Agent-provided keys are immutable. Build can only fill keys the agent did not set.
+        merged_values = {**state_values, **agent_explicit_values}
+        merged_inputs = _pipe_values_to_nested(merged_values)
+        signature = _stable_payload_signature(merged_values)
+
+        if signature == last_signature:
+            converged = True
+            current_inputs = merged_inputs
+            break
+
+        if signature in seen_signatures:
+            oscillation_detected = True
+            current_inputs = merged_inputs
+            warnings.append(
+                {
+                    "code": "build_oscillation_detected",
+                    "field": None,
+                    "message": "Iterative build payload oscillated before convergence.",
+                    "details": {"round": round_number, "max_rounds": max_rounds},
+                }
+            )
+            break
+
+        seen_signatures.add(signature)
+        last_signature = signature
+        current_inputs = merged_inputs
+
+    if not converged and not oscillation_detected and rounds >= max_rounds:
+        warnings.append(
+            {
+                "code": "build_not_converged",
+                "field": None,
+                "message": "Iterative build reached max rounds without convergence.",
+                "details": {"rounds": rounds, "max_rounds": max_rounds},
+            }
+        )
+
+    return {
+        "warnings": warnings,
+        "rounds": rounds,
+        "converged": converged,
+        "oscillation_detected": oscillation_detected,
+        "final_inputs": current_inputs,
+        "resolved_state_inputs": last_state_inputs,
+        "build_result": last_result,
+    }
+
+
+def _preflight_tool_datasets(
+    gi: GalaxyInstance,
+    history_id: str,
+    contract: dict[str, Any],
+    original_inputs: dict[str, Any],
+    resolved_inputs: dict[str, Any],
+) -> dict[str, Any]:
+    errors: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+
+    fields = [
+        field
+        for field in contract.get("fields", [])
+        if isinstance(field, dict) and _is_data_field_type(str(field.get("type", "")))
+    ]
+
+    original_flat = _flatten_input_values(original_inputs)
+    resolved_flat = _flatten_input_values(resolved_inputs)
+    original_refs = _collect_field_refs(original_flat, fields)
+    resolved_refs = _collect_field_refs(resolved_flat, fields)
+
+    original_ref_index: dict[tuple[str, str], list[str]] = {}
+    for ref in original_refs:
+        key = (ref["src"], ref["id"])
+        original_ref_index.setdefault(key, []).append(ref["field"])
+
+    resolved_ref_index = {(ref["src"], ref["id"]) for ref in resolved_refs}
+    dropped_refs = sorted(original_ref_index.keys() - resolved_ref_index)
+    if dropped_refs:
+        warnings.append(
+            {
+                "code": "dataset_reference_removed_by_resolution",
+                "field": None,
+                "message": (
+                    "Some dataset references from the original payload were removed after "
+                    "conditional resolution."
+                ),
+                "details": {
+                    "dropped": [
+                        {
+                            "src": src,
+                            "id": dataset_id,
+                            "fields": sorted(set(original_ref_index[(src, dataset_id)])),
+                        }
+                        for src, dataset_id in dropped_refs
+                    ],
+                    "hint": "Check conditional selectors and branch-specific dataset inputs.",
+                },
+            }
+        )
+
+    try:
+        history_info = gi.histories.show_history(history_id, contents=False)
+        if isinstance(history_info, dict) and history_info.get("deleted"):
+            errors.append(
+                {
+                    "code": "history_deleted",
+                    "field": None,
+                    "message": f"Target history '{history_id}' is deleted.",
+                    "details": {"history_id": history_id},
+                }
+            )
+    except Exception as exc:
+        errors.append(
+            {
+                "code": "history_unavailable",
+                "field": None,
+                "message": f"Unable to access target history '{history_id}'.",
+                "details": {"history_id": history_id, "error": str(exc)},
+            }
+        )
+
+    dataset_cache: dict[str, dict[str, Any] | Exception] = {}
+    collection_cache: dict[str, dict[str, Any] | Exception] = {}
+
+    for ref in resolved_refs:
+        src = str(ref["src"])
+        dataset_id = str(ref["id"])
+        field_key = str(ref["field"])
+        expected_extensions = {
+            str(extension).lower()
+            for extension in ref.get("expected_extensions", [])
+            if str(extension).strip()
+        }
+        expected_collection_types = {
+            str(collection_type).lower()
+            for collection_type in ref.get("expected_collection_types", [])
+            if str(collection_type).strip()
+        }
+
+        if _is_collection_src(src):
+            if dataset_id not in collection_cache:
+                try:
+                    collection_cache[dataset_id] = gi.dataset_collections.show_dataset_collection(dataset_id)
+                except Exception as exc:
+                    collection_cache[dataset_id] = exc
+            collection_info = collection_cache[dataset_id]
+            if isinstance(collection_info, Exception):
+                errors.append(
+                    {
+                        "code": "dataset_collection_not_found",
+                        "field": field_key,
+                        "message": f"Dataset collection '{dataset_id}' is not accessible.",
+                        "details": {"src": src, "id": dataset_id, "error": str(collection_info)},
+                    }
+                )
+                continue
+
+            collection_type = str(collection_info.get("collection_type", "")).lower()
+            if expected_collection_types and collection_type not in expected_collection_types:
+                errors.append(
+                    {
+                        "code": "collection_type_mismatch",
+                        "field": field_key,
+                        "message": (
+                            f"Collection '{dataset_id}' type '{collection_type}' does not match expected "
+                            f"types for '{field_key}'."
+                        ),
+                        "details": {
+                            "expected_collection_types": sorted(expected_collection_types),
+                            "actual_collection_type": collection_type,
+                        },
+                    }
+                )
+
+            collection_history_id = collection_info.get("history_id")
+            if isinstance(collection_history_id, str) and collection_history_id != history_id:
+                warnings.append(
+                    {
+                        "code": "collection_cross_history_reference",
+                        "field": field_key,
+                        "message": (
+                            f"Collection '{dataset_id}' belongs to history '{collection_history_id}', "
+                            f"not target history '{history_id}'."
+                        ),
+                        "details": {"collection_history_id": collection_history_id},
+                    }
+                )
+            continue
+
+        if dataset_id not in dataset_cache:
+            try:
+                dataset_cache[dataset_id] = gi.datasets.show_dataset(dataset_id)
+            except Exception as exc:
+                dataset_cache[dataset_id] = exc
+        dataset_info = dataset_cache[dataset_id]
+        if isinstance(dataset_info, Exception):
+            errors.append(
+                {
+                    "code": "dataset_not_found",
+                    "field": field_key,
+                    "message": f"Dataset '{dataset_id}' is not accessible.",
+                    "details": {"src": src, "id": dataset_id, "error": str(dataset_info)},
+                }
+            )
+            continue
+
+        if dataset_info.get("deleted") or dataset_info.get("purged"):
+            errors.append(
+                {
+                    "code": "dataset_deleted",
+                    "field": field_key,
+                    "message": f"Dataset '{dataset_id}' is deleted or purged.",
+                    "details": {"id": dataset_id},
+                }
+            )
+
+        state = str(dataset_info.get("state", "")).lower()
+        if state in _DATASET_ERROR_STATES:
+            errors.append(
+                {
+                    "code": "dataset_invalid_state",
+                    "field": field_key,
+                    "message": f"Dataset '{dataset_id}' is in state '{state}'.",
+                    "details": {"id": dataset_id, "state": state},
+                }
+            )
+        elif state in _DATASET_PENDING_STATES:
+            warnings.append(
+                {
+                    "code": "dataset_not_ready",
+                    "field": field_key,
+                    "message": f"Dataset '{dataset_id}' is still processing (state '{state}').",
+                    "details": {"id": dataset_id, "state": state},
+                }
+            )
+
+        dataset_history_id = dataset_info.get("history_id")
+        if isinstance(dataset_history_id, str) and dataset_history_id != history_id:
+            warnings.append(
+                {
+                    "code": "dataset_cross_history_reference",
+                    "field": field_key,
+                    "message": (
+                        f"Dataset '{dataset_id}' belongs to history '{dataset_history_id}', "
+                        f"not target history '{history_id}'."
+                    ),
+                    "details": {"dataset_history_id": dataset_history_id},
+                }
+            )
+
+        dataset_extension = str(dataset_info.get("extension", "")).lower()
+        if expected_extensions and dataset_extension:
+            if "data" not in expected_extensions and dataset_extension not in expected_extensions:
+                warnings.append(
+                    {
+                        "code": "dataset_extension_mismatch",
+                        "field": field_key,
+                        "message": (
+                            f"Dataset '{dataset_id}' extension '{dataset_extension}' is not in expected "
+                            f"extensions for '{field_key}'."
+                        ),
+                        "details": {
+                            "id": dataset_id,
+                            "actual_extension": dataset_extension,
+                            "expected_extensions": sorted(expected_extensions),
+                        },
+                    }
+                )
+
+    return {
+        "errors": errors,
+        "warnings": warnings,
+        "checked_dataset_references": len(resolved_refs),
+        "dropped_dataset_references": len(dropped_refs),
+    }
+
+
+def _validate_tool_inputs_internal_with_preflight(
+    gi: GalaxyInstance,
+    history_id: str,
+    tool_id: str,
+    inputs: dict[str, Any],
+    input_format: Literal["legacy", "21.01"],
+    require_explicit_conditionals: bool,
+    strict_unknown_keys: bool,
+) -> dict[str, Any]:
+    tool_info = gi.tools.show_tool(tool_id, io_details=True)
+    contract = build_tool_contract(tool_info)
+    lint = validate_payload_against_contract(
+        contract,
+        inputs,
+        input_format=input_format,
+        require_explicit_conditionals=require_explicit_conditionals,
+        strict_unknown_keys=strict_unknown_keys,
+    )
+
+    iterative_build = _iterative_build_with_immutable_agent_values(
+        gi=gi,
+        tool_id=tool_id,
+        history_id=history_id,
+        original_inputs=inputs,
+        input_format=input_format,
+    )
+    lint["warnings"].extend(iterative_build["warnings"])
+
+    build_result = iterative_build["build_result"]
+    build_errors: dict[str, Any] = {}
+    tool_errors: Any = None
+    if isinstance(build_result, dict):
+        build_errors = build_result.get("errors") or {}
+        tool_errors = build_result.get("tool_errors")
+        if build_errors:
+            lint["errors"].append(
+                {
+                    "code": "build_errors",
+                    "field": None,
+                    "message": "Galaxy build endpoint reported input errors.",
+                    "details": build_errors,
+                }
+            )
+        if tool_errors:
+            lint["errors"].append(
+                {
+                    "code": "tool_errors",
+                    "field": None,
+                    "message": "Galaxy tool parser reported errors.",
+                    "details": tool_errors,
+                }
+            )
+
+    resolved_inputs = iterative_build["resolved_state_inputs"]
+    preflight = _preflight_tool_datasets(
+        gi=gi,
+        history_id=history_id,
+        contract=contract,
+        original_inputs=inputs,
+        resolved_inputs=resolved_inputs,
+    )
+    lint["errors"].extend(preflight["errors"])
+    lint["warnings"].extend(preflight["warnings"])
+
+    lint["valid"] = len(lint["errors"]) == 0
+    return {
+        "tool_id": tool_id,
+        "history_id": history_id,
+        "input_format": input_format,
+        "require_explicit_conditionals": require_explicit_conditionals,
+        "strict_unknown_keys": strict_unknown_keys,
+        "contract": contract,
+        "validation": lint,
+        "resolved_inputs": resolved_inputs,
+        "iterative_inputs": iterative_build["final_inputs"],
+        "build_rounds": iterative_build["rounds"],
+        "build_converged": iterative_build["converged"],
+        "build_oscillation_detected": iterative_build["oscillation_detected"],
+        "build_errors": build_errors,
+        "tool_errors": tool_errors,
+        "dataset_preflight": preflight,
+    }
+
+
+@mcp.tool()
+def inspect_tool_contract(
+    tool_id: str,
+    history_id: str | None = None,
+    include_test_cases: bool = False,
+    tool_version: str | None = None,
+) -> GalaxyResult:
+    """
+    Return an agent-friendly tool contract with canonical keys, conditionals, and templates.
+
+    This is intended for payload construction and setup validation before calling run_tool().
+
+    Args:
+        tool_id: Galaxy tool identifier.
+        history_id: Optional history ID for dynamic build context.
+        include_test_cases: Include tool tests for additional examples.
+        tool_version: Optional version selector for test cases.
+
+    Returns:
+        GalaxyResult containing:
+        - tool metadata
+        - structured contract (fields, required keys, conditional groups)
+        - agent_hints with type-specific setup constraints
+        - optional build preview (state_inputs) for canonical payload shape
+        - optional test cases
+    """
+    state = ensure_connected()
+    gi: GalaxyInstance = state["gi"]
+
+    try:
+        tool_info = gi.tools.show_tool(tool_id, io_details=True)
+        contract = build_tool_contract(tool_info)
+        agent_hints = build_agent_hints(contract)
+
+        build_preview: dict[str, Any] | None = None
+        build_warning: str | None = None
+        try:
+            build_preview = gi.tools.build(tool_id, history_id=history_id)
+        except Exception as exc:
+            build_warning = str(exc)
+
+        test_cases: list[dict[str, Any]] | None = None
+        if include_test_cases:
+            test_cases = gi.tools.get_tool_tests(tool_id, tool_version=tool_version)
+
+        return GalaxyResult(
+            data={
+                "tool": {
+                    "id": tool_info.get("id", tool_id),
+                    "name": tool_info.get("name"),
+                    "version": tool_info.get("version"),
+                    "description": tool_info.get("description"),
+                },
+                "contract": contract,
+                "agent_hints": agent_hints,
+                "build_preview": {
+                    "state_inputs": (build_preview or {}).get("state_inputs"),
+                    "errors": (build_preview or {}).get("errors"),
+                    "tool_errors": (build_preview or {}).get("tool_errors"),
+                    "warning": build_warning,
+                },
+                "test_cases": test_cases,
+                "agent_identity": USER_AGENT,
+            },
+            success=True,
+            message=f"Retrieved structured contract for tool '{tool_id}'",
+        )
+    except Exception as e:
+        context = {"tool_id": tool_id, "history_id": history_id}
+        if tool_version:
+            context["tool_version"] = tool_version
+        raise ValueError(format_error("Inspect tool contract", e, context)) from e
+
+
+@mcp.tool()
+def validate_tool_inputs(
+    history_id: str,
+    tool_id: str,
+    inputs: dict[str, Any],
+    input_format: Literal["legacy", "21.01"] = "legacy",
+    require_explicit_conditionals: bool = True,
+    strict_unknown_keys: bool = True,
+) -> GalaxyResult:
+    """
+    Validate a tool payload before submission and return resolved input preview.
+
+    Args:
+        history_id: Galaxy history ID where the tool would run.
+        tool_id: Galaxy tool identifier.
+        inputs: Proposed tool payload.
+        input_format: Galaxy input format ('legacy' or '21.01').
+        require_explicit_conditionals: Require explicit conditional selection keys.
+        strict_unknown_keys: Treat unknown input keys as errors (True) or warnings (False).
+
+    Returns:
+        GalaxyResult with deterministic validation diagnostics.
+    """
+    state = ensure_connected()
+    gi: GalaxyInstance = state["gi"]
+
+    try:
+        details = _validate_tool_inputs_internal(
+            gi=gi,
+            history_id=history_id,
+            tool_id=tool_id,
+            inputs=inputs,
+            input_format=input_format,
+            require_explicit_conditionals=require_explicit_conditionals,
+            strict_unknown_keys=strict_unknown_keys,
+        )
+        valid = bool(details["validation"]["valid"])
+        return GalaxyResult(
+            data={**details, "agent_identity": USER_AGENT},
+            success=True,
+            message=(
+                f"Tool payload is valid for '{tool_id}'"
+                if valid
+                else f"Tool payload is invalid for '{tool_id}'"
+            ),
+        )
+    except Exception as e:
+        raise ValueError(
+            format_error(
+                "Validate tool inputs",
+                e,
+                {
+                    "history_id": history_id,
+                    "tool_id": tool_id,
+                    "input_format": input_format,
+                    "strict_unknown_keys": strict_unknown_keys,
+                },
+            )
+        ) from e
+
+
 @mcp.tool()
 def get_tool_run_examples(tool_id: str, tool_version: str | None = None) -> GalaxyResult:
     """
@@ -584,7 +1333,12 @@ def run_tool(history_id: str, tool_id: str, inputs: dict[str, Any]) -> GalaxyRes
     """
     Run a Galaxy tool on datasets in a history.
 
-    RECOMMENDED WORKFLOW:
+    RECOMMENDED WORKFLOW FOR AGENTS:
+    1. inspect_tool_contract(tool_id) to understand canonical keys and constraints
+    2. validate_tool_inputs(history_id, tool_id, inputs) before submission
+    3. run_tool_validated(history_id, tool_id, inputs) to execute with guardrails
+
+    BASIC WORKFLOW (when payload is already trusted):
     1. Create or select a history: create_history() or get_histories()
     2. Upload data: upload_file() or upload_file_from_url()
     3. Get tool parameters: get_tool_details(tool_id, io_details=True)
@@ -640,6 +1394,8 @@ def run_tool(history_id: str, tool_id: str, inputs: dict[str, Any]) -> GalaxyRes
     - "Tool not found": Verify tool_id with search_tools_by_name()
     - "Invalid input": Check input format with get_tool_details(io_details=True)
     - "Dataset not found": Verify dataset_id exists in the history
+
+    For stricter, agent-oriented safety checks, use run_tool_validated().
     """
     state = ensure_connected()
     gi: GalaxyInstance = state["gi"]
@@ -656,6 +1412,85 @@ def run_tool(history_id: str, tool_id: str, inputs: dict[str, Any]) -> GalaxyRes
         raise ValueError(
             format_error(
                 "Run tool", e, {"history_id": history_id, "tool_id": tool_id, "inputs": inputs}
+            )
+        ) from e
+
+
+@mcp.tool()
+def run_tool_validated(
+    history_id: str,
+    tool_id: str,
+    inputs: dict[str, Any],
+    input_format: Literal["legacy", "21.01"] = "legacy",
+    require_explicit_conditionals: bool = True,
+    strict_unknown_keys: bool = True,
+) -> GalaxyResult:
+    """
+    Validate a payload and run the tool only when validation passes.
+
+    Args:
+        history_id: Galaxy history ID for the run.
+        tool_id: Galaxy tool identifier.
+        inputs: Tool input parameters.
+        input_format: Galaxy input format ('legacy' or '21.01').
+        require_explicit_conditionals: Require explicit selection for conditional inputs.
+        strict_unknown_keys: Treat unknown input keys as errors (True) or warnings (False).
+
+    Returns:
+        GalaxyResult with submission response and validation diagnostics.
+    """
+    state = ensure_connected()
+    gi: GalaxyInstance = state["gi"]
+
+    try:
+        details = _validate_tool_inputs_internal(
+            gi=gi,
+            history_id=history_id,
+            tool_id=tool_id,
+            inputs=inputs,
+            input_format=input_format,
+            require_explicit_conditionals=require_explicit_conditionals,
+            strict_unknown_keys=strict_unknown_keys,
+        )
+        validation = details["validation"]
+        if not validation["valid"]:
+            raise ValueError(
+                "Tool payload validation failed. "
+                f"Errors: {validation.get('errors', [])}. "
+                "Use validate_tool_inputs() to inspect and fix the payload."
+            )
+
+        if input_format == "legacy":
+            submission = gi.tools.run_tool(history_id, tool_id, inputs)
+        else:
+            submission = gi.tools.run_tool(history_id, tool_id, inputs, input_format=input_format)
+
+        return GalaxyResult(
+            data={
+                "submission": submission,
+                "validation": validation,
+                "resolved_inputs": details.get("resolved_inputs"),
+                "iterative_inputs": details.get("iterative_inputs"),
+                "build_rounds": details.get("build_rounds"),
+                "build_converged": details.get("build_converged"),
+                "build_oscillation_detected": details.get("build_oscillation_detected"),
+                "dataset_preflight": details.get("dataset_preflight"),
+                "agent_identity": USER_AGENT,
+            },
+            success=True,
+            message=f"Started validated tool run '{tool_id}' in history '{history_id}'",
+        )
+    except Exception as e:
+        raise ValueError(
+            format_error(
+                "Run tool validated",
+                e,
+                {
+                    "history_id": history_id,
+                    "tool_id": tool_id,
+                    "input_format": input_format,
+                    "strict_unknown_keys": strict_unknown_keys,
+                },
             )
         ) from e
 

--- a/mcp-server-galaxy-py/src/galaxy_mcp/tool_contract.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/tool_contract.py
@@ -1,0 +1,633 @@
+"""Helpers to expose structured Galaxy tool contracts and lint tool payloads."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+def _join_key(prefix: str, name: str) -> str:
+    return f"{prefix}|{name}" if prefix else name
+
+
+def _is_missing_value(value: Any) -> bool:
+    return value in (None, "", [], {})
+
+
+_REPEAT_SEGMENT_RE = re.compile(r"^(?P<base>.+_repeat)_\d+$")
+
+
+def _normalize_repeat_segment(segment: str) -> str:
+    match = _REPEAT_SEGMENT_RE.match(segment)
+    if not match:
+        return segment
+    return str(match.group("base"))
+
+
+def _normalize_repeat_key(key: str) -> str:
+    return "|".join(_normalize_repeat_segment(part) for part in key.split("|"))
+
+
+def _is_data_column_type(field_type: str) -> bool:
+    lowered = field_type.strip().lower()
+    return lowered == "data_column" or "datacolumn" in lowered
+
+
+def _is_text_like_field_type(field_type: str) -> bool:
+    lowered = field_type.strip().lower()
+    if lowered in {"text", "textarea", "string", "str"}:
+        return True
+    return "texttoolparameter" in lowered or "textareatoolparameter" in lowered
+
+
+def _looks_like_json_blob(value: str) -> bool:
+    stripped = value.strip()
+    if len(stripped) < 2:
+        return False
+    if stripped[0] == "{" and stripped[-1] == "}":
+        return True
+    if stripped[0] == "[" and stripped[-1] == "]":
+        return True
+    return False
+
+
+def _normalize_options(options: Any) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    if not isinstance(options, list):
+        return normalized
+
+    for option in options:
+        label: Any = None
+        value: Any = None
+        selected = False
+
+        if isinstance(option, dict):
+            label = option.get("label", option.get("name", option.get("value")))
+            value = option.get("value")
+            selected = bool(option.get("selected", False))
+        elif isinstance(option, (list, tuple)):
+            if len(option) >= 1:
+                label = option[0]
+            if len(option) >= 2:
+                value = option[1]
+            else:
+                value = label
+            if len(option) >= 3:
+                selected = bool(option[2])
+        else:
+            label = option
+            value = option
+
+        normalized.append(
+            {
+                "label": str(label) if label is not None else "",
+                "value": value,
+                "selected": selected,
+            }
+        )
+
+    return normalized
+
+
+def _infer_default_case_index(options: list[dict[str, Any]]) -> int | None:
+    for idx, option in enumerate(options):
+        if option.get("selected"):
+            return idx
+    return 0 if options else None
+
+
+def _infer_case_value(case: dict[str, Any], options: list[dict[str, Any]], idx: int) -> Any:
+    if "value" in case:
+        return case.get("value")
+    if idx < len(options):
+        return options[idx].get("value")
+    return idx
+
+
+def _walk_tool_inputs(
+    inputs: list[Any],
+    *,
+    prefix: str,
+    fields: list[dict[str, Any]],
+    known_keys: set[str],
+    required_keys: set[str],
+    conditional_groups: list[dict[str, Any]],
+    case_required_bucket: set[str] | None = None,
+    case_known_bucket: set[str] | None = None,
+) -> None:
+    for item in inputs:
+        if not isinstance(item, dict):
+            continue
+
+        raw_name = item.get("name")
+        if not isinstance(raw_name, str) or not raw_name:
+            continue
+
+        field_type = str(item.get("type") or item.get("model_class") or "unknown")
+        key = _join_key(prefix, raw_name)
+        optional = bool(item.get("optional", False))
+        default_value = item.get("value", item.get("default_value"))
+        has_default = not _is_missing_value(default_value)
+        entry: dict[str, Any] = {
+            "key": key,
+            "name": raw_name,
+            "label": item.get("label"),
+            "type": field_type,
+            "required": not optional,
+            "has_default": has_default,
+            "help": item.get("help"),
+        }
+        extensions_raw = item.get("extensions", item.get("format"))
+        if isinstance(extensions_raw, list):
+            extensions = [str(ext) for ext in extensions_raw if ext is not None]
+            if extensions:
+                entry["extensions"] = extensions
+        elif isinstance(extensions_raw, str) and extensions_raw:
+            entry["extensions"] = [extensions_raw]
+
+        collection_types_raw = item.get("collection_types")
+        if isinstance(collection_types_raw, list):
+            collection_types = [str(col_type) for col_type in collection_types_raw if col_type]
+            if collection_types:
+                entry["collection_types"] = collection_types
+        elif isinstance(collection_types_raw, str) and collection_types_raw:
+            entry["collection_types"] = [collection_types_raw]
+
+        if field_type == "conditional":
+            test_param = item.get("test_param") if isinstance(item.get("test_param"), dict) else {}
+            selector_name = test_param.get("name") if isinstance(test_param.get("name"), str) else "__current_case__"
+            selector_key = _join_key(key, selector_name)
+            selector_options = _normalize_options(test_param.get("options"))
+            default_case = _infer_default_case_index(selector_options)
+
+            known_keys.update({key, selector_key, f"{key}|__current_case__"})
+            if case_known_bucket is not None:
+                case_known_bucket.update({key, selector_key, f"{key}|__current_case__"})
+
+            selector_field = {
+                "key": selector_key,
+                "name": selector_name,
+                "label": test_param.get("label"),
+                "type": str(test_param.get("type") or "select"),
+                "required": True,
+                "has_default": default_case is not None,
+                "help": test_param.get("help"),
+                "conditional_group": key,
+                "is_selector": True,
+                "choices": selector_options,
+            }
+            fields.append(selector_field)
+
+            conditional_group: dict[str, Any] = {
+                "key": key,
+                "selector_key": selector_key,
+                "selector_name": selector_name,
+                "choices": selector_options,
+                "default_case": default_case,
+                "cases": [],
+            }
+
+            cases = item.get("cases") if isinstance(item.get("cases"), list) else []
+            for idx, case in enumerate(cases):
+                case_payload = case if isinstance(case, dict) else {}
+                nested_inputs = (
+                    case_payload.get("inputs") if isinstance(case_payload.get("inputs"), list) else []
+                )
+                case_required_keys: set[str] = set()
+                case_known_keys: set[str] = set()
+                _walk_tool_inputs(
+                    nested_inputs,
+                    prefix=key,
+                    fields=fields,
+                    known_keys=known_keys,
+                    required_keys=required_keys,
+                    conditional_groups=conditional_groups,
+                    case_required_bucket=case_required_keys,
+                    case_known_bucket=case_known_keys,
+                )
+                conditional_group["cases"].append(
+                    {
+                        "index": idx,
+                        "value": _infer_case_value(case_payload, selector_options, idx),
+                        "required_keys": sorted(case_required_keys),
+                        "known_keys": sorted(case_known_keys),
+                    }
+                )
+
+            conditional_groups.append(conditional_group)
+            continue
+
+        if field_type in {"repeat", "section"}:
+            entry["is_container"] = True
+            known_keys.add(key)
+            if case_known_bucket is not None:
+                case_known_bucket.add(key)
+            fields.append(entry)
+            nested = item.get("inputs") if isinstance(item.get("inputs"), list) else []
+            _walk_tool_inputs(
+                nested,
+                prefix=key,
+                fields=fields,
+                known_keys=known_keys,
+                required_keys=required_keys,
+                conditional_groups=conditional_groups,
+                case_required_bucket=case_required_bucket,
+                case_known_bucket=case_known_bucket,
+            )
+            continue
+
+        options = _normalize_options(item.get("options"))
+        if options:
+            entry["choices"] = options
+
+        fields.append(entry)
+        known_keys.add(key)
+        if case_known_bucket is not None:
+            case_known_bucket.add(key)
+
+        should_require = (
+            not optional and not has_default and field_type not in {"hidden", "hidden_data"}
+        )
+        if should_require:
+            required_keys.add(key)
+            if case_required_bucket is not None:
+                case_required_bucket.add(key)
+
+
+def build_tool_contract(tool_info: dict[str, Any]) -> dict[str, Any]:
+    """Create an agent-friendly contract from Galaxy's raw tool details response."""
+
+    raw_inputs = tool_info.get("inputs")
+    inputs = raw_inputs if isinstance(raw_inputs, list) else []
+
+    fields: list[dict[str, Any]] = []
+    known_keys: set[str] = set()
+    required_keys: set[str] = set()
+    conditional_groups: list[dict[str, Any]] = []
+
+    _walk_tool_inputs(
+        inputs,
+        prefix="",
+        fields=fields,
+        known_keys=known_keys,
+        required_keys=required_keys,
+        conditional_groups=conditional_groups,
+    )
+
+    return {
+        "input_format_supported": ["legacy", "21.01"],
+        "fields": fields,
+        "known_keys": sorted(known_keys),
+        "required_keys": sorted(required_keys),
+        "conditional_groups": conditional_groups,
+    }
+
+
+def _lookup_input_value(inputs: dict[str, Any], key: str) -> Any:
+    if key in inputs:
+        return inputs[key]
+
+    current: Any = inputs
+    for part in key.split("|"):
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        else:
+            return None
+    return current
+
+
+def _flatten_nested_keys(payload: dict[str, Any], prefix: str = "") -> set[str]:
+    keys: set[str] = set()
+    for raw_key, value in payload.items():
+        key = _join_key(prefix, str(raw_key))
+        keys.add(key)
+        if isinstance(value, dict):
+            keys.update(_flatten_nested_keys(value, prefix=key))
+    return keys
+
+
+def _resolve_selected_case(
+    conditional_group: dict[str, Any], inputs: dict[str, Any]
+) -> tuple[int | None, bool]:
+    selector_key = str(conditional_group.get("selector_key"))
+    current_case_key = f"{conditional_group.get('key')}|__current_case__"
+
+    selector_value = _lookup_input_value(inputs, selector_key)
+    explicit_selector = selector_value is not None
+
+    if explicit_selector:
+        for case in conditional_group.get("cases", []):
+            case_value = case.get("value")
+            if selector_value == case_value or str(selector_value) == str(case_value):
+                return int(case["index"]), True
+
+        try:
+            index_guess = int(selector_value)
+        except Exception:
+            index_guess = None
+        if index_guess is not None:
+            indexes = {int(case["index"]) for case in conditional_group.get("cases", [])}
+            if index_guess in indexes:
+                return index_guess, True
+        return None, True
+
+    case_value = _lookup_input_value(inputs, current_case_key)
+    explicit_case = case_value is not None
+    if explicit_case:
+        try:
+            index_guess = int(case_value)
+        except Exception:
+            return None, True
+        indexes = {int(case["index"]) for case in conditional_group.get("cases", [])}
+        if index_guess in indexes:
+            return index_guess, True
+        return None, True
+
+    default_case = conditional_group.get("default_case")
+    if isinstance(default_case, int):
+        return default_case, False
+    return None, False
+
+
+def validate_payload_against_contract(
+    contract: dict[str, Any],
+    inputs: dict[str, Any],
+    *,
+    input_format: str = "legacy",
+    require_explicit_conditionals: bool = True,
+    strict_unknown_keys: bool = True,
+) -> dict[str, Any]:
+    """Lint payload keys against a structured tool contract."""
+
+    errors: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+    selected_conditionals: list[dict[str, Any]] = []
+
+    top_level_keys = {str(k) for k in inputs.keys()}
+    nested_keys = _flatten_nested_keys(inputs)
+    submitted_keys = top_level_keys if input_format == "legacy" else nested_keys
+    normalized_submitted_keys = {_normalize_repeat_key(key) for key in submitted_keys}
+    submitted_keys_by_template: dict[str, list[str]] = {}
+    for key in submitted_keys:
+        template = _normalize_repeat_key(key)
+        submitted_keys_by_template.setdefault(template, []).append(key)
+
+    required_keys = set(contract.get("required_keys", []))
+    missing_required = sorted(
+        key for key in required_keys if key not in submitted_keys and key not in normalized_submitted_keys
+    )
+    if missing_required:
+        errors.append(
+            {
+                "code": "missing_required_inputs",
+                "field": None,
+                "message": "Missing required input keys.",
+                "details": {"missing_keys": missing_required},
+            }
+        )
+
+    for conditional_group in contract.get("conditional_groups", []):
+        group_key = str(conditional_group.get("key"))
+        selector_key = str(conditional_group.get("selector_key"))
+        current_case_key = f"{group_key}|__current_case__"
+
+        has_explicit_selector = (
+            _lookup_input_value(inputs, selector_key) is not None
+            or _lookup_input_value(inputs, current_case_key) is not None
+        )
+
+        selected_case, selected_explicitly = _resolve_selected_case(conditional_group, inputs)
+        if require_explicit_conditionals and not has_explicit_selector:
+            errors.append(
+                {
+                    "code": "conditional_selector_missing",
+                    "field": selector_key,
+                    "message": (
+                        f"Conditional '{group_key}' requires explicit selector '{selector_key}' "
+                        "or '|__current_case__' to avoid silent default branches."
+                    ),
+                }
+            )
+            continue
+
+        if selected_case is None:
+            if has_explicit_selector:
+                errors.append(
+                    {
+                        "code": "conditional_selector_invalid",
+                        "field": selector_key,
+                        "message": f"Conditional selector for '{group_key}' did not match any case.",
+                    }
+                )
+            continue
+
+        selected_conditionals.append(
+            {
+                "conditional": group_key,
+                "selector_key": selector_key,
+                "selected_case": selected_case,
+                "selected_explicitly": selected_explicitly,
+            }
+        )
+
+        group_cases = conditional_group.get("cases", [])
+        case = next(
+            (item for item in group_cases if int(item.get("index", -1)) == int(selected_case)),
+            None,
+        )
+        if not isinstance(case, dict):
+            continue
+
+        missing_case_required = [
+            key
+            for key in case.get("required_keys", [])
+            if key not in submitted_keys and key not in normalized_submitted_keys
+        ]
+        if missing_case_required:
+            errors.append(
+                {
+                    "code": "conditional_required_missing",
+                    "field": selector_key,
+                    "message": (
+                        f"Selected case {selected_case} for conditional '{group_key}' is missing "
+                        "required inputs."
+                    ),
+                    "details": {"missing_keys": sorted(missing_case_required)},
+                }
+            )
+
+    known_keys = set(contract.get("known_keys", []))
+    unknown_keys = sorted(
+        key
+        for key in submitted_keys
+        if key not in known_keys
+        and _normalize_repeat_key(key) not in known_keys
+        and not key.startswith("__")
+    )
+    if unknown_keys:
+        issue = {
+            "code": "unknown_input_keys",
+            "field": None,
+            "message": "Payload contains keys not present in tool schema.",
+            "details": {"unknown_keys": unknown_keys},
+        }
+        if strict_unknown_keys:
+            errors.append(issue)
+        else:
+            warnings.append(issue)
+
+    for field in contract.get("fields", []):
+        if not isinstance(field, dict):
+            continue
+        key = field.get("key")
+        if not isinstance(key, str) or not key:
+            continue
+        choices = field.get("choices")
+        if not isinstance(choices, list) or not choices:
+            continue
+
+        allowed_values = [choice.get("value") for choice in choices if isinstance(choice, dict)]
+        allowed_str_values = {str(value) for value in allowed_values}
+        allowed_display = sorted(allowed_str_values)
+
+        candidate_keys = submitted_keys_by_template.get(key, [key])
+        for candidate_key in candidate_keys:
+            value = _lookup_input_value(inputs, candidate_key)
+            if value is None:
+                continue
+
+            values_to_check = value if isinstance(value, list) else [value]
+            invalid_values: list[Any] = []
+            for current_value in values_to_check:
+                if current_value in allowed_values or str(current_value) in allowed_str_values:
+                    continue
+                invalid_values.append(current_value)
+
+            if invalid_values:
+                errors.append(
+                    {
+                        "code": "invalid_select_value",
+                        "field": candidate_key,
+                        "message": (
+                            f"Value '{invalid_values[0]}' not in allowed choices for '{candidate_key}'."
+                        ),
+                        "details": {
+                            "invalid_values": invalid_values,
+                            "allowed": allowed_display,
+                        },
+                    }
+                )
+
+    for field in contract.get("fields", []):
+        if not isinstance(field, dict):
+            continue
+        key = field.get("key")
+        if not isinstance(key, str) or not key:
+            continue
+        field_type = str(field.get("type") or "")
+        if not _is_data_column_type(field_type):
+            continue
+
+        candidate_keys = submitted_keys_by_template.get(key, [key])
+        for candidate_key in candidate_keys:
+            value = _lookup_input_value(inputs, candidate_key)
+            if value is None:
+                continue
+
+            if isinstance(value, bool):
+                parsed = None
+            elif isinstance(value, int):
+                parsed = value
+            elif isinstance(value, str) and value.strip().isdigit():
+                parsed = int(value.strip())
+            else:
+                parsed = None
+
+            if parsed is None or parsed < 1:
+                errors.append(
+                    {
+                        "code": "invalid_data_column_value",
+                        "field": candidate_key,
+                        "message": (
+                            f"Field '{candidate_key}' must be a 1-indexed integer column index."
+                        ),
+                        "details": {"value": value},
+                    }
+                )
+
+    for field in contract.get("fields", []):
+        if not isinstance(field, dict):
+            continue
+        key = field.get("key")
+        if not isinstance(key, str) or not key:
+            continue
+        field_type = str(field.get("type") or "")
+        if not _is_text_like_field_type(field_type):
+            continue
+
+        candidate_keys = submitted_keys_by_template.get(key, [key])
+        for candidate_key in candidate_keys:
+            value = _lookup_input_value(inputs, candidate_key)
+            if isinstance(value, str) and _looks_like_json_blob(value):
+                warnings.append(
+                    {
+                        "code": "json_blob_in_text_field",
+                        "field": candidate_key,
+                        "message": (
+                            f"Field '{candidate_key}' looks like JSON in a text parameter. "
+                            "Galaxy may escape characters (e.g., __oc__/__cc__/__dq__). "
+                            "Consider using file/dataset input instead."
+                        ),
+                    }
+                )
+
+    return {
+        "valid": len(errors) == 0,
+        "input_format": input_format,
+        "strict_unknown_keys": strict_unknown_keys,
+        "errors": errors,
+        "warnings": warnings,
+        "missing_required_keys": missing_required,
+        "unknown_keys": unknown_keys,
+        "selected_conditionals": selected_conditionals,
+    }
+
+
+def build_agent_hints(contract: dict[str, Any]) -> list[dict[str, Any]]:
+    """Derive agent-facing setup hints from a structured tool contract."""
+
+    hints: list[dict[str, Any]] = []
+    for field in contract.get("fields", []):
+        if not isinstance(field, dict):
+            continue
+        key = field.get("key")
+        field_type = str(field.get("type") or "")
+        if not isinstance(key, str) or not key:
+            continue
+
+        if _is_data_column_type(field_type):
+            hints.append(
+                {
+                    "field": key,
+                    "code": "data_column_requires_index",
+                    "hint": (
+                        "Requires a 1-indexed integer column index (e.g., 1, 2, 3), "
+                        "not a column name string."
+                    ),
+                }
+            )
+            continue
+
+        if _is_text_like_field_type(field_type):
+            hints.append(
+                {
+                    "field": key,
+                    "code": "text_json_escape_risk",
+                    "hint": (
+                        "Text parameter. If you pass JSON text, Galaxy may escape characters "
+                        "(__oc__/__cc__/__dq__). Prefer dataset/file input for structured data."
+                    ),
+                }
+            )
+
+    return hints

--- a/mcp-server-galaxy-py/tests/test_helpers.py
+++ b/mcp-server-galaxy-py/tests/test_helpers.py
@@ -25,6 +25,7 @@ from galaxy_mcp.server import (
     get_iwc_workflows,
     get_job_details,
     get_server_info,
+    inspect_tool_contract,
     get_tool_citations,
     get_tool_details,
     get_tool_panel,
@@ -37,11 +38,13 @@ from galaxy_mcp.server import (
     list_workflows,
     recommend_iwc_workflows,
     run_tool,
+    run_tool_validated,
     search_iwc_workflows,
     search_tools_by_keywords,
     search_tools_by_name,
     upload_file,
     upload_file_from_url,
+    validate_tool_inputs,
 )
 
 
@@ -68,6 +71,7 @@ get_iwc_workflow_details_fn = get_function(get_iwc_workflow_details)
 get_iwc_workflows_fn = get_function(get_iwc_workflows)
 get_job_details_fn = get_function(get_job_details)
 get_server_info_fn = get_function(get_server_info)
+inspect_tool_contract_fn = get_function(inspect_tool_contract)
 get_tool_citations_fn = get_function(get_tool_citations)
 get_tool_details_fn = get_function(get_tool_details)
 get_tool_run_examples_fn = get_function(get_tool_run_examples)
@@ -80,10 +84,12 @@ list_history_ids_fn = get_function(list_history_ids)
 list_workflows_fn = get_function(list_workflows)
 recommend_iwc_workflows_fn = get_function(recommend_iwc_workflows)
 run_tool_fn = get_function(run_tool)
+run_tool_validated_fn = get_function(run_tool_validated)
 search_iwc_workflows_fn = get_function(search_iwc_workflows)
 search_tools_fn = get_function(search_tools_by_name)
 upload_file_fn = get_function(upload_file)
 upload_file_from_url_fn = get_function(upload_file_from_url)
+validate_tool_inputs_fn = get_function(validate_tool_inputs)
 
 # Re-export non-wrapped items
 __all__ = [
@@ -104,6 +110,7 @@ __all__ = [
     "get_iwc_workflows_fn",
     "get_job_details_fn",
     "get_server_info_fn",
+    "inspect_tool_contract_fn",
     "get_tool_citations_fn",
     "get_tool_details_fn",
     "get_tool_run_examples_fn",
@@ -116,10 +123,12 @@ __all__ = [
     "list_workflows_fn",
     "recommend_iwc_workflows_fn",
     "run_tool_fn",
+    "run_tool_validated_fn",
     "search_iwc_workflows_fn",
     "search_tools_fn",
     "upload_file_fn",
     "upload_file_from_url_fn",
+    "validate_tool_inputs_fn",
     "galaxy_state",
     "ensure_connected",
 ]

--- a/mcp-server-galaxy-py/tests/test_tool_validation.py
+++ b/mcp-server-galaxy-py/tests/test_tool_validation.py
@@ -1,0 +1,711 @@
+"""Tests for structured tool contracts and validated tool submission."""
+
+from unittest.mock import patch
+
+import pytest
+
+from galaxy_mcp import server
+
+from .test_helpers import (
+    galaxy_state,
+    inspect_tool_contract_fn,
+    run_tool_validated_fn,
+    validate_tool_inputs_fn,
+)
+
+
+def _sample_tool_info() -> dict:
+    return {
+        "id": "example_tool",
+        "name": "Example Tool",
+        "version": "1.0.0",
+        "description": "Example for contract tests",
+        "inputs": [
+            {
+                "name": "input_dataset",
+                "type": "data",
+                "label": "Input dataset",
+                "optional": False,
+            },
+            {
+                "name": "mode",
+                "type": "conditional",
+                "optional": False,
+                "test_param": {
+                    "name": "selector",
+                    "type": "select",
+                    "label": "Mode selector",
+                    "options": [
+                        ["Alpha", "alpha", True],
+                        ["Beta", "beta", False],
+                    ],
+                },
+                "cases": [
+                    {
+                        "value": "alpha",
+                        "inputs": [
+                            {
+                                "name": "alpha_threshold",
+                                "type": "float",
+                                "label": "Alpha threshold",
+                                "optional": False,
+                            }
+                        ],
+                    },
+                    {
+                        "value": "beta",
+                        "inputs": [
+                            {
+                                "name": "beta_flag",
+                                "type": "boolean",
+                                "label": "Beta flag",
+                                "optional": False,
+                            }
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def _sample_tool_info_simple() -> dict:
+    return {
+        "id": "simple_tool",
+        "name": "Simple Tool",
+        "version": "1.0.0",
+        "description": "Simple schema",
+        "inputs": [
+            {
+                "name": "input_dataset",
+                "type": "data",
+                "label": "Input dataset",
+                "optional": False,
+            }
+        ],
+    }
+
+
+def _sample_tool_info_batch_size() -> dict:
+    return {
+        "id": "batch_tool",
+        "name": "Batch Tool",
+        "version": "1.0.0",
+        "description": "Batch schema",
+        "inputs": [
+            {
+                "name": "batch_size",
+                "type": "integer",
+                "label": "Batch size",
+                "optional": True,
+            }
+        ],
+    }
+
+
+def _sample_tool_info_select() -> dict:
+    return {
+        "id": "select_tool",
+        "name": "Select Tool",
+        "version": "1.0.0",
+        "description": "Select schema",
+        "inputs": [
+            {
+                "name": "strategy",
+                "type": "select",
+                "label": "Strategy",
+                "optional": False,
+                "options": [
+                    ["Option A", "a", True],
+                    ["Option B", "b", False],
+                ],
+            }
+        ],
+    }
+
+
+def _sample_tool_info_repeat() -> dict:
+    return {
+        "id": "repeat_tool",
+        "name": "Repeat Tool",
+        "version": "1.0.0",
+        "description": "Repeat schema",
+        "inputs": [
+            {
+                "name": "images_zip_repeat",
+                "type": "repeat",
+                "optional": False,
+                "inputs": [
+                    {
+                        "name": "images_zip",
+                        "type": "data",
+                        "label": "Images archive",
+                        "optional": False,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _sample_tool_info_with_extension() -> dict:
+    return {
+        "id": "ext_tool",
+        "name": "Extension Tool",
+        "version": "1.0.0",
+        "description": "Extension-aware schema",
+        "inputs": [
+            {
+                "name": "input_dataset",
+                "type": "data",
+                "label": "Input dataset",
+                "optional": False,
+                "extensions": ["csv"],
+            }
+        ],
+    }
+
+
+def _sample_tool_info_collection() -> dict:
+    return {
+        "id": "collection_tool",
+        "name": "Collection Tool",
+        "version": "1.0.0",
+        "description": "Collection schema",
+        "inputs": [
+            {
+                "name": "input_collection",
+                "type": "data_collection",
+                "label": "Input collection",
+                "optional": False,
+                "collection_types": ["list"],
+            }
+        ],
+    }
+
+
+def _sample_tool_info_conditional_dataset() -> dict:
+    return {
+        "id": "conditional_dataset_tool",
+        "name": "Conditional Dataset Tool",
+        "version": "1.0.0",
+        "description": "Conditional dataset schema",
+        "inputs": [
+            {
+                "name": "mode",
+                "type": "conditional",
+                "optional": False,
+                "test_param": {
+                    "name": "selector",
+                    "type": "select",
+                    "label": "Selector",
+                    "options": [["Alpha", "alpha", True], ["Beta", "beta", False]],
+                },
+                "cases": [
+                    {
+                        "value": "alpha",
+                        "inputs": [
+                            {"name": "alpha_input", "type": "data", "optional": True},
+                        ],
+                    },
+                    {
+                        "value": "beta",
+                        "inputs": [
+                            {"name": "beta_input", "type": "data", "optional": True},
+                        ],
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def _sample_tool_info_column_and_text() -> dict:
+    return {
+        "id": "column_text_tool",
+        "name": "Column/Text Tool",
+        "version": "1.0.0",
+        "description": "Column and text schema",
+        "inputs": [
+            {
+                "name": "table_input",
+                "type": "data",
+                "label": "Input table",
+                "optional": False,
+            },
+            {
+                "name": "target_column",
+                "type": "data_column",
+                "label": "Target column",
+                "optional": False,
+            },
+            {
+                "name": "hyperparameters",
+                "type": "text",
+                "label": "Hyperparameters JSON",
+                "optional": True,
+            },
+        ],
+    }
+
+
+class TestToolValidation:
+    def test_inspect_tool_contract_returns_structured_output(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info()
+        mock_galaxy_instance.tools.build.return_value = {
+            "state_inputs": {"mode": {"selector": "alpha"}},
+            "errors": {},
+            "tool_errors": None,
+        }
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = inspect_tool_contract_fn("example_tool", history_id="hist1")
+
+        assert result.success is True
+        contract = result.data["contract"]
+        assert "fields" in contract
+        assert "conditional_groups" in contract
+        assert "input_dataset" in contract["required_keys"]
+        assert any(g["selector_key"] == "mode|selector" for g in contract["conditional_groups"])
+        assert "agent_hints" in result.data
+        assert result.data["agent_identity"] == server.USER_AGENT
+
+    def test_inspect_tool_contract_includes_agent_hints_for_special_field_types(
+        self, mock_galaxy_instance
+    ):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info_column_and_text()
+        mock_galaxy_instance.tools.build.return_value = {"state_inputs": {}, "errors": {}, "tool_errors": None}
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = inspect_tool_contract_fn("column_text_tool", history_id="hist1")
+
+        assert result.success is True
+        codes = {hint["code"] for hint in result.data["agent_hints"]}
+        assert "data_column_requires_index" in codes
+        assert "text_json_escape_risk" in codes
+
+    def test_validate_tool_inputs_detects_missing_conditional_selector(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info()
+        mock_galaxy_instance.tools.build.return_value = {
+            "state_inputs": {"mode": {"selector": "alpha"}},
+            "errors": {},
+            "tool_errors": None,
+        }
+
+        inputs = {
+            "input_dataset": {"src": "hda", "id": "dataset1"},
+            "mode|alpha_threshold": 0.1,
+        }
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = validate_tool_inputs_fn("hist1", "example_tool", inputs)
+
+        assert result.success is True
+        assert result.data["validation"]["valid"] is False
+        assert any(
+            err["code"] == "conditional_selector_missing"
+            for err in result.data["validation"]["errors"]
+        )
+        assert result.data["agent_identity"] == server.USER_AGENT
+        assert mock_galaxy_instance.tools.build.call_count >= 1
+        first_call = mock_galaxy_instance.tools.build.call_args_list[0]
+        assert first_call.args[0] == "example_tool"
+        assert first_call.kwargs["history_id"] == "hist1"
+
+    def test_validate_tool_inputs_accepts_valid_payload(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info()
+        mock_galaxy_instance.tools.build.return_value = {
+            "state_inputs": {
+                "input_dataset": {"src": "hda", "id": "dataset1"},
+                "mode": {"selector": "alpha", "alpha_threshold": 0.1},
+            },
+            "errors": {},
+            "tool_errors": None,
+        }
+
+        inputs = {
+            "input_dataset": {"src": "hda", "id": "dataset1"},
+            "mode|selector": "alpha",
+            "mode|alpha_threshold": 0.1,
+        }
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = validate_tool_inputs_fn("hist1", "example_tool", inputs)
+
+        assert result.success is True
+        assert result.data["validation"]["valid"] is True
+        assert result.data["validation"]["errors"] == []
+        assert mock_galaxy_instance.tools.build.call_count >= 1
+
+    def test_run_tool_validated_rejects_invalid_payload(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info()
+        mock_galaxy_instance.tools.build.return_value = {
+            "state_inputs": {"mode": {"selector": "alpha"}},
+            "errors": {},
+            "tool_errors": None,
+        }
+
+        inputs = {
+            "input_dataset": {"src": "hda", "id": "dataset1"},
+            "mode|alpha_threshold": 0.1,
+        }
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            with pytest.raises(ValueError, match="Run tool validated failed"):
+                run_tool_validated_fn("hist1", "example_tool", inputs)
+
+        assert mock_galaxy_instance.tools.build.call_count >= 1
+        mock_galaxy_instance.tools.run_tool.assert_not_called()
+
+    def test_run_tool_validated_submits_when_valid(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info()
+        mock_galaxy_instance.tools.build.return_value = {
+            "state_inputs": {
+                "input_dataset": {"src": "hda", "id": "dataset1"},
+                "mode": {"selector": "alpha", "alpha_threshold": 0.1},
+            },
+            "errors": {},
+            "tool_errors": None,
+        }
+        mock_galaxy_instance.tools.run_tool.return_value = {
+            "jobs": [{"id": "job1", "state": "queued"}],
+            "outputs": [{"id": "out1"}],
+        }
+
+        inputs = {
+            "input_dataset": {"src": "hda", "id": "dataset1"},
+            "mode|selector": "alpha",
+            "mode|alpha_threshold": 0.1,
+        }
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = run_tool_validated_fn("hist1", "example_tool", inputs)
+
+        assert result.success is True
+        assert result.data["validation"]["valid"] is True
+        assert "submission" in result.data
+        assert "build_rounds" in result.data
+        assert "build_converged" in result.data
+        assert "dataset_preflight" in result.data
+        assert result.data["agent_identity"] == server.USER_AGENT
+        mock_galaxy_instance.tools.run_tool.assert_called_once_with(
+            "hist1",
+            "example_tool",
+            inputs,
+        )
+
+    def test_unknown_keys_are_errors_by_default(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info_simple()
+        mock_galaxy_instance.tools.build.return_value = {"state_inputs": {}, "errors": {}, "tool_errors": None}
+
+        inputs = {
+            "input_dataset": {"src": "hda", "id": "dataset1"},
+            "data_train": {"src": "hda", "id": "dataset2"},
+        }
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = validate_tool_inputs_fn("hist1", "simple_tool", inputs)
+
+        assert result.success is True
+        assert result.data["validation"]["valid"] is False
+        assert any(err["code"] == "unknown_input_keys" for err in result.data["validation"]["errors"])
+
+    def test_unknown_keys_can_be_warning_in_non_strict_mode(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info_simple()
+        mock_galaxy_instance.tools.build.return_value = {"state_inputs": {}, "errors": {}, "tool_errors": None}
+        mock_galaxy_instance.tools.run_tool.return_value = {"jobs": [{"id": "job1"}], "outputs": []}
+
+        inputs = {
+            "input_dataset": {"src": "hda", "id": "dataset1"},
+            "data_train": {"src": "hda", "id": "dataset2"},
+        }
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            validation = validate_tool_inputs_fn(
+                "hist1", "simple_tool", inputs, strict_unknown_keys=False
+            )
+
+        assert validation.success is True
+        assert validation.data["validation"]["valid"] is True
+        assert any(
+            warning["code"] == "unknown_input_keys"
+            for warning in validation.data["validation"]["warnings"]
+        )
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            submission = run_tool_validated_fn(
+                "hist1",
+                "simple_tool",
+                inputs,
+                strict_unknown_keys=False,
+            )
+
+        assert submission.success is True
+        mock_galaxy_instance.tools.run_tool.assert_called_once()
+
+    def test_repeat_indexed_keys_are_accepted(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info_repeat()
+        mock_galaxy_instance.tools.build.return_value = {"state_inputs": {}, "errors": {}, "tool_errors": None}
+
+        inputs = {"images_zip_repeat_0|images_zip": {"src": "hda", "id": "dataset_zip"}}
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = validate_tool_inputs_fn("hist1", "repeat_tool", inputs)
+
+        assert result.success is True
+        assert result.data["validation"]["valid"] is True
+        assert result.data["validation"]["unknown_keys"] == []
+
+    def test_non_repeat_suffix_key_is_not_normalized(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info_batch_size()
+        mock_galaxy_instance.tools.build.return_value = {"state_inputs": {}, "errors": {}, "tool_errors": None}
+
+        inputs = {"batch_size_2": 32}
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = validate_tool_inputs_fn("hist1", "batch_tool", inputs)
+
+        assert result.success is True
+        assert result.data["validation"]["valid"] is False
+        assert any(
+            err["code"] == "unknown_input_keys" for err in result.data["validation"]["errors"]
+        )
+
+    def test_data_column_requires_1_indexed_integer(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info_column_and_text()
+        mock_galaxy_instance.tools.build.return_value = {"state_inputs": {}, "errors": {}, "tool_errors": None}
+
+        invalid_inputs = {
+            "table_input": {"src": "hda", "id": "dataset_table"},
+            "target_column": "patient_id",
+        }
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            invalid_result = validate_tool_inputs_fn("hist1", "column_text_tool", invalid_inputs)
+
+        assert invalid_result.success is True
+        assert invalid_result.data["validation"]["valid"] is False
+        assert any(
+            err["code"] == "invalid_data_column_value"
+            for err in invalid_result.data["validation"]["errors"]
+        )
+
+        valid_inputs = {"table_input": {"src": "hda", "id": "dataset_table"}, "target_column": 2}
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            valid_result = validate_tool_inputs_fn("hist1", "column_text_tool", valid_inputs)
+
+        assert valid_result.success is True
+        assert valid_result.data["validation"]["valid"] is True
+
+    def test_json_blob_in_text_field_warns(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info_column_and_text()
+        mock_galaxy_instance.tools.build.return_value = {"state_inputs": {}, "errors": {}, "tool_errors": None}
+
+        inputs = {
+            "table_input": {"src": "hda", "id": "dataset_table"},
+            "target_column": 1,
+            "hyperparameters": "{\"learning_rate\":0.01}",
+        }
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = validate_tool_inputs_fn("hist1", "column_text_tool", inputs)
+
+        assert result.success is True
+        assert result.data["validation"]["valid"] is True
+        assert any(
+            warning["code"] == "json_blob_in_text_field"
+            for warning in result.data["validation"]["warnings"]
+        )
+
+    def test_invalid_select_value_is_rejected(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info_select()
+        mock_galaxy_instance.tools.build.return_value = {
+            "state_inputs": {"strategy": "invalid_choice"},
+            "errors": {},
+            "tool_errors": None,
+        }
+
+        inputs = {"strategy": "invalid_choice"}
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = validate_tool_inputs_fn("hist1", "select_tool", inputs)
+
+        assert result.success is True
+        assert result.data["validation"]["valid"] is False
+        assert any(
+            err["code"] == "invalid_select_value"
+            for err in result.data["validation"]["errors"]
+        )
+
+    def test_iterative_build_preserves_agent_values(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info()
+        mock_galaxy_instance.tools.build.side_effect = [
+            {
+                "state_inputs": {
+                    "input_dataset": {"src": "hda", "id": "dataset1"},
+                    "mode": {"selector": "alpha", "alpha_threshold": 0.5},
+                },
+                "errors": {},
+                "tool_errors": None,
+            },
+            {
+                "state_inputs": {
+                    "input_dataset": {"src": "hda", "id": "dataset1"},
+                    "mode": {"selector": "alpha", "alpha_threshold": 0.5},
+                },
+                "errors": {},
+                "tool_errors": None,
+            },
+        ]
+
+        inputs = {
+            "input_dataset": {"src": "hda", "id": "dataset1"},
+            "mode|selector": "alpha",
+            "mode|alpha_threshold": 0.1,
+        }
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = validate_tool_inputs_fn("hist1", "example_tool", inputs)
+
+        assert result.success is True
+        assert result.data["resolved_inputs"]["mode"]["alpha_threshold"] == 0.5
+        assert mock_galaxy_instance.tools.build.call_count >= 2
+        second_call = mock_galaxy_instance.tools.build.call_args_list[1]
+        assert second_call.kwargs["inputs"]["mode"]["alpha_threshold"] == 0.1
+        assert result.data["build_rounds"] >= 2
+        assert result.data["build_converged"] is True
+
+    def test_iterative_build_warns_when_not_converged(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info_select()
+        mock_galaxy_instance.tools.build.side_effect = [
+            {"state_inputs": {"strategy": "a"}, "errors": {}, "tool_errors": None},
+            {"state_inputs": {"strategy": "b"}, "errors": {}, "tool_errors": None},
+            {"state_inputs": {"strategy": "a"}, "errors": {}, "tool_errors": None},
+        ]
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = validate_tool_inputs_fn("hist1", "select_tool", {})
+
+        assert result.success is True
+        warning_codes = {warning["code"] for warning in result.data["validation"]["warnings"]}
+        assert "build_not_converged" in warning_codes or "build_oscillation_detected" in warning_codes
+        assert result.data["build_rounds"] == 3
+
+    def test_dataset_preflight_dataset_not_found(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info_simple()
+        mock_galaxy_instance.tools.build.return_value = {
+            "state_inputs": {"input_dataset": {"src": "hda", "id": "dataset_missing"}},
+            "errors": {},
+            "tool_errors": None,
+        }
+        mock_galaxy_instance.datasets.show_dataset.side_effect = Exception("404 not found")
+
+        inputs = {"input_dataset": {"src": "hda", "id": "dataset_missing"}}
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = validate_tool_inputs_fn("hist1", "simple_tool", inputs)
+
+        assert result.success is True
+        assert result.data["validation"]["valid"] is False
+        assert any(
+            err["code"] == "dataset_not_found"
+            for err in result.data["validation"]["errors"]
+        )
+
+    def test_dataset_preflight_history_deleted(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info_simple()
+        mock_galaxy_instance.tools.build.return_value = {
+            "state_inputs": {"input_dataset": {"src": "hda", "id": "dataset1"}},
+            "errors": {},
+            "tool_errors": None,
+        }
+        mock_galaxy_instance.histories.show_history.return_value = {"id": "hist1", "deleted": True}
+
+        inputs = {"input_dataset": {"src": "hda", "id": "dataset1"}}
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = validate_tool_inputs_fn("hist1", "simple_tool", inputs)
+
+        assert result.success is True
+        assert any(
+            err["code"] == "history_deleted"
+            for err in result.data["validation"]["errors"]
+        )
+
+    def test_dataset_preflight_extension_mismatch_warns(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info_with_extension()
+        mock_galaxy_instance.tools.build.return_value = {
+            "state_inputs": {"input_dataset": {"src": "hda", "id": "dataset1"}},
+            "errors": {},
+            "tool_errors": None,
+        }
+        mock_galaxy_instance.datasets.show_dataset.return_value = {
+            "id": "dataset1",
+            "state": "ok",
+            "history_id": "hist1",
+            "extension": "txt",
+        }
+
+        inputs = {"input_dataset": {"src": "hda", "id": "dataset1"}}
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = validate_tool_inputs_fn("hist1", "ext_tool", inputs)
+
+        assert result.success is True
+        assert result.data["validation"]["valid"] is True
+        assert any(
+            warning["code"] == "dataset_extension_mismatch"
+            for warning in result.data["validation"]["warnings"]
+        )
+
+    def test_dataset_preflight_collection_type_mismatch(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info_collection()
+        mock_galaxy_instance.tools.build.return_value = {
+            "state_inputs": {"input_collection": {"src": "hdca", "id": "collection1"}},
+            "errors": {},
+            "tool_errors": None,
+        }
+        mock_collection_client = type("MockCollectionClient", (), {})()
+        mock_collection_client.show_dataset_collection = (
+            lambda _collection_id: {
+                "id": "collection1",
+                "collection_type": "paired",
+                "history_id": "hist1",
+            }
+        )
+        mock_galaxy_instance.dataset_collections = mock_collection_client
+
+        inputs = {"input_collection": {"src": "hdca", "id": "collection1"}}
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = validate_tool_inputs_fn("hist1", "collection_tool", inputs)
+
+        assert result.success is True
+        assert result.data["validation"]["valid"] is False
+        assert any(
+            err["code"] == "collection_type_mismatch"
+            for err in result.data["validation"]["errors"]
+        )
+
+    def test_dataset_reference_removed_after_resolution_warns(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = _sample_tool_info_conditional_dataset()
+        mock_galaxy_instance.tools.build.side_effect = [
+            {
+                "state_inputs": {"mode": {"selector": "alpha"}},
+                "errors": {},
+                "tool_errors": None,
+            },
+            {
+                "state_inputs": {"mode": {"selector": "alpha"}},
+                "errors": {},
+                "tool_errors": None,
+            },
+        ]
+
+        inputs = {
+            "mode|selector": "alpha",
+            "mode|beta_input": {"src": "hda", "id": "dataset_beta"},
+        }
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = validate_tool_inputs_fn("hist1", "conditional_dataset_tool", inputs)
+
+        assert result.success is True
+        assert any(
+            warning["code"] == "dataset_reference_removed_by_resolution"
+            for warning in result.data["validation"]["warnings"]
+        )


### PR DESCRIPTION
## Summary

Adds a tool contract system for agent-friendly tool validation and execution:

- `tool_contract.py` — builds structured contracts describing tool inputs/outputs with validation, and provides `validate_payload_against_contract` for pre-flight parameter checking
- `build_agent_hints` — generates agent-oriented guidance for tool usage
- Comprehensive test suite in `test_tool_validation.py`

Authored by @paulocilasjr.

## Test plan

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] Verify tool contracts generate correct schemas for representative Galaxy tools