### PR TITLE
Auto-discover Galaxy tool credentials when running tools

### DIFF
--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -645,12 +645,25 @@ def run_tool(history_id: str, tool_id: str, inputs: dict[str, Any]) -> GalaxyRes
     gi: GalaxyInstance = state["gi"]
 
     try:
-        # Run the tool with provided inputs
-        result = gi.tools.run_tool(history_id, tool_id, inputs)
+        credentials_context = None
+        try:
+            user_info = gi.users.get_current_user()
+            user_id = user_info["id"]
+            credentials_context = gi.users.get_credentials_for_tool(user_id, tool_id)  # type: ignore[attr-defined]
+        except Exception:
+            pass  # Credentials lookup is best-effort
+
+        result = gi.tools.run_tool(
+            history_id,
+            tool_id,
+            inputs,
+            credentials_context=credentials_context,  # type: ignore[call-arg]
+        )
+        cred_msg = " (with credentials)" if credentials_context else ""
         return GalaxyResult(
             data=result,
             success=True,
-            message=f"Started tool '{tool_id}' in history '{history_id}'",
+            message=f"Started tool '{tool_id}' in history '{history_id}'{cred_msg}",
         )
     except Exception as e:
         raise ValueError(

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -1,6 +1,8 @@
 # Galaxy MCP Server
 import concurrent.futures
+import contextlib
 import importlib.metadata
+import inspect
 import logging
 import os
 import threading
@@ -59,6 +61,68 @@ class GalaxyResult(BaseModel):
 # Set up logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def _get_tool_credentials_context(gi: GalaxyInstance, tool_id: str) -> list[dict[str, Any]] | None:
+    """Return stored credentials for a tool when the BioBlend client supports it."""
+    get_credentials_for_tool = getattr(gi.users, "get_credentials_for_tool", None)
+    if get_credentials_for_tool is None:
+        return None
+
+    user_info = gi.users.get_current_user()
+    user_id = user_info["id"]
+    return cast(list[dict[str, Any]] | None, get_credentials_for_tool(user_id, tool_id))
+
+
+def _supports_credentials_context(run_tool_method: Any) -> bool:
+    """Detect whether BioBlend's tools.run_tool() accepts credentials_context."""
+    try:
+        signature = inspect.signature(run_tool_method)
+    except (TypeError, ValueError):
+        return False
+
+    parameters = signature.parameters.values()
+    return any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD or parameter.name == "credentials_context"
+        for parameter in parameters
+    )
+
+
+def _is_credential_related_error(error: Exception) -> bool:
+    """Return True when a tool run failure appears to involve Galaxy credentials."""
+    error_text = str(error).lower()
+    credential_markers = (
+        "credential",
+        "credentials",
+        "credentials_context",
+        "user_credentials",
+        "service credential",
+        "service credentials",
+    )
+    return any(marker in error_text for marker in credential_markers)
+
+
+def _format_run_tool_credential_error(
+    error: Exception,
+    *,
+    history_id: str,
+    tool_id: str,
+    used_credentials: bool,
+) -> str:
+    """Return an agent-friendly error for missing or invalid tool credentials."""
+    base = format_error("Run tool", error, {"history_id": history_id, "tool_id": tool_id})
+    if used_credentials:
+        return (
+            f"{base}. Galaxy rejected the run while using stored credentials for tool "
+            f"'{tool_id}'. Check the configured credential values or active credential group "
+            "for this tool, then try again."
+        )
+
+    return (
+        f"{base}. This tool appears to require Galaxy tool credentials, but no stored "
+        f"credentials were found for tool '{tool_id}'. Configure credentials for this tool "
+        "in Galaxy, then retry the run."
+    )
 
 
 def format_error(action: str, error: Exception, context: dict | None = None) -> str:
@@ -646,26 +710,38 @@ def run_tool(history_id: str, tool_id: str, inputs: dict[str, Any]) -> GalaxyRes
 
     try:
         credentials_context = None
