### PR TITLE
Tag the user-defined tool endpoints (follow-up to #42)

### DIFF
--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -2649,7 +2649,7 @@ def cancel_workflow_invocation(invocation_id: str) -> GalaxyResult:
         ) from e
 
 
-@mcp.tool()
+@mcp.tool(tags={"tools", "write", "extended"})
 def create_user_tool(representation: dict[str, Any]) -> GalaxyResult:
     """Create a user-defined tool in Galaxy from a YAML tool definition.
 
@@ -2730,7 +2730,7 @@ def create_user_tool(representation: dict[str, Any]) -> GalaxyResult:
         ) from e
 
 
-@mcp.tool()
+@mcp.tool(tags={"tools", "read", "extended"})
 def list_user_tools(active: bool = True) -> GalaxyResult:
     """List user-defined tools belonging to the current user.
 
@@ -2757,7 +2757,7 @@ def list_user_tools(active: bool = True) -> GalaxyResult:
         raise ValueError(format_error("List user tools", e)) from e
 
 
-@mcp.tool()
+@mcp.tool(tags={"tools", "write", "extended"})
 def delete_user_tool(uuid: str) -> GalaxyResult:
     """Deactivate a user-defined tool. Deactivated tools are not loaded into the toolbox.
 
@@ -2782,7 +2782,7 @@ def delete_user_tool(uuid: str) -> GalaxyResult:
         raise ValueError(format_error("Delete user tool", e, {"uuid": uuid})) from e
 
 
-@mcp.tool()
+@mcp.tool(tags={"tools", "write", "extended"})
 def run_user_tool(history_id: str, tool_uuid: str, inputs: dict[str, Any]) -> GalaxyResult:
     """Run a user-defined tool via the Galaxy jobs API.
 

--- a/mcp-server-galaxy-py/uv.lock
+++ b/mcp-server-galaxy-py/uv.lock
@@ -886,7 +886,7 @@ wheels = [
 
 [[package]]
 name = "galaxy-mcp"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- Adds the missing `domain`/`access`/`tier` tags to the four user-defined tool endpoints from #40 (`create_user_tool`, `list_user_tools`, `delete_user_tool`, `run_user_tool`).
- Syncs `uv.lock` to the 1.4.0 version bump already on main.

#40 (user-defined tools) merged after #42's tagging branch was cut, so those four endpoints never got tagged. `test_every_tool_is_tagged` started failing once they sat on top of each other -- this closes that gap so #45 can go green.

All four get `{"tools", "write", "extended"}` except `list_user_tools`, which is `{"tools", "read", "extended"}`. They're `extended` rather than `core` because user-defined tools are a specialized feature, not the primary tool-execution path.

## Test plan

- [x] `uv run pytest tests/test_tool_tags.py` passes locally
- [ ] CI green on 3.10 / 3.11 / 3.12