### PR TITLE
Implement session-scoped Galaxy credentials for multi-user clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ export GALAXY_API_KEY="your-api-key"
 For OAuth flows the server exchanges user credentials for short-lived Galaxy API keys on demand, so
 you typically leave `GALAXY_API_KEY` unset.
 
+For non-OAuth HTTP clients, `connect(url=..., api_key=...)` stores Galaxy credentials per MCP
+session rather than globally. Clients normally preserve MCP sessions by default, which allows
+multiple users to share the same MCP server while keeping their Galaxy credentials isolated.
+
 ### Alternative Installation
 
 ```bash

--- a/mcp-server-galaxy-py/.gitignore
+++ b/mcp-server-galaxy-py/.gitignore
@@ -51,3 +51,6 @@ Thumbs.db
 # Build artifacts
 *.whl
 *.tar.gz
+# pixi environments
+.pixi/*
+!.pixi/config.toml

--- a/mcp-server-galaxy-py/README.md
+++ b/mcp-server-galaxy-py/README.md
@@ -66,6 +66,10 @@ How you authenticate depends on your transport:
 
   Optionally set `GALAXY_MCP_CLIENT_REGISTRY` to control where OAuth client registrations are stored.
 
+  For non-OAuth HTTP clients, `connect(url=..., api_key=...)` stores Galaxy credentials per MCP
+  session rather than globally. Clients normally preserve MCP sessions by default, which allows
+  multiple users to share the same MCP server while keeping their Galaxy credentials isolated.
+
 You can also steer the transport with `GALAXY_MCP_TRANSPORT` (`stdio`, `streamable-http`, or `sse`).
 All variables can be placed in a `.env` file for convenience.
 

--- a/mcp-server-galaxy-py/pyproject.toml
+++ b/mcp-server-galaxy-py/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "requests>=2.32.3,<3",
     "python-dotenv>=1.0.0,<2",
     "rank-bm25>=0.2.2,<1",
+    "typing-extensions>=4.0.0,<5",
 ]
 
 [project.urls]

--- a/mcp-server-galaxy-py/src/galaxy_mcp/auth.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/auth.py
@@ -376,7 +376,7 @@ class GalaxyOAuthProvider(OAuthProvider):
         """Return OAuth protected resource metadata."""
         return {
             "resource": self._galaxy_url,
-            "authorization_servers": [self.base_url],
+            "authorization_servers": [str(self.base_url)],
             "scopes_supported": self.required_scopes,
             "token_types_supported": ["Bearer"],
         }

--- a/mcp-server-galaxy-py/src/galaxy_mcp/auth.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/auth.py
@@ -47,7 +47,6 @@ from starlette.responses import (
 from starlette.routing import Route
 from typing_extensions import override
 
-
 logger = logging.getLogger(__name__)
 
 AUTH_CODE_TTL_SECONDS = 5 * 60

--- a/mcp-server-galaxy-py/src/galaxy_mcp/auth.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/auth.py
@@ -45,16 +45,7 @@ from starlette.responses import (
     Response,
 )
 from starlette.routing import Route
-
-try:  # pragma: no cover - fallback import for Python < 3.12
-    from typing import override
-except ImportError:  # pragma: no cover - Python < 3.12 without typing.override
-    try:
-        from typing_extensions import override  # type: ignore
-    except ImportError:  # pragma: no cover - hard fallback if typing_extensions missing
-
-        def override(func):  # type: ignore
-            return func
+from typing_extensions import override
 
 
 logger = logging.getLogger(__name__)

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -2992,7 +2992,8 @@ def cancel_workflow_invocation(invocation_id: str) -> GalaxyResult:
         workflow_id = invocation.get("workflow_id")
         if not isinstance(workflow_id, str) or not workflow_id:
             raise ValueError(
-                f"Invocation '{invocation_id}' did not include a workflow_id, so it cannot be cancelled."
+                f"Invocation '{invocation_id}' did not include a workflow_id,"
+                f" so it cannot be cancelled."
             )
         result = gi.workflows.cancel_invocation(workflow_id, invocation_id)
         return GalaxyResult(

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -103,6 +103,23 @@ def _clear_session_connection(session_id: str) -> None:
         _session_connections.pop(session_id, None)
 
 
+def _resolve_history_id(gi: GalaxyInstance, history_id: str | None) -> str:
+    if history_id is not None:
+        return history_id
+
+    histories = gi.histories.get_histories()
+    if not histories:
+        raise ValueError(
+            "No Galaxy histories found. Create a history first or provide history_id explicitly."
+        )
+
+    resolved_history_id = histories[0].get("id")
+    if not isinstance(resolved_history_id, str) or not resolved_history_id:
+        raise ValueError("Failed to resolve a usable history_id from the current Galaxy histories.")
+
+    return resolved_history_id
+
+
 class PaginationInfo(BaseModel):
     """Pagination metadata for list operations."""
 
@@ -2114,8 +2131,8 @@ def upload_file(path: str, history_id: str | None = None) -> GalaxyResult:
                 "Check that the file exists and you have read permissions."
             )
 
-        # BioBlend accepts None for history_id and uses the most recently used history
-        result = gi.tools.upload_file(path, history_id=history_id)  # type: ignore[arg-type]
+        resolved_history_id = _resolve_history_id(gi, history_id)
+        result = gi.tools.upload_file(path, history_id=resolved_history_id)
         return GalaxyResult(
             data=result,
             success=True,
@@ -2159,8 +2176,9 @@ def upload_file_from_url(
         }
         if file_name:
             kwargs["file_name"] = file_name
+        resolved_history_id = _resolve_history_id(gi, history_id)
 
-        result = gi.tools.put_url(url, history_id=history_id, **kwargs)
+        result = gi.tools.put_url(url, history_id=resolved_history_id, **kwargs)
         return GalaxyResult(
             data=result,
             success=True,
@@ -2922,13 +2940,17 @@ def invoke_workflow(
 
     try:
         gi: GalaxyInstance = state["gi"]
+        resolved_inputs_by = cast(
+            Literal["step_index|step_uuid", "step_index", "step_id", "step_uuid", "name"],
+            inputs_by,
+        )
         invocation = gi.workflows.invoke_workflow(
             workflow_id=workflow_id,
             inputs=inputs,
             params=params,
             history_id=history_id,
             history_name=history_name,
-            inputs_by=inputs_by,
+            inputs_by=resolved_inputs_by,
             parameters_normalized=parameters_normalized,
         )
         return GalaxyResult(
@@ -2966,7 +2988,13 @@ def cancel_workflow_invocation(invocation_id: str) -> GalaxyResult:
 
     try:
         gi: GalaxyInstance = state["gi"]
-        result = gi.workflows.cancel_invocation(invocation_id)
+        invocation = gi.invocations.show_invocation(invocation_id)
+        workflow_id = invocation.get("workflow_id")
+        if not isinstance(workflow_id, str) or not workflow_id:
+            raise ValueError(
+                f"Invocation '{invocation_id}' did not include a workflow_id, so it cannot be cancelled."
+            )
+        result = gi.workflows.cancel_invocation(workflow_id, invocation_id)
         return GalaxyResult(
             data={"cancelled": True, "invocation": result},
             success=True,

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -103,23 +103,6 @@ def _clear_session_connection(session_id: str) -> None:
         _session_connections.pop(session_id, None)
 
 
-def _resolve_history_id(gi: GalaxyInstance, history_id: str | None) -> str:
-    if history_id is not None:
-        return history_id
-
-    histories = gi.histories.get_histories()
-    if not histories:
-        raise ValueError(
-            "No Galaxy histories found. Create a history first or provide history_id explicitly."
-        )
-
-    resolved_history_id = histories[0].get("id")
-    if not isinstance(resolved_history_id, str) or not resolved_history_id:
-        raise ValueError("Failed to resolve a usable history_id from the current Galaxy histories.")
-
-    return resolved_history_id
-
-
 class PaginationInfo(BaseModel):
     """Pagination metadata for list operations."""
 
@@ -2131,8 +2114,8 @@ def upload_file(path: str, history_id: str | None = None) -> GalaxyResult:
                 "Check that the file exists and you have read permissions."
             )
 
-        resolved_history_id = _resolve_history_id(gi, history_id)
-        result = gi.tools.upload_file(path, history_id=resolved_history_id)
+        # BioBlend accepts None for history_id and uses the most recently used history
+        result = gi.tools.upload_file(path, history_id=history_id)  # type: ignore[arg-type]
         return GalaxyResult(
             data=result,
             success=True,
@@ -2176,9 +2159,7 @@ def upload_file_from_url(
         }
         if file_name:
             kwargs["file_name"] = file_name
-        resolved_history_id = _resolve_history_id(gi, history_id)
-
-        result = gi.tools.put_url(url, history_id=resolved_history_id, **kwargs)
+        result = gi.tools.put_url(url, history_id=history_id, **kwargs)  # type: ignore[arg-type]
         return GalaxyResult(
             data=result,
             success=True,

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -6,6 +6,7 @@ import logging
 import os
 import threading
 import types
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -15,6 +16,7 @@ import requests
 from bioblend.galaxy import GalaxyInstance
 from dotenv import find_dotenv, load_dotenv
 from fastmcp import FastMCP
+from fastmcp.server.dependencies import get_context
 from mcp.server.auth.middleware.auth_context import get_access_token
 from pydantic import BaseModel, Field
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -38,6 +40,18 @@ _galaxy_mcp_version = importlib.metadata.version("galaxy-mcp")
 USER_AGENT = f"galaxy-mcp/{_galaxy_mcp_version} bioblend/{bioblend.__version__}"
 
 _gi_lock = threading.Lock()
+_session_state_lock = threading.Lock()
+
+
+@dataclass
+class SessionGalaxyConnection:
+    url: str
+    api_key: str
+    gi: GalaxyInstance
+    connected: bool = True
+
+
+_session_connections: dict[str, SessionGalaxyConnection] = {}
 
 
 def _make_thread_safe(gi: GalaxyInstance) -> GalaxyInstance:
@@ -61,6 +75,32 @@ def _make_thread_safe(gi: GalaxyInstance) -> GalaxyInstance:
 
         setattr(gi, method_name, locked_method)
     return gi
+
+
+def _get_current_session_id() -> str | None:
+    try:
+        return get_context().session_id
+    except Exception:
+        return None
+
+
+def _get_session_connection(session_id: str) -> SessionGalaxyConnection | None:
+    with _session_state_lock:
+        return _session_connections.get(session_id)
+
+
+def _set_session_connection(
+    session_id: str, *, url: str, api_key: str, gi: GalaxyInstance, connected: bool = True
+) -> None:
+    with _session_state_lock:
+        _session_connections[session_id] = SessionGalaxyConnection(
+            url=url, api_key=api_key, gi=gi, connected=connected
+        )
+
+
+def _clear_session_connection(session_id: str) -> None:
+    with _session_state_lock:
+        _session_connections.pop(session_id, None)
 
 
 class PaginationInfo(BaseModel):
@@ -461,12 +501,25 @@ def _get_request_connection_state() -> dict[str, Any]:
                     "session": credentials,
                 }
 
+    session_id = _get_current_session_id()
+    if session_id:
+        session_connection = _get_session_connection(session_id)
+        if session_connection and session_connection.connected and session_connection.gi:
+            return {
+                "url": session_connection.url,
+                "api_key": session_connection.api_key,
+                "gi": session_connection.gi,
+                "connected": True,
+                "source": "session",
+                "session": {"id": session_id},
+            }
+
     return {
         "url": galaxy_state.get("url") or normalized_galaxy_url,
         "api_key": galaxy_state.get("api_key"),
         "gi": galaxy_state.get("gi"),
         "connected": galaxy_state.get("connected", False) and bool(galaxy_state.get("gi")),
-        "source": "api_key" if galaxy_state.get("connected") else None,
+        "source": "global" if galaxy_state.get("connected") else None,
         "session": None,
     }
 
@@ -512,10 +565,21 @@ def connect(url: str | None = None, api_key: str | None = None) -> GalaxyResult:
     Returns:
         GalaxyResult with connection status and user information in data field
     """
+    use_url = url
+    use_api_key = api_key
+    galaxy_url: str | None = None
+
     try:
-        # Reuse current OAuth session when available
+        # Reuse the active connection when no replacement credentials were supplied.
         state = _get_request_connection_state()
-        if state["connected"] and state.get("source") == "oauth" and state["gi"]:
+        session_id = _get_current_session_id()
+        if (
+            state["connected"]
+            and state["gi"]
+            and not url
+            and not api_key
+            and state.get("source") in {"oauth", "session", "global"}
+        ):
             gi: GalaxyInstance = state["gi"]
             user_info = gi.users.get_current_user()
             return GalaxyResult(
@@ -523,10 +587,16 @@ def connect(url: str | None = None, api_key: str | None = None) -> GalaxyResult:
                     "connected": True,
                     "user": user_info,
                     "url": state["url"],
-                    "auth": "oauth",
+                    "auth": cast(str, state["source"]),
                 },
                 success=True,
-                message=f"Connected to Galaxy at {state['url']} via OAuth",
+                message=f"Connected to Galaxy at {state['url']} via {state['source']}",
+            )
+
+        if session_id and not url and not api_key and not state["connected"]:
+            raise ValueError(
+                "No Galaxy connection is configured for this MCP session. "
+                "Call connect(url='https://your-galaxy.org', api_key='your-key') first."
             )
 
         # Use provided parameters or fall back to environment variables
@@ -567,25 +637,29 @@ def connect(url: str | None = None, api_key: str | None = None) -> GalaxyResult:
         # Test the connection by fetching user info
         user_info = gi.users.get_current_user()
 
-        # Update galaxy state
-        galaxy_state["url"] = galaxy_url
-        galaxy_state["api_key"] = use_api_key
-        galaxy_state["gi"] = gi
-        galaxy_state["connected"] = True
+        if session_id:
+            _set_session_connection(session_id, url=galaxy_url, api_key=use_api_key, gi=gi)
 
         return GalaxyResult(
-            data={"connected": True, "user": user_info},
+            data={
+                "connected": True,
+                "user": user_info,
+                "url": galaxy_url,
+                "auth": "session" if session_id else "global",
+            },
             success=True,
-            message=f"Connected to Galaxy at {galaxy_url}",
+            message=(
+                f"Connected to Galaxy at {galaxy_url} for the current MCP session"
+                if session_id
+                else f"Validated global Galaxy connection at {galaxy_url}"
+            ),
         )
     except Exception as e:
-        # Reset state on failure
-        galaxy_state["url"] = None
-        galaxy_state["api_key"] = None
-        galaxy_state["gi"] = None
-        galaxy_state["connected"] = False
+        session_id = _get_current_session_id()
+        if session_id:
+            _clear_session_connection(session_id)
 
-        galaxy_url = locals().get("galaxy_url") or use_url or normalized_galaxy_url or "unknown"
+        galaxy_url = galaxy_url or use_url or normalized_galaxy_url or "unknown"
         error_msg = f"Failed to connect to Galaxy at {galaxy_url}: {str(e)}"
         if "401" in str(e) or "authentication" in str(e).lower():
             error_msg += " Check that your API key is valid and has the necessary permissions."
@@ -2074,9 +2148,10 @@ def upload_file_from_url(
     Returns:
         GalaxyResult with upload status and information about the created dataset(s) in data field
     """
-    ensure_connected()
+    state = ensure_connected()
 
     try:
+        gi: GalaxyInstance = state["gi"]
         # Prepare kwargs for put_url
         kwargs = {
             "file_type": file_type,
@@ -2085,7 +2160,7 @@ def upload_file_from_url(
         if file_name:
             kwargs["file_name"] = file_name
 
-        result = galaxy_state["gi"].tools.put_url(url, history_id=history_id, **kwargs)
+        result = gi.tools.put_url(url, history_id=history_id, **kwargs)
         return GalaxyResult(
             data=result,
             success=True,
@@ -2760,10 +2835,11 @@ def list_workflows(
     Returns:
         GalaxyResult with list of workflows in data field
     """
-    ensure_connected()
+    state = ensure_connected()
 
     try:
-        workflows = galaxy_state["gi"].workflows.get_workflows(
+        gi: GalaxyInstance = state["gi"]
+        workflows = gi.workflows.get_workflows(
             workflow_id=workflow_id, name=name, published=published
         )
         return GalaxyResult(
@@ -2794,12 +2870,11 @@ def get_workflow_details(workflow_id: str, version: int | None = None) -> Galaxy
     Returns:
         GalaxyResult with workflow information including steps, inputs, and parameters in data field
     """
-    ensure_connected()
+    state = ensure_connected()
 
     try:
-        workflow = galaxy_state["gi"].workflows.show_workflow(
-            workflow_id=workflow_id, version=version
-        )
+        gi: GalaxyInstance = state["gi"]
+        workflow = gi.workflows.show_workflow(workflow_id=workflow_id, version=version)
         return GalaxyResult(
             data=workflow,
             success=True,
@@ -2843,10 +2918,11 @@ def invoke_workflow(
     Returns:
         GalaxyResult with workflow invocation information including invocation ID in data field
     """
-    ensure_connected()
+    state = ensure_connected()
 
     try:
-        invocation = galaxy_state["gi"].workflows.invoke_workflow(
+        gi: GalaxyInstance = state["gi"]
+        invocation = gi.workflows.invoke_workflow(
             workflow_id=workflow_id,
             inputs=inputs,
             params=params,
@@ -2886,10 +2962,11 @@ def cancel_workflow_invocation(invocation_id: str) -> GalaxyResult:
     Returns:
         GalaxyResult with cancellation status and updated invocation information in data field
     """
-    ensure_connected()
+    state = ensure_connected()
 
     try:
-        result = galaxy_state["gi"].workflows.cancel_invocation(invocation_id)
+        gi: GalaxyInstance = state["gi"]
+        result = gi.workflows.cancel_invocation(invocation_id)
         return GalaxyResult(
             data={"cancelled": True, "invocation": result},
             success=True,

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -2969,14 +2969,7 @@ def cancel_workflow_invocation(invocation_id: str) -> GalaxyResult:
 
     try:
         gi: GalaxyInstance = state["gi"]
-        invocation = gi.invocations.show_invocation(invocation_id)
-        workflow_id = invocation.get("workflow_id")
-        if not isinstance(workflow_id, str) or not workflow_id:
-            raise ValueError(
-                f"Invocation '{invocation_id}' did not include a workflow_id,"
-                f" so it cannot be cancelled."
-            )
-        result = gi.workflows.cancel_invocation(workflow_id, invocation_id)
+        result = gi.invocations.cancel_invocation(invocation_id)
         return GalaxyResult(
             data={"cancelled": True, "invocation": result},
             success=True,

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -5,6 +5,7 @@ import importlib.metadata
 import logging
 import os
 import threading
+import time
 import types
 from dataclasses import dataclass
 from functools import lru_cache
@@ -41,6 +42,7 @@ USER_AGENT = f"galaxy-mcp/{_galaxy_mcp_version} bioblend/{bioblend.__version__}"
 
 _gi_lock = threading.Lock()
 _session_state_lock = threading.Lock()
+_MAX_SESSION_CONNECTIONS = int(os.environ.get("GALAXY_MCP_MAX_SESSION_CONNECTIONS", 128))
 
 
 @dataclass
@@ -48,10 +50,20 @@ class SessionGalaxyConnection:
     url: str
     api_key: str
     gi: GalaxyInstance
+    last_accessed_at: float
     connected: bool = True
 
 
 _session_connections: dict[str, SessionGalaxyConnection] = {}
+
+
+def _prune_session_connections() -> None:
+    while len(_session_connections) > _MAX_SESSION_CONNECTIONS:
+        least_recently_used_session_id = min(
+            _session_connections,
+            key=lambda session_id: _session_connections[session_id].last_accessed_at,
+        )
+        _session_connections.pop(least_recently_used_session_id, None)
 
 
 def _make_thread_safe(gi: GalaxyInstance) -> GalaxyInstance:
@@ -86,16 +98,26 @@ def _get_current_session_id() -> str | None:
 
 def _get_session_connection(session_id: str) -> SessionGalaxyConnection | None:
     with _session_state_lock:
-        return _session_connections.get(session_id)
+        session_connection = _session_connections.get(session_id)
+        if not session_connection:
+            return None
+        session_connection.last_accessed_at = time.monotonic()
+        return session_connection
 
 
 def _set_session_connection(
     session_id: str, *, url: str, api_key: str, gi: GalaxyInstance, connected: bool = True
 ) -> None:
     with _session_state_lock:
+        now = time.monotonic()
         _session_connections[session_id] = SessionGalaxyConnection(
-            url=url, api_key=api_key, gi=gi, connected=connected
+            url=url,
+            api_key=api_key,
+            gi=gi,
+            connected=connected,
+            last_accessed_at=now,
         )
+        _prune_session_connections()
 
 
 def _clear_session_connection(session_id: str) -> None:
@@ -595,8 +617,10 @@ def connect(url: str | None = None, api_key: str | None = None) -> GalaxyResult:
 
         if session_id and not url and not api_key and not state["connected"]:
             raise ValueError(
-                "No Galaxy connection is configured for this MCP session. "
-                "Call connect(url='https://your-galaxy.org', api_key='your-key') first."
+                "No Galaxy connection is available for this MCP session. "
+                "It may not have been configured yet, or it may have been evicted from the "
+                "session connection cache. Call connect(url='https://your-galaxy.org', "
+                "api_key='your-key') again."
             )
 
         # Use provided parameters or fall back to environment variables

--- a/mcp-server-galaxy-py/tests/conftest.py
+++ b/mcp-server-galaxy-py/tests/conftest.py
@@ -45,7 +45,11 @@ def mock_galaxy_instance():
     # Mock invocations
     mock_invocations = Mock()
     mock_invocations.get_invocations.return_value = []
-    mock_invocations.show_invocation.return_value = {"id": "inv1", "state": "ok"}
+    mock_invocations.show_invocation.return_value = {
+        "id": "inv1",
+        "state": "ok",
+        "workflow_id": "workflow1",
+    }
     mock_gi.invocations = mock_invocations
 
     # Mock datasets

--- a/mcp-server-galaxy-py/tests/conftest.py
+++ b/mcp-server-galaxy-py/tests/conftest.py
@@ -97,7 +97,12 @@ def mock_galaxy_instance():
 @pytest.fixture(autouse=True)
 def _reset_galaxy_state():
     """Reset galaxy state for each test"""
-    from galaxy_mcp.server import _TOOL_SCHEMA_CACHE, galaxy_state, get_manifest_json
+    from galaxy_mcp.server import (
+        _TOOL_SCHEMA_CACHE,
+        _session_connections,
+        galaxy_state,
+        get_manifest_json,
+    )
 
     # Clear lru_cache to prevent test pollution
     get_manifest_json.cache_clear()
@@ -107,16 +112,20 @@ def _reset_galaxy_state():
 
     # Save original state
     original_state = galaxy_state.copy()
+    original_session_connections = _session_connections.copy()
 
     # Clear state
     galaxy_state.clear()
     galaxy_state.update({"url": None, "api_key": None, "gi": None, "connected": False})
+    _session_connections.clear()
 
     yield
 
     # Restore original state
     galaxy_state.clear()
     galaxy_state.update(original_state)
+    _session_connections.clear()
+    _session_connections.update(original_session_connections)
 
 
 @pytest.fixture

--- a/mcp-server-galaxy-py/tests/test_connection.py
+++ b/mcp-server-galaxy-py/tests/test_connection.py
@@ -98,6 +98,120 @@ class TestConnection:
             user_agent=server.USER_AGENT,
         )
 
+    def test_connect_stores_credentials_per_session(self, mock_galaxy_instance):
+        """Non-OAuth connect() should bind credentials to the current MCP session."""
+        mock_context = type("Ctx", (), {"session_id": "session-123"})()
+
+        with patch("galaxy_mcp.server.get_context", return_value=mock_context):
+            with patch("galaxy_mcp.server.GalaxyInstance", return_value=mock_galaxy_instance):
+                result = connect_fn(url="https://session.galaxy", api_key="session-key")
+
+        assert result.success is True
+        assert result.data["auth"] == "session"
+        session_state = server._session_connections["session-123"]
+        assert session_state.url == "https://session.galaxy/"
+        assert session_state.api_key == "session-key"
+        assert session_state.gi is mock_galaxy_instance
+        assert galaxy_state["connected"] is False
+
+    def test_connect_reuses_existing_session_connection(self, mock_galaxy_instance):
+        """connect() should reuse a session-bound connection when no new creds are given."""
+        server._session_connections["session-123"] = server.SessionGalaxyConnection(
+            url="https://session.galaxy/",
+            api_key="session-key",
+            gi=mock_galaxy_instance,
+        )
+        mock_context = type("Ctx", (), {"session_id": "session-123"})()
+
+        with patch("galaxy_mcp.server.get_context", return_value=mock_context):
+            result = connect_fn()
+
+        assert result.success is True
+        assert result.data["auth"] == "session"
+        assert result.data["url"] == "https://session.galaxy/"
+        assert (
+            result.data["user"]["username"]
+            == mock_galaxy_instance.users.get_current_user.return_value["username"]
+        )
+
+    def test_connect_requires_explicit_credentials_for_new_session(self):
+        """A fresh session should not bootstrap itself from global env credentials."""
+        mock_context = type("Ctx", (), {"session_id": "session-456"})()
+
+        with patch("galaxy_mcp.server.get_context", return_value=mock_context):
+            with pytest.raises(
+                ValueError, match="No Galaxy connection is configured for this MCP session"
+            ):
+                connect_fn()
+
+    def test_connect_allows_global_fallback_for_new_session(self, mock_galaxy_instance):
+        """A fresh session may reuse a configured global fallback without seeding session state."""
+        mock_context = type("Ctx", (), {"session_id": "session-789"})()
+
+        with patch.dict(
+            galaxy_state,
+            {
+                "url": "https://global.galaxy/",
+                "api_key": "global-key",
+                "gi": mock_galaxy_instance,
+                "connected": True,
+            },
+        ):
+            with patch("galaxy_mcp.server.get_context", return_value=mock_context):
+                result = connect_fn()
+
+        assert result.success is True
+        assert result.data["auth"] == "global"
+        assert "session-789" not in server._session_connections
+
+    def test_connect_without_session_does_not_mutate_global_fallback(self, mock_galaxy_instance):
+        """Sessionless connect() should not rewrite the configured global fallback state."""
+        with patch.dict(
+            galaxy_state,
+            {
+                "url": "https://global.galaxy/",
+                "api_key": "global-key",
+                "gi": mock_galaxy_instance,
+                "connected": True,
+            },
+        ):
+            with patch("galaxy_mcp.server.get_context", side_effect=RuntimeError("no session")):
+                with patch("galaxy_mcp.server.GalaxyInstance", return_value=mock_galaxy_instance):
+                    result = connect_fn(url="https://other.galaxy", api_key="other-key")
+
+            assert result.success is True
+            assert result.data["auth"] == "global"
+            assert galaxy_state["url"] == "https://global.galaxy/"
+            assert galaxy_state["api_key"] == "global-key"
+            assert galaxy_state["gi"] is mock_galaxy_instance
+            assert galaxy_state["connected"] is True
+
+    def test_request_state_prefers_session_credentials(self, mock_galaxy_instance):
+        """Session-bound credentials should override process-global API-key state."""
+        server._session_connections["session-123"] = server.SessionGalaxyConnection(
+            url="https://session.galaxy/",
+            api_key="session-key",
+            gi=mock_galaxy_instance,
+        )
+
+        with patch.dict(
+            galaxy_state,
+            {
+                "url": "https://global.galaxy/",
+                "api_key": "global-key",
+                "gi": object(),
+                "connected": True,
+            },
+        ):
+            mock_context = type("Ctx", (), {"session_id": "session-123"})()
+            with patch("galaxy_mcp.server.get_context", return_value=mock_context):
+                state = server._get_request_connection_state()
+
+        assert state["source"] == "session"
+        assert state["url"] == "https://session.galaxy/"
+        assert state["api_key"] == "session-key"
+        assert state["gi"] is mock_galaxy_instance
+
     def test_get_server_info_success(self, mock_galaxy_instance):
         """Test successful server info retrieval"""
         # Mock server config and version responses

--- a/mcp-server-galaxy-py/tests/test_connection.py
+++ b/mcp-server-galaxy-py/tests/test_connection.py
@@ -120,6 +120,7 @@ class TestConnection:
             url="https://session.galaxy/",
             api_key="session-key",
             gi=mock_galaxy_instance,
+            last_accessed_at=1.0,
         )
         mock_context = type("Ctx", (), {"session_id": "session-123"})()
 
@@ -134,13 +135,42 @@ class TestConnection:
             == mock_galaxy_instance.users.get_current_user.return_value["username"]
         )
 
+    def test_session_connection_cache_evicts_lru_entry(self, mock_galaxy_instance):
+        """Session-bound connections should be capped by least-recently-used eviction."""
+        with patch("galaxy_mcp.server._MAX_SESSION_CONNECTIONS", 2):
+            with patch(
+                "galaxy_mcp.server.time.monotonic",
+                side_effect=[1.0, 2.0, 3.0, 4.0],
+            ):
+                server._set_session_connection(
+                    "session-1",
+                    url="https://session-1.galaxy/",
+                    api_key="session-key-1",
+                    gi=mock_galaxy_instance,
+                )
+                server._set_session_connection(
+                    "session-2",
+                    url="https://session-2.galaxy/",
+                    api_key="session-key-2",
+                    gi=mock_galaxy_instance,
+                )
+                assert server._get_session_connection("session-1") is not None
+                server._set_session_connection(
+                    "session-3",
+                    url="https://session-3.galaxy/",
+                    api_key="session-key-3",
+                    gi=mock_galaxy_instance,
+                )
+
+        assert set(server._session_connections) == {"session-1", "session-3"}
+
     def test_connect_requires_explicit_credentials_for_new_session(self):
         """A fresh session should not bootstrap itself from global env credentials."""
         mock_context = type("Ctx", (), {"session_id": "session-456"})()
 
         with patch("galaxy_mcp.server.get_context", return_value=mock_context):
             with pytest.raises(
-                ValueError, match="No Galaxy connection is configured for this MCP session"
+                ValueError, match="No Galaxy connection is available for this MCP session"
             ):
                 connect_fn()
 
@@ -192,6 +222,7 @@ class TestConnection:
             url="https://session.galaxy/",
             api_key="session-key",
             gi=mock_galaxy_instance,
+            last_accessed_at=1.0,
         )
 
         with patch.dict(

--- a/mcp-server-galaxy-py/tests/test_dataset_operations.py
+++ b/mcp-server-galaxy-py/tests/test_dataset_operations.py
@@ -242,7 +242,7 @@ class TestDatasetOperations:
             assert result.data["outputs"][0]["name"] == "custom_name.txt"
             mock_galaxy_instance.tools.put_url.assert_called_once_with(
                 url,
-                history_id="test_history_1",
+                history_id=None,
                 file_type="tabular",
                 dbkey="?",
                 file_name="custom_name.txt",

--- a/mcp-server-galaxy-py/tests/test_dataset_operations.py
+++ b/mcp-server-galaxy-py/tests/test_dataset_operations.py
@@ -241,7 +241,11 @@ class TestDatasetOperations:
             assert result.success is True
             assert result.data["outputs"][0]["name"] == "custom_name.txt"
             mock_galaxy_instance.tools.put_url.assert_called_once_with(
-                url, history_id=None, file_type="tabular", dbkey="?", file_name="custom_name.txt"
+                url,
+                history_id="test_history_1",
+                file_type="tabular",
+                dbkey="?",
+                file_name="custom_name.txt",
             )
 
     def test_upload_file_from_url_error(self, mock_galaxy_instance):

--- a/mcp-server-galaxy-py/tests/test_workflow_operations.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_operations.py
@@ -318,13 +318,8 @@ class TestWorkflowOperations:
             "state": "cancelled",
             "workflow_id": "workflow1",
         }
-        mock_galaxy_instance.invocations.show_invocation.return_value = {
-            "id": "invocation123",
-            "state": "running",
-            "workflow_id": "workflow1",
-        }
 
-        mock_galaxy_instance.workflows.cancel_invocation.return_value = mock_cancelled_invocation
+        mock_galaxy_instance.invocations.cancel_invocation.return_value = mock_cancelled_invocation
 
         with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
             result = cancel_workflow_invocation_fn("invocation123")
@@ -334,9 +329,7 @@ class TestWorkflowOperations:
             assert result.data["invocation"]["state"] == "cancelled"
 
             # Verify function was called correctly
-            mock_galaxy_instance.workflows.cancel_invocation.assert_called_with(
-                "workflow1", "invocation123"
-            )
+            mock_galaxy_instance.invocations.cancel_invocation.assert_called_with("invocation123")
 
     def test_workflow_operations_error_handling(self, mock_galaxy_instance):
         """Test error handling in workflow operations"""
@@ -362,7 +355,7 @@ class TestWorkflowOperations:
                 invoke_workflow_fn("workflow1")
 
         # Test cancel_workflow_invocation error
-        mock_galaxy_instance.workflows.cancel_invocation.side_effect = Exception(
+        mock_galaxy_instance.invocations.cancel_invocation.side_effect = Exception(
             "Invocation not found"
         )
 

--- a/mcp-server-galaxy-py/tests/test_workflow_operations.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_operations.py
@@ -318,6 +318,11 @@ class TestWorkflowOperations:
             "state": "cancelled",
             "workflow_id": "workflow1",
         }
+        mock_galaxy_instance.invocations.show_invocation.return_value = {
+            "id": "invocation123",
+            "state": "running",
+            "workflow_id": "workflow1",
+        }
 
         mock_galaxy_instance.workflows.cancel_invocation.return_value = mock_cancelled_invocation
 
@@ -329,7 +334,9 @@ class TestWorkflowOperations:
             assert result.data["invocation"]["state"] == "cancelled"
 
             # Verify function was called correctly
-            mock_galaxy_instance.workflows.cancel_invocation.assert_called_with("invocation123")
+            mock_galaxy_instance.workflows.cancel_invocation.assert_called_with(
+                "workflow1", "invocation123"
+            )
 
     def test_workflow_operations_error_handling(self, mock_galaxy_instance):
         """Test error handling in workflow operations"""

--- a/mcp-server-galaxy-py/uv.lock
+++ b/mcp-server-galaxy-py/uv.lock
@@ -903,6 +903,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "rank-bm25" },
     { name = "requests" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -950,6 +951,7 @@ requires-dist = [
     { name = "tox", marker = "extra == 'dev'", specifier = ">=4.11.0" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.31.0" },
+    { name = "typing-extensions", specifier = ">=4.0.0,<5" },
 ]
 provides-extras = ["code-mode", "dev"]
 


### PR DESCRIPTION
## Description

This PR improves HTTP session handling for galaxy-mcp by storing Galaxy credentials per MCP session instead of globally. It allows multiple users to share the same MCP server while connecting with their own Galaxy API keys and Galaxy URLs.

## Type of Change
<!-- Check the relevant boxes -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ⬆️ Dependency update
- [ ] 🧰 Maintenance/chore

## Checklist
- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Related Issues
<!-- Link to related issues if any -->
Closes #
