### PR TITLE
Surface agent-facing usage guidance via FastMCP instructions

### DIFF
--- a/mcp-server-galaxy-py/README.md
+++ b/mcp-server-galaxy-py/README.md
@@ -119,6 +119,8 @@ The `code-mode` extra installs `pydantic-monty`, the sandboxed Python interprete
 
 Default is `full`, which keeps the existing catalog unchanged. CodeMode is useful when you want to keep the agent's context lean and are willing to trade a few extra turns (search -> schema -> execute) per tool call. It's built on FastMCP's experimental `CodeMode` transform, so the API may shift before it stabilizes.
 
+The server also ships agent-facing usage guidance via the MCP `instructions` field (returned during the initial handshake). It explains the typical workflow, the difference between MCP tools and Galaxy tools (e.g. FastQC isn't an MCP tool -- find it via `search_tools_by_name`), and -- when code mode is active -- how to use `run_galaxy_tool` and `call_tool`. Agents that respect the `instructions` field will read this without you having to prompt them.
+
 ## Available MCP Tools
 
 The Python implementation provides the following MCP tools:

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -232,7 +232,51 @@ if _discovery_mode == "code":
 elif _discovery_mode != "full":
     logger.warning("Unknown GALAXY_MCP_DISCOVERY_MODE=%r; falling back to 'full'.", _discovery_mode)
 
-_mcp_kwargs: dict[str, Any] = {}
+_BASE_INSTRUCTIONS = """\
+Galaxy MCP exposes the Galaxy bioinformatics platform. Most tasks follow the
+same shape: pick or create a history, upload data, run a Galaxy tool on the
+data, then read results back from the history.
+
+Two kinds of "tool" exist here and are easy to confuse:
+- MCP tools (registered by this server) are operations like `upload_file`,
+  `run_tool`, `get_histories`, `invoke_workflow`. They appear in tools/list.
+- Galaxy tools (FastQC, Trimmomatic, Bowtie2, ...) are bioinformatics programs
+  inside a Galaxy instance. They are NOT in the MCP tools/list. Find them with
+  the MCP tools `search_tools_by_name` or `search_tools_by_keywords` (which
+  query the connected Galaxy's tool catalog), then execute via
+  `run_tool(history_id, tool_id, inputs)`.
+
+For curated multi-step analyses, prefer `search_iwc_workflows` to find a
+vetted Interactive Workflow Composer (IWC) workflow, then
+`import_workflow_from_iwc` and `invoke_workflow`.
+
+User-defined tools (created via `create_user_tool`) are run with
+`run_user_tool`, not `run_tool` -- they use a different Galaxy endpoint.
+"""
+
+_CODE_MODE_INSTRUCTIONS = """\
+
+This server is running in `--discovery-mode code`. The MCP tool catalog is
+collapsed into three meta-tools:
+- `search(query, ...)` -- find MCP tools by BM25 over names/descriptions
+- `get_schema(tools=[...])` -- fetch parameter schemas for specific tools
+- `run_galaxy_tool(code=...)` -- execute a Python script that calls MCP tools
+
+Inside `run_galaxy_tool`, the only injected callable is
+`call_tool(name: str, params: dict) -> Any`. Chain multiple calls in one
+script and `return` the final answer to avoid round-trips.
+
+`search` indexes the MCP tools (above), NOT Galaxy's full tool catalog. To
+find a Galaxy tool like FastQC, call
+`await call_tool('search_tools_by_name', {'name': 'fastqc'})` from inside
+`run_galaxy_tool`.
+"""
+
+_instructions = _BASE_INSTRUCTIONS
+if _discovery_mode == "code":
+    _instructions += _CODE_MODE_INSTRUCTIONS
+
+_mcp_kwargs: dict[str, Any] = {"instructions": _instructions}
 if _transforms:
     _mcp_kwargs["transforms"] = _transforms
 if auth_provider:

--- a/mcp-server-galaxy-py/tests/test_discovery_mode.py
+++ b/mcp-server-galaxy-py/tests/test_discovery_mode.py
@@ -54,6 +54,41 @@ def test_unknown_mode_falls_back_to_full():
     assert "run_galaxy_tool" not in names
 
 
+def _instructions(env_mode: str | None) -> str:
+    env = os.environ.copy()
+    env.pop("GALAXY_MCP_DISCOVERY_MODE", None)
+    if env_mode is not None:
+        env["GALAXY_MCP_DISCOVERY_MODE"] = env_mode
+
+    script = textwrap.dedent(
+        """
+        from galaxy_mcp import server
+        print(server.mcp.instructions or '')
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], env=env, capture_output=True, text=True, check=True
+    )
+    return result.stdout
+
+
+def test_full_mode_instructions_cover_galaxy_workflow():
+    text = _instructions(None)
+    assert "Galaxy MCP" in text
+    assert "search_tools_by_name" in text  # the MCP-tool vs Galaxy-tool gotcha
+    assert "search_iwc_workflows" in text
+    # Code-mode-specific guidance must NOT leak into full mode
+    assert "run_galaxy_tool" not in text
+    assert "call_tool" not in text
+
+
+def test_code_mode_instructions_add_meta_tool_guidance():
+    text = _instructions("code")
+    assert "search_tools_by_name" in text  # base content still present
+    assert "run_galaxy_tool" in text
+    assert "call_tool" in text
+
+
 def test_code_mode_without_pydantic_monty_raises_clear_error():
     """If pydantic_monty is missing, server import should fail with a setup hint."""
     env = os.environ.copy()


### PR DESCRIPTION
## Summary
- Set the FastMCP server's `instructions` field so capable MCP clients pick up Galaxy-specific usage guidance during the initial handshake -- without us having to prompt every agent individually.
- Base instructions explain the typical workflow (history -> upload -> tool -> results), call out the MCP-tool vs Galaxy-tool distinction (FastQC isn't in tools/list -- you find it via `search_tools_by_name`), point at IWC for curated workflows, and note that user-defined tools run via `run_user_tool` rather than `run_tool`.
- In code mode we append a paragraph that covers the `search` -> `get_schema` -> `run_galaxy_tool` workflow and explains the `call_tool` bridge inside the sandbox.
- Added two tests asserting the right content surfaces for each mode (and that code-mode-specific guidance does not leak into full mode).

## Test plan
- [x] `uv run pytest` -- 95/95 unit tests pass
- [x] `uv run pre-commit run --all-files` -- clean
- [x] Manually verified `Client(server.mcp).initialize().instructions` returns the expected text in both `full` and `code` modes