### PR TITLE
Add tool visibility middleware (Phase 2 of progressive discovery)

### DIFF
--- a/mcp-server-galaxy-py/src/galaxy_mcp/middleware.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/middleware.py
@@ -1,0 +1,140 @@
+"""Session-aware tool visibility middleware for the Galaxy MCP server.
+
+Filters which tools are exposed to each MCP client based on:
+
+* Per-session Galaxy capabilities (admin privileges, unprivileged_tools
+  support) -- hides tags the caller can't meaningfully use.
+* Static include / exclude tag lists supplied at server startup.
+
+Tools rely on `@mcp.tool(tags={...})` registrations added in Phase 1 of the
+progressive tool discovery plan.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import mcp.types as mt
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools.tool import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+SessionStateFn = Callable[[], dict[str, Any]]
+
+
+class ToolVisibilityMiddleware(Middleware):
+    """Filter tool listings and guard direct calls based on session capabilities."""
+
+    def __init__(
+        self,
+        *,
+        get_session_state: SessionStateFn,
+        include_tags: set[str] | None = None,
+        exclude_tags: set[str] | None = None,
+    ) -> None:
+        self._get_session_state = get_session_state
+        self._include_tags = set(include_tags) if include_tags else None
+        self._exclude_tags = set(exclude_tags) if exclude_tags else set()
+        self._admin_cache: dict[tuple[str, str], bool] = {}
+        self._user_tools_cache: dict[str, bool] = {}
+
+    async def on_list_tools(
+        self,
+        context: MiddlewareContext[mt.ListToolsRequest],
+        call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
+    ) -> Sequence[Tool]:
+        tools = await call_next(context)
+        hidden_tags = self._hidden_tags_for_session()
+        return [tool for tool in tools if self._is_visible(tool, hidden_tags)]
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        tool = await self._resolve_tool(context)
+        if tool is not None:
+            hidden_tags = self._hidden_tags_for_session()
+            if not self._is_visible(tool, hidden_tags):
+                raise ToolError(f"Tool '{context.message.name}' is not available in this session")
+        return await call_next(context)
+
+    async def _resolve_tool(
+        self, context: MiddlewareContext[mt.CallToolRequestParams]
+    ) -> Tool | None:
+        fastmcp_context = context.fastmcp_context
+        if fastmcp_context is None:
+            return None
+        server = getattr(fastmcp_context, "fastmcp", None)
+        if server is None:
+            return None
+        try:
+            return await server.get_tool(context.message.name)
+        except Exception as exc:
+            logger.debug("get_tool lookup failed for %s: %s", context.message.name, exc)
+            return None
+
+    def _is_visible(self, tool: Tool, hidden_tags: set[str]) -> bool:
+        tags = set(tool.tags or ())
+        if self._exclude_tags & tags:
+            return False
+        if hidden_tags & tags:
+            return False
+        if self._include_tags is None:
+            return True
+        return bool(self._include_tags & tags)
+
+    def _hidden_tags_for_session(self) -> set[str]:
+        hidden: set[str] = set()
+        state: dict[str, Any] = {}
+        with contextlib.suppress(Exception):
+            state = self._get_session_state()
+
+        if not self._session_is_admin(state):
+            hidden.add("admin")
+        if not self._session_supports_user_tools(state):
+            hidden.add("user_tools")
+        return hidden
+
+    def _session_is_admin(self, state: dict[str, Any]) -> bool:
+        gi = state.get("gi")
+        if gi is None:
+            return False
+        key = (str(state.get("url") or ""), str(state.get("api_key") or ""))
+        if not all(key):
+            return False
+        cached = self._admin_cache.get(key)
+        if cached is not None:
+            return cached
+        try:
+            user = gi.users.get_current_user()
+        except Exception as exc:
+            logger.debug("Admin probe failed for %s: %s", key[0], exc)
+            return False
+        is_admin = bool(user.get("is_admin"))
+        self._admin_cache[key] = is_admin
+        return is_admin
+
+    def _session_supports_user_tools(self, state: dict[str, Any]) -> bool:
+        gi = state.get("gi")
+        if gi is None:
+            return False
+        url = str(state.get("url") or "")
+        if not url:
+            return False
+        cached = self._user_tools_cache.get(url)
+        if cached is not None:
+            return cached
+        try:
+            config = gi.config.get_config()
+        except Exception as exc:
+            logger.debug("Capability probe failed for %s: %s", url, exc)
+            return False
+        supported = bool(config.get("enable_unprivileged_tools"))
+        self._user_tools_cache[url] = supported
+        return supported

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -26,6 +26,7 @@ from galaxy_mcp.auth import (
     configure_auth_provider,
     get_active_session,
 )
+from galaxy_mcp.middleware import ToolVisibilityMiddleware
 
 _galaxy_mcp_version = importlib.metadata.version("galaxy-mcp")
 USER_AGENT = f"galaxy-mcp/{_galaxy_mcp_version} bioblend/{bioblend.__version__}"
@@ -357,6 +358,23 @@ def ensure_connected() -> dict[str, Any]:
             "api_key='your-key')"
         )
     return state
+
+
+def _parse_tag_env(var_name: str) -> set[str] | None:
+    raw = os.environ.get(var_name)
+    if not raw:
+        return None
+    tags = {tag.strip() for tag in raw.split(",") if tag.strip()}
+    return tags or None
+
+
+mcp.add_middleware(
+    ToolVisibilityMiddleware(
+        get_session_state=_get_request_connection_state,
+        include_tags=_parse_tag_env("GALAXY_MCP_INCLUDE_TAGS"),
+        exclude_tags=_parse_tag_env("GALAXY_MCP_EXCLUDE_TAGS"),
+    )
+)
 
 
 @mcp.tool(tags={"connection", "write", "core"})

--- a/mcp-server-galaxy-py/tests/test_middleware.py
+++ b/mcp-server-galaxy-py/tests/test_middleware.py
@@ -1,0 +1,174 @@
+"""Tests for ToolVisibilityMiddleware."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware.middleware import MiddlewareContext
+
+from galaxy_mcp.middleware import ToolVisibilityMiddleware
+
+
+def _tool(name: str, tags: set[str]) -> SimpleNamespace:
+    return SimpleNamespace(name=name, tags=tags)
+
+
+def _session(*, is_admin: bool = False, user_tools: bool = False) -> dict:
+    gi = Mock()
+    gi.users.get_current_user.return_value = {"id": "u1", "is_admin": is_admin}
+    gi.config.get_config.return_value = {"enable_unprivileged_tools": user_tools}
+    return {"gi": gi, "url": "https://galaxy.test/", "api_key": "k"}
+
+
+def _run_list_tools(middleware: ToolVisibilityMiddleware, tools: list) -> list:
+    async def call_next(_ctx):
+        return tools
+
+    ctx = MiddlewareContext(message=None, method="tools/list")
+    return asyncio.run(middleware.on_list_tools(ctx, call_next))
+
+
+def _run_call_tool(middleware: ToolVisibilityMiddleware, tool, *, name: str | None = None):
+    server = Mock()
+
+    async def get_tool(_name):
+        return tool
+
+    server.get_tool.side_effect = get_tool
+    fastmcp_context = SimpleNamespace(fastmcp=server)
+    ctx = MiddlewareContext(
+        message=SimpleNamespace(name=name or getattr(tool, "name", "t")),
+        method="tools/call",
+        fastmcp_context=fastmcp_context,
+    )
+
+    async def call_next(_ctx):
+        return "ok"
+
+    return asyncio.run(middleware.on_call_tool(ctx, call_next))
+
+
+class TestAdminGating:
+    def test_admin_tools_hidden_for_non_admin(self):
+        mw = ToolVisibilityMiddleware(get_session_state=lambda: _session(is_admin=False))
+        tools = [
+            _tool("get_users", {"admin", "read", "niche"}),
+            _tool("get_histories", {"histories", "read", "core"}),
+        ]
+        visible = _run_list_tools(mw, tools)
+        assert [t.name for t in visible] == ["get_histories"]
+
+    def test_admin_tools_visible_for_admin(self):
+        mw = ToolVisibilityMiddleware(get_session_state=lambda: _session(is_admin=True))
+        tools = [
+            _tool("get_users", {"admin", "read", "niche"}),
+            _tool("get_histories", {"histories", "read", "core"}),
+        ]
+        visible = _run_list_tools(mw, tools)
+        assert {t.name for t in visible} == {"get_users", "get_histories"}
+
+
+class TestUserToolsGating:
+    def test_user_tools_hidden_when_galaxy_lacks_capability(self):
+        mw = ToolVisibilityMiddleware(get_session_state=lambda: _session(user_tools=False))
+        tools = [
+            _tool("create_user_tool", {"user_tools", "write", "niche"}),
+            _tool("get_histories", {"histories", "read", "core"}),
+        ]
+        visible = _run_list_tools(mw, tools)
+        assert [t.name for t in visible] == ["get_histories"]
+
+    def test_user_tools_visible_when_capability_advertised(self):
+        mw = ToolVisibilityMiddleware(get_session_state=lambda: _session(user_tools=True))
+        tools = [_tool("create_user_tool", {"user_tools", "write", "niche"})]
+        visible = _run_list_tools(mw, tools)
+        assert [t.name for t in visible] == ["create_user_tool"]
+
+
+class TestStaticTagFilters:
+    def test_exclude_tags_drops_matching_tools(self):
+        mw = ToolVisibilityMiddleware(
+            get_session_state=lambda: _session(is_admin=True, user_tools=True),
+            exclude_tags={"niche"},
+        )
+        tools = [
+            _tool("a", {"histories", "read", "core"}),
+            _tool("b", {"iwc", "read", "niche"}),
+        ]
+        visible = _run_list_tools(mw, tools)
+        assert [t.name for t in visible] == ["a"]
+
+    def test_include_tags_keeps_only_matching_tools(self):
+        mw = ToolVisibilityMiddleware(
+            get_session_state=lambda: _session(is_admin=True, user_tools=True),
+            include_tags={"core"},
+        )
+        tools = [
+            _tool("a", {"histories", "read", "core"}),
+            _tool("b", {"histories", "read", "extended"}),
+        ]
+        visible = _run_list_tools(mw, tools)
+        assert [t.name for t in visible] == ["a"]
+
+
+class TestOnCallToolGuard:
+    def test_hidden_tool_raises(self):
+        mw = ToolVisibilityMiddleware(get_session_state=lambda: _session(is_admin=False))
+        hidden = _tool("get_users", {"admin", "read", "niche"})
+        with pytest.raises(ToolError, match="not available"):
+            _run_call_tool(mw, hidden, name="get_users")
+
+    def test_visible_tool_passes_through(self):
+        mw = ToolVisibilityMiddleware(get_session_state=lambda: _session(is_admin=False))
+        visible = _tool("get_histories", {"histories", "read", "core"})
+        result = _run_call_tool(mw, visible, name="get_histories")
+        assert result == "ok"
+
+    def test_unknown_tool_is_not_blocked(self):
+        mw = ToolVisibilityMiddleware(get_session_state=lambda: _session(is_admin=False))
+        # When the tool can't be resolved, the middleware should defer to downstream handling.
+        result = _run_call_tool(mw, None, name="missing")
+        assert result == "ok"
+
+    def test_tool_lookup_exception_defers(self):
+        mw = ToolVisibilityMiddleware(get_session_state=lambda: _session(is_admin=False))
+        server = Mock()
+
+        async def boom(_name):
+            raise RuntimeError("lookup failed")
+
+        server.get_tool.side_effect = boom
+        fastmcp_context = SimpleNamespace(fastmcp=server)
+        ctx = MiddlewareContext(
+            message=SimpleNamespace(name="anything"),
+            method="tools/call",
+            fastmcp_context=fastmcp_context,
+        )
+
+        async def call_next(_ctx):
+            return "ok"
+
+        result = asyncio.run(mw.on_call_tool(ctx, call_next))
+        assert result == "ok"
+
+
+class TestCaching:
+    def test_admin_probe_cached_per_session(self):
+        session = _session(is_admin=True)
+        mw = ToolVisibilityMiddleware(get_session_state=lambda: session)
+        tools = [_tool("t", {"admin", "read"})]
+        _run_list_tools(mw, tools)
+        _run_list_tools(mw, tools)
+        assert session["gi"].users.get_current_user.call_count == 1
+
+    def test_user_tools_probe_cached_per_url(self):
+        session = _session(user_tools=True)
+        mw = ToolVisibilityMiddleware(get_session_state=lambda: session)
+        tools = [_tool("t", {"user_tools", "write"})]
+        _run_list_tools(mw, tools)
+        _run_list_tools(mw, tools)
+        assert session["gi"].config.get_config.call_count == 1