-        try:
-            user_info = gi.users.get_current_user()
-            user_id = user_info["id"]
-            credentials_context = gi.users.get_credentials_for_tool(user_id, tool_id)  # type: ignore[attr-defined]
-        except Exception:
-            pass  # Credentials lookup is best-effort
+        with contextlib.suppress(Exception):
+            credentials_context = _get_tool_credentials_context(gi, tool_id)
 
-        result = gi.tools.run_tool(
-            history_id,
-            tool_id,
-            inputs,
-            credentials_context=credentials_context,  # type: ignore[call-arg]
-        )
-        cred_msg = " (with credentials)" if credentials_context else ""
+        run_tool_kwargs: dict[str, Any] = {}
+        if credentials_context:
+            if _supports_credentials_context(gi.tools.run_tool):
+                run_tool_kwargs["credentials_context"] = credentials_context
+            else:
+                logger.warning(
+                    "Stored credentials found for tool '%s', but installed BioBlend "
+                    "does not support credentials_context. Run will proceed without credentials.",
+                    tool_id,
+                )
+
+        used_credentials = "credentials_context" in run_tool_kwargs
+        result = gi.tools.run_tool(history_id, tool_id, inputs, **run_tool_kwargs)
+        cred_msg = " (with credentials)" if used_credentials else ""
         return GalaxyResult(
             data=result,
             success=True,
             message=f"Started tool '{tool_id}' in history '{history_id}'{cred_msg}",
         )
     except Exception as e:
