### PR TITLE
Drop runtime bioblend credentials detection (followup to #41)

### DIFF
--- a/mcp-server-galaxy-py/pyproject.toml
+++ b/mcp-server-galaxy-py/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "anyio>=4.0.0,<5",
-    "bioblend>=1.7.0,<2",
+    "bioblend>=1.9.0,<2",
     "cryptography>=41.0.0,<48",
     "fastmcp>=3.0.0,<4",
     "requests>=2.32.3,<3",

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -2,7 +2,6 @@
 import concurrent.futures
 import contextlib
 import importlib.metadata
-import inspect
 import logging
 import os
 import threading
@@ -89,28 +88,10 @@ logger = logging.getLogger(__name__)
 
 
 def _get_tool_credentials_context(gi: GalaxyInstance, tool_id: str) -> list[dict[str, Any]] | None:
-    """Return stored credentials for a tool when the BioBlend client supports it."""
-    get_credentials_for_tool = getattr(gi.users, "get_credentials_for_tool", None)
-    if get_credentials_for_tool is None:
-        return None
-
+    """Return stored credentials for a tool, if any are configured for the current user."""
     user_info = gi.users.get_current_user()
     user_id = user_info["id"]
-    return cast(list[dict[str, Any]] | None, get_credentials_for_tool(user_id, tool_id))
-
-
-def _supports_credentials_context(run_tool_method: Any) -> bool:
-    """Detect whether BioBlend's tools.run_tool() accepts credentials_context."""
-    try:
-        signature = inspect.signature(run_tool_method)
-    except (TypeError, ValueError):
-        return False
-
-    parameters = signature.parameters.values()
-    return any(
-        parameter.kind == inspect.Parameter.VAR_KEYWORD or parameter.name == "credentials_context"
-        for parameter in parameters
-    )
+    return cast(list[dict[str, Any]] | None, gi.users.get_credentials_for_tool(user_id, tool_id))
 
 
 def _is_credential_related_error(error: Exception) -> bool:
@@ -744,19 +725,10 @@ def run_tool(history_id: str, tool_id: str, inputs: dict[str, Any]) -> GalaxyRes
         with contextlib.suppress(Exception):
             credentials_context = _get_tool_credentials_context(gi, tool_id)
 
-        run_tool_kwargs: dict[str, Any] = {}
-        if credentials_context:
-            if _supports_credentials_context(gi.tools.run_tool):
-                run_tool_kwargs["credentials_context"] = credentials_context
-            else:
-                logger.warning(
-                    "Stored credentials found for tool '%s', but installed BioBlend "
-                    "does not support credentials_context. Run will proceed without credentials.",
-                    tool_id,
-                )
-
-        used_credentials = "credentials_context" in run_tool_kwargs
-        result = gi.tools.run_tool(history_id, tool_id, inputs, **run_tool_kwargs)
+        used_credentials = credentials_context is not None
+        result = gi.tools.run_tool(
+            history_id, tool_id, inputs, credentials_context=credentials_context
+        )
         cred_msg = " (with credentials)" if used_credentials else ""
         return GalaxyResult(
             data=result,

--- a/mcp-server-galaxy-py/tests/test_tool_operations.py
+++ b/mcp-server-galaxy-py/tests/test_tool_operations.py
@@ -98,7 +98,8 @@ class TestToolOperations:
                 "tool1",
                 {"input1": {"src": "hda", "id": "dataset_1"}, "param1": "value1"},
             )
-            assert call_args[1] == {}
+            assert "credentials_context" in call_args.kwargs
+            assert call_args.kwargs["credentials_context"] is None
 
     def test_run_tool_with_credentials(self, mock_galaxy_instance):
         """Test running a tool with stored credentials"""

--- a/mcp-server-galaxy-py/uv.lock
+++ b/mcp-server-galaxy-py/uv.lock
@@ -243,7 +243,7 @@ wheels = [
 
 [[package]]
 name = "bioblend"
-version = "1.7.0"
+version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
@@ -251,9 +251,9 @@ dependencies = [
     { name = "requests-toolbelt" },
     { name = "tuspy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/1b/d34eefc808f9d55e8527d952071d76a74b858b05d6129dbc48c40bf6acab/bioblend-1.7.0.tar.gz", hash = "sha256:6e777ed4bc239e27b1618a193c3f7beca4ae9e9a14ecf1c6e115931488466558", size = 159084, upload-time = "2025-11-08T01:00:31.775Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/3e/c39594d7b19a591c925924aaca989cacd3638d4bb06d2351d075bc337a4f/bioblend-1.9.0.tar.gz", hash = "sha256:c1aefc24ad0bd81e39e55c62231c8b61129a024f80d6596c2ede032d09eef8c5", size = 161737, upload-time = "2026-04-14T16:26:55.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/ba/ff3c536ab50e179a4e1eef0ea3de7b878b6b81629ded651f0af7156a0f9c/bioblend-1.7.0-py3-none-any.whl", hash = "sha256:91f5b5ca0f563a14f297efaa4b68e1b88b6c98704f4b7d898ea5e7661bac3c35", size = 167480, upload-time = "2025-11-08T01:00:30.459Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/6b/72e5f22f3c5069bd950f107110cd17468cdb43abda3c55b48c4013e7b667/bioblend-1.9.0-py3-none-any.whl", hash = "sha256:573d6e8e8f1ee3f5a5630a05e561ca5c69ecfa2cf93d7e81d472ec8fe53abc49", size = 169893, upload-time = "2026-04-14T16:26:53.619Z" },
 ]
 
 [[package]]
@@ -289,14 +289,24 @@ sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/80/ea4ead0c5d52a9828692e7df20f0eafe8d26e671ce4883a0a146bb91049e/caio-0.9.25-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ca6c8ecda611478b6016cb94d23fd3eb7124852b985bdec7ecaad9f3116b9619", size = 36836, upload-time = "2025-12-26T15:22:04.662Z" },
     { url = "https://files.pythonhosted.org/packages/17/b9/36715c97c873649d1029001578f901b50250916295e3dddf20c865438865/caio-0.9.25-cp310-cp310-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db9b5681e4af8176159f0d6598e73b2279bb661e718c7ac23342c550bd78c241", size = 79695, upload-time = "2025-12-26T15:22:18.818Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ab/07080ecb1adb55a02cbd8ec0126aa8e43af343ffabb6a71125b42670e9a1/caio-0.9.25-cp310-cp310-manylinux_2_34_aarch64.whl", hash = "sha256:bf61d7d0c4fd10ffdd98ca47f7e8db4d7408e74649ffaf4bef40b029ada3c21b", size = 79457, upload-time = "2026-03-04T22:08:16.024Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/dd55757bb671eb4c376e006c04e83beb413486821f517792ea603ef216e9/caio-0.9.25-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:ab52e5b643f8bbd64a0605d9412796cd3464cb8ca88593b13e95a0f0b10508ae", size = 77705, upload-time = "2026-03-04T22:08:17.202Z" },
     { url = "https://files.pythonhosted.org/packages/ec/90/543f556fcfcfa270713eef906b6352ab048e1e557afec12925c991dc93c2/caio-0.9.25-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d6956d9e4a27021c8bd6c9677f3a59eb1d820cc32d0343cea7961a03b1371965", size = 36839, upload-time = "2025-12-26T15:21:40.267Z" },
     { url = "https://files.pythonhosted.org/packages/51/3b/36f3e8ec38dafe8de4831decd2e44c69303d2a3892d16ceda42afed44e1b/caio-0.9.25-cp311-cp311-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf84bfa039f25ad91f4f52944452a5f6f405e8afab4d445450978cd6241d1478", size = 80255, upload-time = "2025-12-26T15:22:20.271Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ce/65e64867d928e6aff1b4f0e12dba0ef6d5bf412c240dc1df9d421ac10573/caio-0.9.25-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:ae3d62587332bce600f861a8de6256b1014d6485cfd25d68c15caf1611dd1f7c", size = 80052, upload-time = "2026-03-04T22:08:20.402Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/e278863c47e14ec58309aa2e38a45882fbe67b4cc29ec9bc8f65852d3e45/caio-0.9.25-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:fc220b8533dcf0f238a6b1a4a937f92024c71e7b10b5a2dfc1c73604a25709bc", size = 78273, upload-time = "2026-03-04T22:08:21.368Z" },
     { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
     { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
     { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
     { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
     { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
     { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
     { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 
@@ -909,7 +919,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.0.0,<5" },
-    { name = "bioblend", specifier = ">=1.7.0,<2" },
+    { name = "bioblend", specifier = ">=1.9.0,<2" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2.1" },
     { name = "cryptography", specifier = ">=41.0.0,<48" },
     { name = "fastmcp", specifier = ">=3.0.0,<4" },


### PR DESCRIPTION
## Summary

Followup to #41. BioBlend 1.9.0 shipped `get_credentials_for_tool` and the `credentials_context` kwarg on `tools.run_tool`, so the runtime detection scaffolding we added for forward-compat is no longer needed.

## Changes

- Bump bioblend pin: `>=1.7.0,<2` -> `>=1.9.0,<2`
- `_get_tool_credentials_context`: drop the `getattr` guard, call `gi.users.get_credentials_for_tool` directly
- `_supports_credentials_context`: removed entirely (no more `inspect.signature` probing of `run_tool`)
- `run_tool`: pass `credentials_context=credentials_context` unconditionally; drop the "installed BioBlend doesn't support it" warning branch
- `import inspect` removed (only `_supports_credentials_context` used it)

Net: -17 lines, same behavior.

## Known scope limit

The `contextlib.suppress(Exception)` around the credential lookup stays as-is -- that was the design intent in #41 (best-effort, don't block tool runs on credential issues). Worth revisiting separately whether transient credential-system errors should surface more loudly rather than silently fall through to the no-credentials path, but out of scope here.

## Test plan

- [x] \`make lint\` passes
- [x] \`make test\` passes (76 passed, 24 skipped)
- [x] Codex review: confirmed no stale references, imports clean, bioblend 1.9.0 installed with both APIs present
- [x] Test assertion tightened per review: `test_run_tool_fn` now asserts `credentials_context` is explicitly in kwargs AND is None (the old `.get()` form would pass even if the kwarg was omitted entirely)