### PR TITLE
Make tool-input failures self-correcting

### DIFF
--- a/mcp-server-galaxy-py/README.md
+++ b/mcp-server-galaxy-py/README.md
@@ -129,6 +129,7 @@ The Python implementation provides the following MCP tools:
 - `run_tool`: Execute a Galaxy tool with parameters
 - `get_tool_panel`: Retrieve the Galaxy tool panel structure
 - `get_tool_run_examples`: Retrieve XML-defined test lessons that show how to run a tool
+- `get_tool_input_template`: Returns a ready-to-fill `inputs` skeleton (with placeholders) plus the parameter schema for a tool, to build correct `run_tool` inputs
 - `get_user`: Get current user information
 - `get_histories`: List available Galaxy histories
 - `list_history_ids`: Get simplified list of history IDs and names

--- a/mcp-server-galaxy-py/pyproject.toml
+++ b/mcp-server-galaxy-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "galaxy-mcp"
-version = "1.4.0"
+version = "1.5.0"
 description = "Model Context Protocol server for Galaxy bioinformatics platform"
 readme = "README.md"
 license = "MIT"

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -29,6 +29,7 @@ from galaxy_mcp.auth import (
 from galaxy_mcp.middleware import ToolVisibilityMiddleware
 from galaxy_mcp.tool_inputs import (
     format_input_mismatch_error,
+    is_input_related_error,
     summarize_tool_inputs,
 )
 
@@ -838,6 +839,12 @@ def run_tool(history_id: str, tool_id: str, inputs: dict[str, Any]) -> GalaxyRes
                     history_id=history_id,
                     tool_id=tool_id,
                     used_credentials=used_credentials if "used_credentials" in locals() else False,
+                )
+            ) from e
+        if is_input_related_error(e):
+            raise ValueError(
+                _format_tool_input_error(
+                    e, gi=gi, tool_id=tool_id, history_id=history_id, inputs=inputs
                 )
             ) from e
         raise ValueError(

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -718,7 +718,7 @@ def get_tool_run_examples(tool_id: str, tool_version: str | None = None) -> Gala
         raise ValueError(format_error("Get tool run examples", e, context)) from e
 
 
-@mcp.tool(tags={"tools", "read", "core"})
+@mcp.tool(tags={"tools", "read", "extended"})
 def get_tool_input_template(tool_id: str) -> GalaxyResult:
     """Return a ready-to-fill ``inputs`` skeleton for a tool, plus a compact schema.
 

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -28,6 +28,7 @@ from galaxy_mcp.auth import (
 )
 from galaxy_mcp.middleware import ToolVisibilityMiddleware
 from galaxy_mcp.tool_inputs import (
+    build_input_template,
     format_input_mismatch_error,
     is_input_related_error,
     summarize_tool_inputs,
@@ -715,6 +716,36 @@ def get_tool_run_examples(tool_id: str, tool_version: str | None = None) -> Gala
         if tool_version:
             context["tool_version"] = tool_version
         raise ValueError(format_error("Get tool run examples", e, context)) from e
+
+
+@mcp.tool(tags={"tools", "read", "core"})
+def get_tool_input_template(tool_id: str) -> GalaxyResult:
+    """Return a ready-to-fill ``inputs`` skeleton for a tool, plus a compact schema.
+
+    Call this before run_tool when you are unsure how to shape ``inputs``. Replace
+    placeholders (e.g. ``<dataset_id>``) with real values. Repeats show one
+    instance (``name_0|...``); duplicate with ``name_1|...`` to add more. The
+    flattened-key convention is ``section|param``, ``cond|selector``,
+    ``repeat_0|param``.
+    """
+    state = ensure_connected()
+    gi: GalaxyInstance = state["gi"]
+    try:
+        info = _get_tool_schema(gi, tool_id)
+        return GalaxyResult(
+            data={
+                "tool_id": tool_id,
+                "inputs_template": build_input_template(info),
+                "parameters": summarize_tool_inputs(info),
+            },
+            success=True,
+            message=(
+                f"Built an input template for tool '{tool_id}'. Replace placeholders "
+                f"(e.g. <dataset_id>) and pass the result as `inputs` to run_tool."
+            ),
+        )
+    except Exception as e:
+        raise ValueError(format_error("Get tool input template", e, {"tool_id": tool_id})) from e
 
 
 @mcp.tool(tags={"tools", "read", "extended"})

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -27,6 +27,10 @@ from galaxy_mcp.auth import (
     get_active_session,
 )
 from galaxy_mcp.middleware import ToolVisibilityMiddleware
+from galaxy_mcp.tool_inputs import (
+    format_input_mismatch_error,
+    summarize_tool_inputs,
+)
 
 _galaxy_mcp_version = importlib.metadata.version("galaxy-mcp")
 USER_AGENT = f"galaxy-mcp/{_galaxy_mcp_version} bioblend/{bioblend.__version__}"
@@ -155,6 +159,53 @@ def format_error(action: str, error: Exception, context: dict | None = None) -> 
         msg += f". Context: {context_str}"
 
     return msg
+
+
+# Cache tool io_details schemas. Keyed by (server base URL, tool_id, version)
+# because the same tool id on two servers can have different schemas.
+_TOOL_SCHEMA_CACHE: dict[tuple[str | None, str, str | None], dict[str, Any]] = {}
+
+
+def _get_tool_schema(
+    gi: GalaxyInstance, tool_id: str, tool_version: str | None = None
+) -> dict[str, Any]:
+    """Fetch (and cache) a tool's io_details schema using the given request-scoped client."""
+    key = (getattr(gi, "base_url", None), tool_id, tool_version)
+    if key not in _TOOL_SCHEMA_CACHE:
+        _TOOL_SCHEMA_CACHE[key] = gi.tools.show_tool(tool_id, io_details=True)
+    return _TOOL_SCHEMA_CACHE[key]
+
+
+def _format_tool_input_error(
+    error: Exception,
+    *,
+    gi: GalaxyInstance,
+    tool_id: str,
+    history_id: str,
+    inputs: dict[str, Any],
+    action: str = "Run tool",
+) -> str:
+    """Build a truthful enriched error for an input-related tool failure.
+
+    Fetches the schema and one structural example using the SAME request-scoped
+    ``gi`` (never the module global). Both fetches are best-effort: if either
+    fails we still return the disclaimer + original error. This function must
+    never raise.
+    """
+    schema_summary = None
+    example = None
+    with contextlib.suppress(Exception):
+        schema_summary = summarize_tool_inputs(_get_tool_schema(gi, tool_id))
+    with contextlib.suppress(Exception):
+        tests = gi.tools.get_tool_tests(tool_id)
+        if tests:
+            example = tests[0].get("inputs")
+    original = format_error(
+        action, error, {"history_id": history_id, "tool_id": tool_id, "inputs": inputs}
+    )
+    return format_input_mismatch_error(
+        original_error=original, tool_id=tool_id, schema_summary=schema_summary, example=example
+    )
 
 
 # Try to load environment variables from .env file

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -161,16 +161,14 @@ def format_error(action: str, error: Exception, context: dict | None = None) -> 
     return msg
 
 
-# Cache tool io_details schemas. Keyed by (server base URL, tool_id, version)
-# because the same tool id on two servers can have different schemas.
-_TOOL_SCHEMA_CACHE: dict[tuple[str | None, str, str | None], dict[str, Any]] = {}
+# Cache tool io_details schemas. Keyed by (server base URL, tool_id);
+# version is not part of the key because bioblend's show_tool fetches the default version only.
+_TOOL_SCHEMA_CACHE: dict[tuple[str | None, str], dict[str, Any]] = {}
 
 
-def _get_tool_schema(
-    gi: GalaxyInstance, tool_id: str, tool_version: str | None = None
-) -> dict[str, Any]:
+def _get_tool_schema(gi: GalaxyInstance, tool_id: str) -> dict[str, Any]:
     """Fetch (and cache) a tool's io_details schema using the given request-scoped client."""
-    key = (getattr(gi, "base_url", None), tool_id, tool_version)
+    key = (getattr(gi, "base_url", None), tool_id)
     if key not in _TOOL_SCHEMA_CACHE:
         _TOOL_SCHEMA_CACHE[key] = gi.tools.show_tool(tool_id, io_details=True)
     return _TOOL_SCHEMA_CACHE[key]
@@ -197,7 +195,9 @@ def _format_tool_input_error(
     with contextlib.suppress(Exception):
         schema_summary = summarize_tool_inputs(_get_tool_schema(gi, tool_id))
     with contextlib.suppress(Exception):
-        tests = gi.tools.get_tool_tests(tool_id)
+        tests = gi.tools.get_tool_tests(
+            tool_id
+        )  # any version's example is fine -- structural hint only
         if tests:
             example = tests[0].get("inputs")
     original = format_error(

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -695,10 +695,11 @@ def get_tool_run_examples(tool_id: str, tool_version: str | None = None) -> Gala
     Returns:
         GalaxyResult with test cases in data field
     """
-    ensure_connected()
+    state = ensure_connected()
+    gi: GalaxyInstance = state["gi"]
 
     try:
-        test_cases = galaxy_state["gi"].tools.get_tool_tests(tool_id, tool_version=tool_version)
+        test_cases = gi.tools.get_tool_tests(tool_id, tool_version=tool_version)
         return GalaxyResult(
             data={
                 "tool_id": tool_id,

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -2917,6 +2917,7 @@ def run_user_tool(history_id: str, tool_uuid: str, inputs: dict[str, Any]) -> Ga
     state = ensure_connected()
     gi: GalaxyInstance = state["gi"]
 
+    tool_id: str | None = None
     try:
         url = f"{gi.url}/unprivileged_tools/{tool_uuid}"
         response = gi.make_get_request(url)
@@ -2943,6 +2944,17 @@ def run_user_tool(history_id: str, tool_uuid: str, inputs: dict[str, Any]) -> Ga
             message=f"Started user tool '{tool_id}' (UUID: {tool_uuid}) in history '{history_id}'",
         )
     except Exception as e:
+        if tool_id and is_input_related_error(e):
+            raise ValueError(
+                _format_tool_input_error(
+                    e,
+                    gi=gi,
+                    tool_id=tool_id,
+                    history_id=history_id,
+                    inputs=inputs,
+                    action="Run user tool",
+                )
+            ) from e
         raise ValueError(
             format_error("Run user tool", e, {"history_id": history_id, "tool_uuid": tool_uuid})
         ) from e

--- a/mcp-server-galaxy-py/src/galaxy_mcp/tool_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/tool_inputs.py
@@ -63,6 +63,67 @@ def _option_values(p: dict[str, Any]) -> list[Any]:
     return values
 
 
+def _placeholder(p: dict[str, Any]) -> Any:
+    ptype = p.get("type")
+    if ptype == "data":
+        return {"src": "hda", "id": "<dataset_id>"}
+    if ptype == "data_collection":
+        return {"src": "hdca", "id": "<collection_id>"}
+    if ptype == "select":
+        choices = _option_values(p)
+        return choices[0] if choices else "<choice>"
+    if ptype == "boolean":
+        return False
+    if ptype == "integer":
+        return 0
+    if ptype == "float":
+        return 0.0
+    return "<value>"
+
+
+def _fill_param(p: dict[str, Any], prefix: str, out: dict[str, Any]) -> None:
+    name = p.get("name")
+    if name is None:
+        return
+    key = f"{prefix}{name}"
+    ptype = p.get("type")
+    if ptype == "repeat":
+        for child in p.get("inputs", []):
+            _fill_param(child, prefix=f"{key}_0|", out=out)
+    elif ptype == "section":
+        for child in p.get("inputs", []):
+            _fill_param(child, prefix=f"{key}|", out=out)
+    elif ptype == "conditional":
+        tp = p.get("test_param") or {}
+        tp_name = tp.get("name")
+        cases = p.get("cases", [])
+        first = cases[0] if cases else None
+        sel_value = first.get("value") if first else _placeholder(tp)
+        if tp_name:
+            out[f"{key}|{tp_name}"] = sel_value
+        if first:
+            for child in first.get("inputs", []):
+                _fill_param(child, prefix=f"{key}|", out=out)
+    else:
+        out[key] = _placeholder(p)
+
+
+def build_input_template(tool_info: dict[str, Any]) -> dict[str, Any]:
+    """Build a ready-to-fill flattened ``inputs`` skeleton from a tool schema.
+
+    Data params -> ``{"src": "hda", "id": "<dataset_id>"}``; selects -> a valid
+    choice; conditionals -> the first case's selector + that branch's params;
+    repeats -> one ``name_0|...`` instance (duplicate with ``name_1|...`` to add
+    more); sections -> ``name|...``.
+    """
+    out: dict[str, Any] = {}
+    if not isinstance(tool_info, dict):
+        return out
+    for p in tool_info.get("inputs", []):
+        _fill_param(p, prefix="", out=out)
+    return out
+
+
 def summarize_tool_inputs(tool_info: dict[str, Any]) -> list[dict[str, Any]]:
     """Compact a tool's io_details schema into a model-friendly parameter list.
 

--- a/mcp-server-galaxy-py/src/galaxy_mcp/tool_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/tool_inputs.py
@@ -17,6 +17,6 @@ def is_input_related_error(exc: Exception) -> bool:
     malformed inputs dict) counts too. Auth (401/403), 404, and 5xx do not.
     """
     status = getattr(exc, "status_code", None)
-    if status is not None:
+    if isinstance(status, int):
         return status == 400
     return isinstance(exc, TypeError)

--- a/mcp-server-galaxy-py/src/galaxy_mcp/tool_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/tool_inputs.py
@@ -44,6 +44,8 @@ def _summarize_param(p: dict[str, Any]) -> dict[str, Any]:
             "choices": _option_values(tp),
             "key_hint": f"{p.get('name')}|{tp.get('name')}",
         }
+        if _options_truncated(tp):
+            out["selector"]["choices_truncated"] = True
         out["cases"] = [
             {
                 "when": case.get("value"),
@@ -53,15 +55,26 @@ def _summarize_param(p: dict[str, Any]) -> dict[str, Any]:
         ]
     elif ptype == "select":
         out["choices"] = _option_values(p)
+        if _options_truncated(p):
+            out["choices_truncated"] = True
     return out
 
 
+_MAX_OPTIONS = 25
+
+
 def _option_values(p: dict[str, Any]) -> list[Any]:
-    # Galaxy options are [label, value, selected] triples.
-    values = []
-    for o in (p.get("options") or [])[:25]:
-        values.append(o[1] if isinstance(o, (list, tuple)) and len(o) > 1 else o)
-    return values
+    # Galaxy options are [label, value, selected] triples; cap to keep summaries compact.
+    options = p.get("options") or []
+    return [
+        o[1] if isinstance(o, (list, tuple)) and len(o) > 1 else o for o in options[:_MAX_OPTIONS]
+    ]
+
+
+def _options_truncated(p: dict[str, Any]) -> bool:
+    # Signal when the cap dropped choices so a model doesn't read a clipped list as
+    # the full set. Mirrors the `*_truncated` fields used elsewhere (see server.py).
+    return len(p.get("options") or []) > _MAX_OPTIONS
 
 
 def _placeholder(p: dict[str, Any]) -> Any:

--- a/mcp-server-galaxy-py/src/galaxy_mcp/tool_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/tool_inputs.py
@@ -6,6 +6,8 @@ function of its arguments so it is trivially unit-testable. The I/O wiring
 server.py.
 """
 
+from typing import Any
+
 
 def is_input_related_error(exc: Exception) -> bool:
     """True when a tool-run failure is plausibly caused by the provided inputs.
@@ -20,3 +22,54 @@ def is_input_related_error(exc: Exception) -> bool:
     if isinstance(status, int):
         return status == 400
     return isinstance(exc, TypeError)
+
+
+def _summarize_param(p: dict[str, Any]) -> dict[str, Any]:
+    ptype = p.get("type") or p.get("model_class")
+    out: dict[str, Any] = {"name": p.get("name"), "type": ptype}
+    if p.get("optional") is not None:
+        out["optional"] = p.get("optional")
+    if ptype == "repeat":
+        out["repeat_key_hint"] = f"{p.get('name')}_0|<param>"
+        out["children"] = [_summarize_param(c) for c in p.get("inputs", [])]
+    elif ptype == "section":
+        out["section_key_hint"] = f"{p.get('name')}|<param>"
+        out["children"] = [_summarize_param(c) for c in p.get("inputs", [])]
+    elif ptype == "conditional":
+        tp = p.get("test_param") or {}
+        out["selector"] = {
+            "name": tp.get("name"),
+            "type": tp.get("type"),
+            "choices": _option_values(tp),
+            "key_hint": f"{p.get('name')}|{tp.get('name')}",
+        }
+        out["cases"] = [
+            {
+                "when": case.get("value"),
+                "params": [_summarize_param(c) for c in case.get("inputs", [])],
+            }
+            for case in p.get("cases", [])
+        ]
+    elif ptype == "select":
+        out["choices"] = _option_values(p)
+    return out
+
+
+def _option_values(p: dict[str, Any]) -> list[Any]:
+    # Galaxy options are [label, value, selected] triples.
+    values = []
+    for o in (p.get("options") or [])[:25]:
+        values.append(o[1] if isinstance(o, (list, tuple)) and len(o) > 1 else o)
+    return values
+
+
+def summarize_tool_inputs(tool_info: dict[str, Any]) -> list[dict[str, Any]]:
+    """Compact a tool's io_details schema into a model-friendly parameter list.
+
+    Preserves the nesting that matters for building flattened input keys
+    (repeats -> ``name_0|param``, conditionals -> ``name|selector``, sections
+    -> ``name|param``) without the full Galaxy schema noise.
+    """
+    if not isinstance(tool_info, dict):
+        return []
+    return [_summarize_param(p) for p in tool_info.get("inputs", [])]

--- a/mcp-server-galaxy-py/src/galaxy_mcp/tool_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/tool_inputs.py
@@ -1,0 +1,22 @@
+"""Pure helpers for diagnosing and scaffolding Galaxy tool inputs.
+
+No bioblend client, no network, no global state -- everything here is a pure
+function of its arguments so it is trivially unit-testable. The I/O wiring
+(fetching schemas via a Galaxy client, registering MCP tools) lives in
+server.py.
+"""
+
+
+def is_input_related_error(exc: Exception) -> bool:
+    """True when a tool-run failure is plausibly caused by the provided inputs.
+
+    Keys off the structured bioblend error (HTTP 400 == Galaxy rejected the
+    tool form/parameters) rather than substring-scanning the message. Galaxy's
+    masked-TypeError 'kwd not provided' bug also surfaces as a 400. A bare
+    TypeError (e.g. bioblend choking while building the request from a
+    malformed inputs dict) counts too. Auth (401/403), 404, and 5xx do not.
+    """
+    status = getattr(exc, "status_code", None)
+    if status is not None:
+        return status == 400
+    return isinstance(exc, TypeError)

--- a/mcp-server-galaxy-py/src/galaxy_mcp/tool_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/tool_inputs.py
@@ -6,6 +6,7 @@ function of its arguments so it is trivially unit-testable. The I/O wiring
 server.py.
 """
 
+import json
 from typing import Any
 
 
@@ -134,3 +135,51 @@ def summarize_tool_inputs(tool_info: dict[str, Any]) -> list[dict[str, Any]]:
     if not isinstance(tool_info, dict):
         return []
     return [_summarize_param(p) for p in tool_info.get("inputs", [])]
+
+
+def format_input_mismatch_error(
+    *,
+    original_error: str,
+    tool_id: str,
+    schema_summary: list[dict[str, Any]] | None,
+    example: Any | None,
+) -> str:
+    """Assemble a truthful, actionable error for a likely input-shape mismatch.
+
+    Preserves the original error verbatim and offers the schema as help; it does
+    NOT assert a specific cause (we cannot reliably tell a wrong name from a
+    missing value from a bad dataset id).
+    """
+    lines = [
+        original_error,
+        "",
+        f"This most likely means the `inputs` you provided do not match the parameter "
+        f"schema for tool '{tool_id}'. It is not a sign that the MCP or the Galaxy "
+        f"version is incompatible. (Galaxy sometimes reports input problems as a "
+        f'misleading "Required parameter(s) kwd not provided in request" error -- '
+        f"ignore that wording.)",
+    ]
+    if schema_summary is not None:
+        lines += [
+            "",
+            f"Expected input parameters for '{tool_id}' (build flattened keys like "
+            f"`section|param`, `cond|selector`, `repeat_0|param`):",
+            json.dumps(schema_summary, indent=2, default=str),
+        ]
+    if example is not None:
+        lines += [
+            "",
+            "Structural example from a tool test -- NOT runnable: the dataset IDs below "
+            "will not exist in your history. Copy the shape, not the values:",
+            json.dumps(example, indent=2, default=str),
+        ]
+    if schema_summary is None and example is None:
+        lines += [
+            "",
+            "Call get_tool_details(tool_id, io_details=True) (or "
+            "get_tool_input_template(tool_id)) to see the parameter schema, then rebuild "
+            "`inputs` and retry.",
+        ]
+    else:
+        lines += ["", "Rebuild `inputs` to match the schema above and call the tool again."]
+    return "\n".join(lines)

--- a/mcp-server-galaxy-py/src/galaxy_mcp/tool_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/tool_inputs.py
@@ -98,7 +98,7 @@ def _fill_param(p: dict[str, Any], prefix: str, out: dict[str, Any]) -> None:
         tp_name = tp.get("name")
         cases = p.get("cases", [])
         first = cases[0] if cases else None
-        sel_value = first.get("value") if first else _placeholder(tp)
+        sel_value = first.get("value") if first else "<choice>"
         if tp_name:
             out[f"{key}|{tp_name}"] = sel_value
         if first:

--- a/mcp-server-galaxy-py/tests/conftest.py
+++ b/mcp-server-galaxy-py/tests/conftest.py
@@ -97,10 +97,13 @@ def mock_galaxy_instance():
 @pytest.fixture(autouse=True)
 def _reset_galaxy_state():
     """Reset galaxy state for each test"""
-    from galaxy_mcp.server import galaxy_state, get_manifest_json
+    from galaxy_mcp.server import _TOOL_SCHEMA_CACHE, galaxy_state, get_manifest_json
 
     # Clear lru_cache to prevent test pollution
     get_manifest_json.cache_clear()
+
+    # Clear schema cache to prevent cross-test pollution
+    _TOOL_SCHEMA_CACHE.clear()
 
     # Save original state
     original_state = galaxy_state.copy()

--- a/mcp-server-galaxy-py/tests/test_helpers.py
+++ b/mcp-server-galaxy-py/tests/test_helpers.py
@@ -27,6 +27,7 @@ from galaxy_mcp.server import (
     get_server_info,
     get_tool_citations,
     get_tool_details,
+    get_tool_input_template,
     get_tool_panel,
     get_tool_run_examples,
     get_user,
@@ -71,6 +72,7 @@ get_job_details_fn = get_function(get_job_details)
 get_server_info_fn = get_function(get_server_info)
 get_tool_citations_fn = get_function(get_tool_citations)
 get_tool_details_fn = get_function(get_tool_details)
+get_tool_input_template_fn = get_function(get_tool_input_template)
 get_tool_run_examples_fn = get_function(get_tool_run_examples)
 get_tool_panel_fn = get_function(get_tool_panel)
 get_user_fn = get_function(get_user)
@@ -108,6 +110,7 @@ __all__ = [
     "get_server_info_fn",
     "get_tool_citations_fn",
     "get_tool_details_fn",
+    "get_tool_input_template_fn",
     "get_tool_run_examples_fn",
     "get_tool_panel_fn",
     "get_user_fn",

--- a/mcp-server-galaxy-py/tests/test_helpers.py
+++ b/mcp-server-galaxy-py/tests/test_helpers.py
@@ -37,6 +37,7 @@ from galaxy_mcp.server import (
     list_workflows,
     recommend_iwc_workflows,
     run_tool,
+    run_user_tool,
     search_iwc_workflows,
     search_tools_by_keywords,
     search_tools_by_name,
@@ -80,6 +81,7 @@ list_history_ids_fn = get_function(list_history_ids)
 list_workflows_fn = get_function(list_workflows)
 recommend_iwc_workflows_fn = get_function(recommend_iwc_workflows)
 run_tool_fn = get_function(run_tool)
+run_user_tool_fn = get_function(run_user_tool)
 search_iwc_workflows_fn = get_function(search_iwc_workflows)
 search_tools_fn = get_function(search_tools_by_name)
 upload_file_fn = get_function(upload_file)
@@ -116,6 +118,7 @@ __all__ = [
     "list_workflows_fn",
     "recommend_iwc_workflows_fn",
     "run_tool_fn",
+    "run_user_tool_fn",
     "search_iwc_workflows_fn",
     "search_tools_fn",
     "upload_file_fn",

--- a/mcp-server-galaxy-py/tests/test_tool_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_tool_inputs.py
@@ -26,3 +26,7 @@ def test_auth_and_notfound_are_not_input_related():
 
 def test_plain_exception_is_not_input_related():
     assert is_input_related_error(RuntimeError("network down")) is False
+
+
+def test_valueerror_is_not_input_related():
+    assert is_input_related_error(ValueError("bad inputs")) is False

--- a/mcp-server-galaxy-py/tests/test_tool_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_tool_inputs.py
@@ -2,6 +2,7 @@ import bioblend
 
 from galaxy_mcp.tool_inputs import (
     build_input_template,
+    format_input_mismatch_error,
     is_input_related_error,
     summarize_tool_inputs,
 )
@@ -115,3 +116,29 @@ def test_template_section_flattens():
         "inputs": [{"name": "adv", "type": "section", "inputs": [{"name": "p", "type": "integer"}]}]
     }
     assert build_input_template(schema)["adv|p"] == 0
+
+
+def test_message_includes_schema_and_disclaimer_and_original():
+    msg = format_input_mismatch_error(
+        original_error="Run tool failed: Unexpected HTTP status code: 400: kwd not provided",
+        tool_id="cat1",
+        schema_summary=[{"name": "input1", "type": "data"}],
+        example={"input1": {"src": "hda", "id": "1"}},
+    )
+    assert "Run tool failed" in msg  # original preserved verbatim
+    assert "not a sign" in msg.lower()  # disclaimer
+    assert "kwd" in msg.lower()  # names the misleading wording
+    assert "input1" in msg  # schema embedded
+    assert "NOT runnable" in msg  # example caveat
+    assert "cat1" in msg
+
+
+def test_message_degrades_without_schema_or_example():
+    msg = format_input_mismatch_error(
+        original_error="Run tool failed: boom",
+        tool_id="cat1",
+        schema_summary=None,
+        example=None,
+    )
+    assert "get_tool_details" in msg
+    assert "Run tool failed: boom" in msg

--- a/mcp-server-galaxy-py/tests/test_tool_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_tool_inputs.py
@@ -1,6 +1,10 @@
 import bioblend
 
-from galaxy_mcp.tool_inputs import is_input_related_error, summarize_tool_inputs
+from galaxy_mcp.tool_inputs import (
+    build_input_template,
+    is_input_related_error,
+    summarize_tool_inputs,
+)
 
 
 def _conn_err(status, body="boom"):
@@ -76,3 +80,26 @@ def test_summarize_walks_repeat_conditional():
 def test_summarize_handles_missing_inputs_key():
     assert summarize_tool_inputs({}) == []
     assert summarize_tool_inputs({"inputs": []}) == []
+
+
+CAT1_SCHEMA = {
+    "id": "cat1",
+    "inputs": [
+        {"name": "input1", "type": "data", "optional": False},
+        {"name": "queries", "type": "repeat", "inputs": [{"name": "input2", "type": "data"}]},
+    ],
+}
+
+
+def test_template_flattens_data_and_repeat():
+    t = build_input_template(CAT1_SCHEMA)
+    assert t["input1"] == {"src": "hda", "id": "<dataset_id>"}
+    assert t["queries_0|input2"] == {"src": "hda", "id": "<dataset_id>"}
+
+
+def test_template_conditional_uses_first_case():
+    t = build_input_template(BUILD_LIST_SCHEMA)
+    assert t["datasets_0|input"] == {"src": "hda", "id": "<dataset_id>"}
+    # first case is "idx" -> selector set, no extra params
+    assert t["datasets_0|id_cond|id_select"] == "idx"
+    assert "datasets_0|id_cond|identifier" not in t

--- a/mcp-server-galaxy-py/tests/test_tool_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_tool_inputs.py
@@ -1,0 +1,28 @@
+import bioblend
+
+from galaxy_mcp.tool_inputs import is_input_related_error
+
+
+def _conn_err(status, body="boom"):
+    return bioblend.ConnectionError(
+        f"Unexpected HTTP status code: {status}", body=body, status_code=status
+    )
+
+
+def test_400_is_input_related():
+    assert is_input_related_error(_conn_err(400, "Required parameter(s) kwd not provided.")) is True
+
+
+def test_typeerror_is_input_related():
+    assert is_input_related_error(TypeError("bad inputs")) is True
+
+
+def test_auth_and_notfound_are_not_input_related():
+    assert is_input_related_error(_conn_err(401)) is False
+    assert is_input_related_error(_conn_err(403)) is False
+    assert is_input_related_error(_conn_err(404)) is False
+    assert is_input_related_error(_conn_err(500)) is False
+
+
+def test_plain_exception_is_not_input_related():
+    assert is_input_related_error(RuntimeError("network down")) is False

--- a/mcp-server-galaxy-py/tests/test_tool_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_tool_inputs.py
@@ -83,6 +83,33 @@ def test_summarize_handles_missing_inputs_key():
     assert summarize_tool_inputs({"inputs": []}) == []
 
 
+def test_summarize_select_truncates_long_option_lists():
+    schema = {
+        "inputs": [
+            {
+                "name": "genome",
+                "type": "select",
+                "options": [[f"label{i}", f"val{i}", False] for i in range(40)],
+            }
+        ]
+    }
+    param = summarize_tool_inputs(schema)[0]
+    assert param["choices"][:3] == ["val0", "val1", "val2"]
+    assert len(param["choices"]) == 25  # capped at _MAX_OPTIONS, values only
+    assert param["choices_truncated"] is True
+
+
+def test_summarize_select_keeps_short_option_lists_intact():
+    schema = {
+        "inputs": [
+            {"name": "fmt", "type": "select", "options": [["A", "a", False], ["B", "b", True]]}
+        ]
+    }
+    param = summarize_tool_inputs(schema)[0]
+    assert param["choices"] == ["a", "b"]
+    assert "choices_truncated" not in param
+
+
 CAT1_SCHEMA = {
     "id": "cat1",
     "inputs": [

--- a/mcp-server-galaxy-py/tests/test_tool_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_tool_inputs.py
@@ -1,6 +1,6 @@
 import bioblend
 
-from galaxy_mcp.tool_inputs import is_input_related_error
+from galaxy_mcp.tool_inputs import is_input_related_error, summarize_tool_inputs
 
 
 def _conn_err(status, body="boom"):
@@ -30,3 +30,49 @@ def test_plain_exception_is_not_input_related():
 
 def test_valueerror_is_not_input_related():
     assert is_input_related_error(ValueError("bad inputs")) is False
+
+
+# Shape mirrors Galaxy's /api/tools/{id}?io_details=true output.
+BUILD_LIST_SCHEMA = {
+    "id": "__BUILD_LIST__",
+    "inputs": [
+        {
+            "name": "datasets",
+            "type": "repeat",
+            "inputs": [
+                {"name": "input", "type": "data", "optional": False},
+                {
+                    "name": "id_cond",
+                    "type": "conditional",
+                    "test_param": {
+                        "name": "id_select",
+                        "type": "select",
+                        "options": [["use index", "idx", True], ["manual", "manual", False]],
+                    },
+                    "cases": [
+                        {"value": "idx", "inputs": []},
+                        {"value": "manual", "inputs": [{"name": "identifier", "type": "text"}]},
+                    ],
+                },
+            ],
+        }
+    ],
+}
+
+
+def test_summarize_walks_repeat_conditional():
+    summ = summarize_tool_inputs(BUILD_LIST_SCHEMA)
+    assert summ[0]["name"] == "datasets"
+    assert summ[0]["type"] == "repeat"
+    assert summ[0]["repeat_key_hint"] == "datasets_0|<param>"
+    child_names = [c["name"] for c in summ[0]["children"]]
+    assert child_names == ["input", "id_cond"]
+    cond = summ[0]["children"][1]
+    assert cond["type"] == "conditional"
+    assert cond["selector"]["name"] == "id_select"
+    assert {c["when"] for c in cond["cases"]} == {"idx", "manual"}
+
+
+def test_summarize_handles_missing_inputs_key():
+    assert summarize_tool_inputs({}) == []
+    assert summarize_tool_inputs({"inputs": []}) == []

--- a/mcp-server-galaxy-py/tests/test_tool_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_tool_inputs.py
@@ -103,3 +103,15 @@ def test_template_conditional_uses_first_case():
     # first case is "idx" -> selector set, no extra params
     assert t["datasets_0|id_cond|id_select"] == "idx"
     assert "datasets_0|id_cond|identifier" not in t
+
+
+def test_template_non_dict_returns_empty():
+    assert build_input_template(None) == {}
+    assert build_input_template("not a dict") == {}
+
+
+def test_template_section_flattens():
+    schema = {
+        "inputs": [{"name": "adv", "type": "section", "inputs": [{"name": "p", "type": "integer"}]}]
+    }
+    assert build_input_template(schema)["adv|p"] == 0

--- a/mcp-server-galaxy-py/tests/test_tool_operations.py
+++ b/mcp-server-galaxy-py/tests/test_tool_operations.py
@@ -2,7 +2,8 @@
 Test tool-related operations
 """
 
-from unittest.mock import patch
+import asyncio
+from unittest.mock import MagicMock, patch
 
 import bioblend
 import pytest
@@ -227,13 +228,29 @@ class TestToolOperations:
             "tool1", tool_version=None
         )
 
-    def test_get_tool_run_examples_uses_request_scoped_gi(self, mock_galaxy_instance):
-        """Must read the per-request gi (state['gi']), not the module global."""
-        mock_galaxy_instance.tools.get_tool_tests.return_value = [{"inputs": {"input1": "x"}}]
-        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+    def test_get_tool_run_examples_uses_request_scoped_gi(self):
+        """Must read the per-request gi (state['gi']), not the module global.
+
+        Uses a request-scoped client distinct from galaxy_state['gi'] so the test
+        actually fails if the code reverts to reaching for the global client (the
+        OAuth regression the request-scoped path guards against).
+        """
+        request_gi = MagicMock(name="request_gi")
+        request_gi.tools.get_tool_tests.return_value = [{"inputs": {"input1": "x"}}]
+        global_gi = MagicMock(name="global_gi")
+
+        with (
+            patch.dict(galaxy_state, {"connected": True, "gi": global_gi}),
+            patch(
+                "galaxy_mcp.server._get_request_connection_state",
+                return_value={"connected": True, "gi": request_gi},
+            ),
+        ):
             result = get_tool_run_examples_fn("cat1")
+
         assert result.success is True
-        mock_galaxy_instance.tools.get_tool_tests.assert_called_once_with("cat1", tool_version=None)
+        request_gi.tools.get_tool_tests.assert_called_once_with("cat1", tool_version=None)
+        global_gi.tools.get_tool_tests.assert_not_called()
 
     def test_get_tool_run_examples_error(self, mock_galaxy_instance):
         """Test error handling when fetching tool run lessons fails"""
@@ -265,6 +282,70 @@ class TestToolOperations:
         assert "not a sign" in msg.lower()  # disclaimer
         assert "kwd" in msg.lower()  # original + wording note preserved
         mock_galaxy_instance.tools.show_tool.assert_called_once_with("cat1", io_details=True)
+
+    def test_run_tool_enrichment_uses_request_scoped_gi(self):
+        """Enrichment must fetch the schema via the per-request gi, not the global."""
+        request_gi = MagicMock(name="request_gi")
+        request_gi.tools.run_tool.side_effect = bioblend.ConnectionError(
+            "Unexpected HTTP status code: 400", body="kwd not provided", status_code=400
+        )
+        request_gi.tools.show_tool.return_value = {
+            "id": "cat1",
+            "inputs": [{"name": "input1", "type": "data"}],
+        }
+        request_gi.tools.get_tool_tests.return_value = []
+        global_gi = MagicMock(name="global_gi")
+
+        with (
+            patch.dict(galaxy_state, {"connected": True, "gi": global_gi}),
+            patch(
+                "galaxy_mcp.server._get_request_connection_state",
+                return_value={"connected": True, "gi": request_gi},
+            ),
+            pytest.raises(ValueError) as exc,
+        ):
+            run_tool_fn("hist1", "cat1", {"wrong": "x"})
+
+        assert "input1" in str(exc.value)  # enriched from the request-scoped schema
+        request_gi.tools.show_tool.assert_called_once_with("cat1", io_details=True)
+        global_gi.tools.show_tool.assert_not_called()
+
+    def test_run_tool_enrichment_applies_through_code_mode_dispatch(self):
+        """Code-mode coverage: the run_galaxy_tool meta-tool executes tools via
+        ``ctx.fastmcp.call_tool("run_tool", ...)``, so enrichment must survive the
+        server dispatch path, not just a direct call to run_tool's function. This
+        drives that same dispatch (``mcp.call_tool``) and asserts the enriched error
+        comes back instead of the raw 400.
+        """
+        from fastmcp.exceptions import ToolError
+
+        from galaxy_mcp.server import mcp
+
+        request_gi = MagicMock(name="request_gi")
+        request_gi.tools.run_tool.side_effect = bioblend.ConnectionError(
+            "Unexpected HTTP status code: 400", body="kwd not provided", status_code=400
+        )
+        request_gi.tools.show_tool.return_value = {
+            "id": "cat1",
+            "inputs": [{"name": "input1", "type": "data"}],
+        }
+        request_gi.tools.get_tool_tests.return_value = []
+
+        async def _dispatch():
+            return await mcp.call_tool(
+                "run_tool", {"history_id": "h1", "tool_id": "cat1", "inputs": {"wrong": "x"}}
+            )
+
+        with patch(
+            "galaxy_mcp.server._get_request_connection_state",
+            return_value={"connected": True, "gi": request_gi},
+        ):
+            with pytest.raises(ToolError) as exc:
+                asyncio.run(_dispatch())
+
+        msg = str(exc.value)
+        assert "input1" in msg  # schema-enriched
+        assert "not a sign" in msg.lower()  # disclaimer survived the dispatch
 
     def test_run_tool_non_input_error_uses_plain_format(self, mock_galaxy_instance):
         """A 404 is NOT treated as input-related -- no schema fetch."""

--- a/mcp-server-galaxy-py/tests/test_tool_operations.py
+++ b/mcp-server-galaxy-py/tests/test_tool_operations.py
@@ -225,6 +225,14 @@ class TestToolOperations:
             "tool1", tool_version=None
         )
 
+    def test_get_tool_run_examples_uses_request_scoped_gi(self, mock_galaxy_instance):
+        """Must read the per-request gi (state['gi']), not the module global."""
+        mock_galaxy_instance.tools.get_tool_tests.return_value = [{"inputs": {"input1": "x"}}]
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = get_tool_run_examples_fn("cat1")
+        assert result.success is True
+        mock_galaxy_instance.tools.get_tool_tests.assert_called_once_with("cat1", tool_version=None)
+
     def test_get_tool_run_examples_error(self, mock_galaxy_instance):
         """Test error handling when fetching tool run lessons fails"""
         mock_galaxy_instance.tools.get_tool_tests.side_effect = Exception("Boom")

--- a/mcp-server-galaxy-py/tests/test_tool_operations.py
+++ b/mcp-server-galaxy-py/tests/test_tool_operations.py
@@ -4,6 +4,7 @@ Test tool-related operations
 
 from unittest.mock import patch
 
+import bioblend
 import pytest
 
 from .test_helpers import (
@@ -231,3 +232,36 @@ class TestToolOperations:
         with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
             with pytest.raises(ValueError, match="Get tool run examples failed"):
                 get_tool_run_examples_fn("tool1")
+
+    def test_run_tool_enriches_input_error(self, mock_galaxy_instance):
+        """A 400 from Galaxy yields a truthful enriched error with the schema."""
+        mock_galaxy_instance.tools.run_tool.side_effect = bioblend.ConnectionError(
+            "Unexpected HTTP status code: 400",
+            body="Required parameter(s) kwd not provided in request.",
+            status_code=400,
+        )
+        mock_galaxy_instance.tools.show_tool.return_value = {
+            "id": "cat1",
+            "inputs": [{"name": "input1", "type": "data", "optional": False}],
+        }
+        mock_galaxy_instance.tools.get_tool_tests.return_value = []
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            with pytest.raises(ValueError) as exc:
+                run_tool_fn("hist1", "cat1", {"input": {"src": "hda", "id": "d1"}})
+
+        msg = str(exc.value)
+        assert "input1" in msg  # real param name surfaced
+        assert "not a sign" in msg.lower()  # disclaimer
+        assert "kwd" in msg.lower()  # original + wording note preserved
+        mock_galaxy_instance.tools.show_tool.assert_called_once_with("cat1", io_details=True)
+
+    def test_run_tool_non_input_error_uses_plain_format(self, mock_galaxy_instance):
+        """A 404 is NOT treated as input-related -- no schema fetch."""
+        mock_galaxy_instance.tools.run_tool.side_effect = bioblend.ConnectionError(
+            "Unexpected HTTP status code: 404", body="not found", status_code=404
+        )
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            with pytest.raises(ValueError, match="Run tool failed"):
+                run_tool_fn("hist1", "cat1", {"input1": {"src": "hda", "id": "d1"}})
+        mock_galaxy_instance.tools.show_tool.assert_not_called()

--- a/mcp-server-galaxy-py/tests/test_tool_operations.py
+++ b/mcp-server-galaxy-py/tests/test_tool_operations.py
@@ -9,6 +9,7 @@ import pytest
 
 from .test_helpers import (
     galaxy_state,
+    get_tool_input_template_fn,
     get_tool_run_examples_fn,
     run_tool_fn,
     run_user_tool_fn,
@@ -298,3 +299,23 @@ class TestToolOperations:
                 run_user_tool_fn("hist1", "uuid-123", {"wrong": "x"})
         assert "not a sign" in str(exc.value).lower()
         assert '"in"' in str(exc.value) or "'in'" in str(exc.value)
+
+    def test_get_tool_input_template(self, mock_galaxy_instance):
+        mock_galaxy_instance.tools.show_tool.return_value = {
+            "id": "cat1",
+            "inputs": [
+                {"name": "input1", "type": "data"},
+                {
+                    "name": "queries",
+                    "type": "repeat",
+                    "inputs": [{"name": "input2", "type": "data"}],
+                },
+            ],
+        }
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            result = get_tool_input_template_fn("cat1")
+        assert result.success is True
+        tmpl = result.data["inputs_template"]
+        assert tmpl["input1"] == {"src": "hda", "id": "<dataset_id>"}
+        assert tmpl["queries_0|input2"] == {"src": "hda", "id": "<dataset_id>"}
+        assert result.data["parameters"][0]["name"] == "input1"

--- a/mcp-server-galaxy-py/tests/test_tool_operations.py
+++ b/mcp-server-galaxy-py/tests/test_tool_operations.py
@@ -11,6 +11,7 @@ from .test_helpers import (
     galaxy_state,
     get_tool_run_examples_fn,
     run_tool_fn,
+    run_user_tool_fn,
     search_tools_fn,
 )
 
@@ -273,3 +274,27 @@ class TestToolOperations:
             with pytest.raises(ValueError, match="Run tool failed"):
                 run_tool_fn("hist1", "cat1", {"input1": {"src": "hda", "id": "d1"}})
         mock_galaxy_instance.tools.show_tool.assert_not_called()
+
+    def test_run_user_tool_enriches_input_error(self, mock_galaxy_instance):
+        # resolve uuid -> tool_id succeeds
+        mock_galaxy_instance.url = "http://galaxy/api"
+        resolve = type(
+            "R",
+            (),
+            {"json": lambda self: {"tool_id": "utool", "representation": {"version": "0.1.0"}}},
+        )()
+        mock_galaxy_instance.make_get_request.return_value = resolve
+        # the job POST fails with a 400
+        mock_galaxy_instance.make_post_request.side_effect = bioblend.ConnectionError(
+            "Unexpected HTTP status code: 400", body="kwd not provided", status_code=400
+        )
+        mock_galaxy_instance.tools.show_tool.return_value = {
+            "id": "utool",
+            "inputs": [{"name": "in", "type": "data"}],
+        }
+        mock_galaxy_instance.tools.get_tool_tests.return_value = []
+        with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+            with pytest.raises(ValueError) as exc:
+                run_user_tool_fn("hist1", "uuid-123", {"wrong": "x"})
+        assert "not a sign" in str(exc.value).lower()
+        assert '"in"' in str(exc.value) or "'in'" in str(exc.value)


### PR DESCRIPTION
When a model calls `run_tool` with inputs that don't match a tool's schema, Galaxy often returns a misleading error -- most notoriously `Required parameter(s) kwd not provided in request`, which is actually a masked server-side TypeError, not anything about the payload. With only the raw error surfaced, models (we hit this with DeepSeek) conclude the MCP is incompatible with the Galaxy version and give up, when the real problem is just the input shape.

This makes those failures self-correcting. On an input-related failure (HTTP 400 or TypeError), `run_tool` and `run_user_tool` now return an enriched error: the original message verbatim, a plain note that it's almost certainly an input mismatch (and that the `kwd` wording is a known Galaxy quirk to ignore), the tool's real parameter schema, and a structural example from the tool's tests (marked not-runnable). The classifier keys off the structured HTTP status, not string matching, and the schema/example fetch is best-effort so the error path can't itself raise.

Also adds `get_tool_input_template(tool_id)` -- a ready-to-fill `inputs` skeleton (placeholders + flattened keys for repeats/conditionals/sections) plus the compact schema, so a model can build a correct call up front. And fixes `get_tool_run_examples`, which read the module-global Galaxy client instead of the request-scoped one (broken under OAuth sessions).

Pure logic lives in a new `tool_inputs.py`; the I/O wiring stays in `server.py`; schema lookups are cached per (server, tool). Full test suite passes (111) and mypy is clean. Bumps to 1.5.0.