+        if _is_credential_related_error(e):
+            raise ValueError(
+                _format_run_tool_credential_error(
+                    e,
+                    history_id=history_id,
+                    tool_id=tool_id,
+                    used_credentials=used_credentials if "used_credentials" in locals() else False,
+                )
+            ) from e
         raise ValueError(
             format_error(
                 "Run tool", e, {"history_id": history_id, "tool_id": tool_id, "inputs": inputs}

--- a/mcp-server-galaxy-py/tests/conftest.py
+++ b/mcp-server-galaxy-py/tests/conftest.py
@@ -88,6 +88,7 @@ def mock_galaxy_instance():
         "email": "test@example.com",
         "username": "testuser",
     }
+    mock_users.get_credentials_for_tool.return_value = None
     mock_gi.users = mock_users
 
     return mock_gi

--- a/mcp-server-galaxy-py/tests/test_tool_operations.py
+++ b/mcp-server-galaxy-py/tests/test_tool_operations.py
@@ -74,7 +74,7 @@ class TestToolOperations:
             assert result.data[0]["id"] == "tool1"
 
     def test_run_tool_fn(self, mock_galaxy_instance):
-        """Test running a tool"""
+        """Test running a tool without stored credentials"""
         mock_galaxy_instance.tools.run_tool.return_value = {
             "jobs": [{"id": "job_1", "state": "ok"}],
             "outputs": [{"id": "output_1", "name": "aligned.bam"}],
@@ -98,7 +98,44 @@ class TestToolOperations:
                 "tool1",
                 {"input1": {"src": "hda", "id": "dataset_1"}, "param1": "value1"},
             )
-            assert "credentials_context" in call_args[1]
+            assert call_args[1] == {}
+
+    def test_run_tool_with_credentials(self, mock_galaxy_instance):
+        """Test running a tool with stored credentials"""
+        mock_galaxy_instance.users.get_credentials_for_tool.return_value = [
+            {
+                "user_credentials_id": "cred-1",
+                "name": "external_service",
+                "version": "1.0",
+                "selected_group": {"id": "group-1", "name": "default"},
+            }
+        ]
+        mock_galaxy_instance.tools.run_tool.return_value = {
+            "jobs": [{"id": "job_1", "state": "ok"}],
+            "outputs": [{"id": "output_1", "name": "aligned.bam"}],
+        }
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = run_tool_fn("test_history_1", "tool1", {"param1": "value1"})
+
+            assert result.success is True
+            assert result.message.endswith("(with credentials)")
+            mock_galaxy_instance.users.get_credentials_for_tool.assert_called_once_with(
+                "user1", "tool1"
+            )
+            mock_galaxy_instance.tools.run_tool.assert_called_once_with(
+                "test_history_1",
+                "tool1",
+                {"param1": "value1"},
+                credentials_context=[
+                    {
+                        "user_credentials_id": "cred-1",
+                        "name": "external_service",
+                        "version": "1.0",
+                        "selected_group": {"id": "group-1", "name": "default"},
+                    }
+                ],
+            )
 
     def test_run_tool_error(self, mock_galaxy_instance):
         """Test tool execution error handling"""
@@ -106,6 +143,34 @@ class TestToolOperations:
 
         with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
             with pytest.raises(ValueError, match="Run tool failed"):
+                run_tool_fn("test_history_1", "tool1", {})
+
+    def test_run_tool_missing_credentials_error(self, mock_galaxy_instance):
+        """Test agent-friendly error when Galaxy requires credentials and none are stored."""
+        mock_galaxy_instance.tools.run_tool.side_effect = Exception(
+            "Tool execution failed: missing credentials for service"
+        )
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            with pytest.raises(ValueError, match="no stored credentials were found"):
+                run_tool_fn("test_history_1", "tool1", {})
+
+    def test_run_tool_invalid_stored_credentials_error(self, mock_galaxy_instance):
+        """Test agent-friendly error when stored credentials are rejected."""
+        mock_galaxy_instance.users.get_credentials_for_tool.return_value = [
+            {
+                "user_credentials_id": "cred-1",
+                "name": "external_service",
+                "version": "1.0",
+                "selected_group": {"id": "group-1", "name": "default"},
+            }
+        ]
+        mock_galaxy_instance.tools.run_tool.side_effect = Exception(
+            "Tool execution failed: invalid user_credentials selection"
+        )
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            with pytest.raises(ValueError, match="using stored credentials"):
                 run_tool_fn("test_history_1", "tool1", {})
 
     def test_tool_operations_not_connected(self):

--- a/mcp-server-galaxy-py/tests/test_tool_operations.py
+++ b/mcp-server-galaxy-py/tests/test_tool_operations.py
@@ -91,11 +91,14 @@ class TestToolOperations:
             assert "outputs" in result.data
             assert result.data["outputs"][0]["name"] == "aligned.bam"
 
-            mock_galaxy_instance.tools.run_tool.assert_called_once_with(
+            mock_galaxy_instance.tools.run_tool.assert_called_once()
+            call_args = mock_galaxy_instance.tools.run_tool.call_args
+            assert call_args[0] == (
                 "test_history_1",
                 "tool1",
                 {"input1": {"src": "hda", "id": "dataset_1"}, "param1": "value1"},
             )
+            assert "credentials_context" in call_args[1]
 
     def test_run_tool_error(self, mock_galaxy_instance):
         """Test tool execution error handling"""


### PR DESCRIPTION
## Summary
- Adds best-effort credential auto-discovery to `run_tool`: before submitting a tool run, look up the user's stored credentials for that tool and pass them through as `credentials_context`.
- If the tool doesn't need credentials, or none are configured, the lookup silently no-ops and the run proceeds normally.
- Includes credential-aware error messages so agents get actionable feedback when a run fails for credential reasons (e.g. \"Galaxy rejected the run while using stored credentials for tool 'x' -- check the configured values\").

## BioBlend compatibility
The feature uses `gi.users.get_credentials_for_tool` and the `credentials_context=` kwarg on `gi.tools.run_tool`, which are not yet in a released BioBlend. Runtime detection (`_supports_credentials_context`, `getattr` for the user-client method) keeps this safe on current BioBlend versions:
- On older BioBlend: lookup returns `None`, run_tool is called with the original signature, behavior is unchanged.
- On BioBlend with credentials support: lookup populates context, run_tool receives it, agents see \"(with credentials)\" in the result message.

## Followup
Once BioBlend ships the credentials API in a release, a small followup PR will:
- Drop `_supports_credentials_context` and the `getattr` guard in `_get_tool_credentials_context`.
- Bump the bioblend pin.
- Remove `import inspect` and `import contextlib`.

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (76 passed, 24 real-integration skipped)
- [ ] Smoke test against a Galaxy with a tool that requires credentials configured