### PR DESCRIPTION
Phase 2 of the progressive tool discovery plan. Phase 1 (#42) added tags to every `@mcp.tool()` registration; this PR adds the middleware that actually uses them.

**Depends on #42** -- this branch is stacked on `feature/tool-tags` since the middleware needs the tag assignments to do anything. Review after #42 merges; the diff will collapse to just the middleware bits.

## What it does

`ToolVisibilityMiddleware` hooks FastMCP's `on_list_tools` and `on_call_tool` to filter the tool catalog per session:

- **`admin` tag** is hidden unless `gi.users.get_current_user()` reports `is_admin`.
- **`user_tools` tag** is hidden unless the Galaxy instance advertises `enable_unprivileged_tools` in its config.
- **`GALAXY_MCP_INCLUDE_TAGS`** / **`GALAXY_MCP_EXCLUDE_TAGS`** env vars let deployments narrow or deny tags at startup (comma-separated).

`on_call_tool` applies the same visibility check so a client that already knows a hidden tool's name can't invoke it directly -- the call raises `ToolError`.

Probes are cached by `(url, api_key)` (admin) and `url` (capability) to avoid hammering Galaxy on every `list_tools`.

## Follow-ups (not blockers)

Surfaced by Codex review and explicitly deferred:
- `url`-only caching for `enable_unprivileged_tools` means a mid-process Galaxy config change isn't picked up until restart.
- End-to-end OAuth churn is validated only via synthetic session dicts, not a real `_get_request_connection_state()` run.
- Concurrent first-hit probes racing the empty cache aren't tested.

## Test plan

- [x] `make lint`
- [x] `make test` (12 new tests in `test_middleware.py`; existing suite green)
- [ ] Manual: run with `GALAXY_MCP_EXCLUDE_TAGS=iwc` and confirm IWC tools disappear from `tools/list`