### PR TITLE
Add workflow input templates + invoke-time datatype validation

### DIFF
--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -37,8 +37,11 @@ from galaxy_mcp.tool_inputs import (
     summarize_tool_inputs,
 )
 from galaxy_mcp.workflow_inputs import (
+    build_workflow_input_template,
+    find_legacy_warnings,
     normalize_ga_steps,
     normalize_run_model,
+    validate_inputs,  # noqa: F401 -- used in Task 11's invoke_workflow preflight
 )
 
 _galaxy_mcp_version = importlib.metadata.version("galaxy-mcp")
@@ -2958,6 +2961,41 @@ def _resolve_workflow_slots(
         logger.info("style=run unavailable for %s (%s); falling back to .ga", workflow_id, e)
     definition = gi.workflows.export_workflow_dict(workflow_id)
     return normalize_ga_steps(definition), "ga-fallback"
+
+
+@mcp.tool(tags={"workflows", "read", "extended"})
+def get_workflow_input_template(workflow_id: str, history_id: str | None = None) -> GalaxyResult:
+    """Return a ready-to-fill template of a workflow's input slots.
+
+    Call this before invoke_workflow. Each slot lists its label, expected source
+    (hda/hdca), accepted datatypes, and collection type so you map datasets to
+    the right inputs. Fill `inputs_template` (keyed by step_index) and invoke
+    with `inputs_by="step_index|step_uuid"`. `warnings` flags legacy patterns.
+    """
+    state = ensure_connected()
+    gi: GalaxyInstance = state["gi"]
+    try:
+        slots, provenance = _resolve_workflow_slots(gi, workflow_id, history_id)
+        try:
+            definition = gi.workflows.export_workflow_dict(workflow_id)
+            warnings = find_legacy_warnings(definition)
+        except Exception:  # noqa: BLE001 -- warnings are best-effort
+            warnings = []
+        template = build_workflow_input_template(slots, warnings=warnings)
+        return GalaxyResult(
+            data=template,
+            success=True,
+            message=(
+                f"Built an input template for workflow '{workflow_id}' "
+                f"({len(slots)} slot(s), source: {provenance}). Fill inputs_template "
+                f"and invoke with inputs_by='step_index|step_uuid'."
+            ),
+            count=len(slots),
+        )
+    except Exception as e:
+        raise ValueError(
+            format_error("Get workflow input template", e, {"workflow_id": workflow_id})
+        ) from e
 
 
 @mcp.tool(tags={"workflows", "write", "extended"})

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -229,6 +229,30 @@ def format_error(action: str, error: Exception, context: dict | None = None) -> 
 # version is not part of the key because bioblend's show_tool fetches the default version only.
 _TOOL_SCHEMA_CACHE: dict[tuple[str | None, str], dict[str, Any]] = {}
 
+# Cache Galaxy's datatype class mapping per base URL -- it's static for a given server version,
+# so one fetch per server is fine even across many requests.
+_DATATYPES_MAPPING_CACHE: dict[str | None, dict[str, Any]] = {}
+
+
+def _get_datatypes_mapping(gi: GalaxyInstance) -> dict[str, Any]:
+    """Fetch and cache the datatypes class mapping (per Galaxy base URL).
+
+    User-independent, so a base-URL-keyed cache is safe. Returns the inner
+    ``datatypes_mapping`` object: {ext_to_class_name, class_to_classes}.
+    """
+    key = getattr(gi, "base_url", None)
+    if key in _DATATYPES_MAPPING_CACHE:
+        return _DATATYPES_MAPPING_CACHE[key]
+    resp = gi.make_get_request(f"{gi.url}/api/datatypes/types_and_mapping?upload_only=false")
+    if resp.status_code != 200:
+        mapping: dict[str, Any] = {"ext_to_class_name": {}, "class_to_classes": {}}
+    else:
+        mapping = resp.json().get(
+            "datatypes_mapping", {"ext_to_class_name": {}, "class_to_classes": {}}
+        )
+    _DATATYPES_MAPPING_CACHE[key] = mapping
+    return mapping
+
 
 def _get_tool_schema(gi: GalaxyInstance, tool_id: str) -> dict[str, Any]:
     """Fetch (and cache) a tool's io_details schema using the given request-scoped client."""

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -133,6 +133,14 @@ def _clear_session_connection(session_id: str) -> None:
         _session_connections.pop(session_id, None)
 
 
+class WorkflowInputValidationError(ValueError):
+    """Raised when invoke_workflow's preflight finds a provable input mismatch.
+
+    Carries a complete, model-facing message (reasons + slot template); the
+    outer handler re-raises it unchanged so the message isn't wrapped or duplicated.
+    """
+
+
 class PaginationInfo(BaseModel):
     """Pagination metadata for list operations."""
 
@@ -252,12 +260,14 @@ def _get_datatypes_mapping(gi: GalaxyInstance) -> dict[str, Any]:
     if key in _DATATYPES_MAPPING_CACHE:
         return _DATATYPES_MAPPING_CACHE[key]
     resp = gi.make_get_request(f"{gi.url}/api/datatypes/types_and_mapping?upload_only=false")
+    _empty: dict[str, Any] = {"ext_to_class_name": {}, "class_to_classes": {}}
     if resp.status_code != 200:
-        mapping: dict[str, Any] = {"ext_to_class_name": {}, "class_to_classes": {}}
+        mapping: dict[str, Any] = _empty
     else:
-        mapping = resp.json().get(
-            "datatypes_mapping", {"ext_to_class_name": {}, "class_to_classes": {}}
-        )
+        try:
+            mapping = resp.json().get("datatypes_mapping", _empty)
+        except Exception:  # noqa: BLE001 -- truncated or non-JSON 200 body; degrade gracefully
+            mapping = _empty
     _DATATYPES_MAPPING_CACHE[key] = mapping
     return mapping
 
@@ -3080,7 +3090,7 @@ def invoke_workflow(
                     "\n\nExpected input slots"
                     " (fill and retry with inputs_by='step_index|step_uuid'):\n"
                 )
-                raise ValueError(
+                raise WorkflowInputValidationError(
                     "Workflow inputs failed validation; not submitting:\n"
                     + "\n".join(lines)
                     + retry_hint
@@ -3105,6 +3115,8 @@ def invoke_workflow(
             success=True,
             message=f"Invoked workflow '{workflow_id}'",
         )
+    except WorkflowInputValidationError:
+        raise
     except Exception as e:
         hint = ""
         with contextlib.suppress(Exception):

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -36,6 +36,10 @@ from galaxy_mcp.tool_inputs import (
     is_input_related_error,
     summarize_tool_inputs,
 )
+from galaxy_mcp.workflow_inputs import (
+    normalize_ga_steps,
+    normalize_run_model,
+)
 
 _galaxy_mcp_version = importlib.metadata.version("galaxy-mcp")
 USER_AGENT = f"galaxy-mcp/{_galaxy_mcp_version} bioblend/{bioblend.__version__}"
@@ -2933,6 +2937,27 @@ def get_workflow_details(workflow_id: str, version: int | None = None) -> Galaxy
                 "Get workflow details", e, {"workflow_id": workflow_id, "version": version}
             )
         ) from e
+
+
+def _resolve_workflow_slots(
+    gi: GalaxyInstance, workflow_id: str, history_id: str | None = None
+) -> tuple[list[dict[str, Any]], str]:
+    """Resolve a workflow's input slots. Primary: style=run (webapp's source),
+    behind our normalizer. Fallback: the .ga export. Returns (slots, provenance).
+    """
+    params = "style=run&instance=true"
+    if history_id:
+        params += f"&history_id={history_id}"
+    try:
+        resp = gi.make_get_request(f"{gi.url}/api/workflows/{workflow_id}/download?{params}")
+        if resp.status_code == 200:
+            slots = normalize_run_model(resp.json())
+            if slots:
+                return slots, "style=run"
+    except Exception as e:  # noqa: BLE001 -- fall back on any style=run failure
+        logger.info("style=run unavailable for %s (%s); falling back to .ga", workflow_id, e)
+    definition = gi.workflows.export_workflow_dict(workflow_id)
+    return normalize_ga_steps(definition), "ga-fallback"
 
 
 @mcp.tool(tags={"workflows", "write", "extended"})

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -2,6 +2,7 @@
 import concurrent.futures
 import contextlib
 import importlib.metadata
+import json
 import logging
 import os
 import threading
@@ -41,7 +42,7 @@ from galaxy_mcp.workflow_inputs import (
     find_legacy_warnings,
     normalize_ga_steps,
     normalize_run_model,
-    validate_inputs,  # noqa: F401 -- used in Task 11's invoke_workflow preflight
+    validate_inputs,
 )
 
 _galaxy_mcp_version = importlib.metadata.version("galaxy-mcp")
@@ -2998,6 +2999,33 @@ def get_workflow_input_template(workflow_id: str, history_id: str | None = None)
         ) from e
 
 
+def _enrich_supplied_inputs(gi: GalaxyInstance, inputs: dict[str, Any]) -> dict[str, Any]:
+    """Resolve each supplied {id,src} to the metadata validate_inputs needs."""
+    enriched: dict[str, Any] = {}
+    for key, value in (inputs or {}).items():
+        if not (isinstance(value, dict) and "src" in value):
+            enriched[key] = value
+            continue
+        entry = dict(value)
+        try:
+            if value["src"] == "hda":
+                entry["ext"] = gi.datasets.show_dataset(value["id"]).get("extension")
+            elif value["src"] == "hdca":
+                coll = gi.dataset_collections.show_dataset_collection(value["id"])
+                entry["collection_type"] = coll.get("collection_type")
+                entry["element_extensions"] = sorted(
+                    {
+                        e.get("object", {}).get("extension")
+                        for e in coll.get("elements", [])
+                        if e.get("object", {}).get("extension")
+                    }
+                )
+        except Exception:  # noqa: BLE001 -- unknown metadata -> validator stays permissive
+            pass
+        enriched[key] = entry
+    return enriched
+
+
 @mcp.tool(tags={"workflows", "write", "extended"})
 def invoke_workflow(
     workflow_id: str,
@@ -3032,6 +3060,33 @@ def invoke_workflow(
 
     try:
         gi: GalaxyInstance = state["gi"]
+
+        # Preflight: validate supplied inputs against the workflow's slots.
+        if inputs:
+            try:
+                slots, _prov = _resolve_workflow_slots(gi, workflow_id, history_id)
+                mapping = _get_datatypes_mapping(gi)
+                supplied = _enrich_supplied_inputs(gi, inputs)
+                verdict = validate_inputs(slots, supplied, mapping)
+            except Exception:  # noqa: BLE001 -- never let preflight failure block a valid run
+                verdict = {"rejects": [], "warnings": []}
+            if verdict["rejects"]:
+                template = build_workflow_input_template(slots, warnings=verdict["warnings"])
+                lines = [
+                    f"  - step {r['step_index']} ({r.get('label', '?')}): {r['reason']}"
+                    for r in verdict["rejects"]
+                ]
+                retry_hint = (
+                    "\n\nExpected input slots"
+                    " (fill and retry with inputs_by='step_index|step_uuid'):\n"
+                )
+                raise ValueError(
+                    "Workflow inputs failed validation; not submitting:\n"
+                    + "\n".join(lines)
+                    + retry_hint
+                    + json.dumps(template["slots"], indent=2, default=str)
+                )
+
         resolved_inputs_by = cast(
             Literal["step_index|step_uuid", "step_index", "step_id", "step_uuid", "name"],
             inputs_by,
@@ -3051,6 +3106,12 @@ def invoke_workflow(
             message=f"Invoked workflow '{workflow_id}'",
         )
     except Exception as e:
+        hint = ""
+        with contextlib.suppress(Exception):
+            slots, _ = _resolve_workflow_slots(gi, workflow_id, history_id)
+            hint = "\n\nWorkflow input slots:\n" + json.dumps(
+                build_workflow_input_template(slots)["slots"], indent=2, default=str
+            )
         raise ValueError(
             format_error(
                 "Invoke workflow",
@@ -3062,6 +3123,7 @@ def invoke_workflow(
                     "inputs_by": inputs_by,
                 },
             )
+            + hint
         ) from e
 
 

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -3060,7 +3060,8 @@ def invoke_workflow(
         params: Tool parameter overrides as a nested dictionary
         history_id: ID of history to store workflow outputs (optional)
         history_name: Name for new history to create (ignored if history_id provided)
-        inputs_by: How to identify workflow inputs - 'step_index', 'step_uuid', or 'name'
+        inputs_by: How to identify workflow inputs - 'step_index', 'step_uuid', 'name', or
+                  'step_index|step_uuid' (recommended; matches get_workflow_input_template)
         parameters_normalized: Whether parameters are already in normalized format
 
     Returns:

--- a/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
@@ -88,3 +88,51 @@ def normalize_ga_steps(definition: dict[str, Any]) -> list[dict[str, Any]]:
             }
         )
     return slots
+
+
+# style=run step "step_type" -> our input_type. Galaxy uses the same
+# data_input/data_collection_input/parameter_input discriminators here.
+def normalize_run_model(run_dict: dict[str, Any]) -> list[dict[str, Any]]:
+    """Normalize a style=run workflow model into input slots (the slot contract).
+
+    style=run is the webapp's own run-form serialization; for data inputs its
+    ``extensions`` already reflect Galaxy's downstream-consumer resolution. We
+    consume it rather than reconstruct from connections.
+    """
+    raw_steps = run_dict.get("steps")
+    if isinstance(raw_steps, dict):
+        step_iter = [raw_steps[k] for k in sorted(raw_steps, key=lambda k: int(k))]
+    else:
+        step_iter = list(raw_steps or [])
+    slots: list[dict[str, Any]] = []
+    for step in step_iter:
+        input_type = _INPUT_TYPE_MAP.get(step.get("step_type") or step.get("type", ""))
+        if input_type is None:
+            continue
+        index = int(step.get("step_index", step.get("order_index", step.get("id"))))
+        # The run model nests the actual param under "inputs"[0] for input steps.
+        param = (step.get("inputs") or [{}])[0]
+        ctype = param.get("collection_type")
+        if not ctype:
+            ctypes = param.get("collection_types")
+            ctype = ctypes[0] if isinstance(ctypes, list) and ctypes else None
+        # style=run uses "step_label" for the step name; param["label"] is a fallback.
+        label = (
+            step.get("step_label")
+            or param.get("label")
+            or f"{_FALLBACK_LABEL[input_type]} (step {index})"
+        )
+        slots.append(
+            {
+                "step_index": index,
+                "step_uuid": step.get("uuid"),
+                "label": label,
+                "input_type": input_type,
+                "src": _SRC_MAP[input_type],
+                "accepted_formats": list(param.get("extensions") or []),
+                "collection_type": ctype,
+                "parameter_type": param.get("parameter_type") or step.get("parameter_type"),
+                "optional": bool(param.get("optional", False)),
+            }
+        )
+    return slots

--- a/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
@@ -322,3 +322,26 @@ def validate_inputs(
                 }
             )
     return {"rejects": rejects, "warnings": warnings}
+
+
+def _placeholder_for(slot: dict[str, Any]) -> Any:
+    if slot["input_type"] == "data":
+        return {"src": "hda", "id": "<dataset_id>"}
+    if slot["input_type"] == "data_collection":
+        return {"src": "hdca", "id": "<collection_id>"}
+    return "<value>"
+
+
+def build_workflow_input_template(
+    slots: list[dict[str, Any]], warnings: list[dict[str, Any]] | None = None
+) -> dict[str, Any]:
+    """Assemble the model-facing template: a ready-to-fill skeleton keyed by
+    step_index, the per-slot constraint summary, the invoke key hint, and any
+    legacy warnings.
+    """
+    return {
+        "inputs_template": {str(s["step_index"]): _placeholder_for(s) for s in slots},
+        "slots": slots,
+        "inputs_by": "step_index|step_uuid",
+        "warnings": warnings or [],
+    }

--- a/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
@@ -136,3 +136,37 @@ def normalize_run_model(run_dict: dict[str, Any]) -> list[dict[str, Any]]:
             }
         )
     return slots
+
+
+def _has_runtime_value(obj: Any) -> bool:
+    """True if ``obj`` contains a bare RuntimeValue marker (not ConnectedValue)."""
+    if isinstance(obj, dict):
+        if obj.get("__class__") == "RuntimeValue":
+            return True
+        return any(_has_runtime_value(v) for v in obj.values())
+    if isinstance(obj, list):
+        return any(_has_runtime_value(v) for v in obj)
+    return False
+
+
+def find_legacy_warnings(definition: dict[str, Any]) -> list[dict[str, str]]:
+    """Warn on tool steps carrying unconnected RuntimeValue params (the real
+    legacy-run-form trigger). Bare ``parameter_input`` steps are formal inputs
+    and are NOT flagged.
+    """
+    warnings: list[dict[str, str]] = []
+    for key, step in sorted(definition.get("steps", {}).items(), key=lambda kv: int(kv[0])):
+        if step.get("type") != "tool":
+            continue
+        if _has_runtime_value(_coerce_state(step.get("tool_state"))):
+            name = step.get("label") or step.get("tool_id") or f"step {key}"
+            warnings.append(
+                {
+                    "kind": "legacy_runtime_value",
+                    "message": (
+                        f"Tool step '{name}' has a RuntimeValue parameter set at runtime "
+                        f"(legacy run-form pattern); the workflow may not run cleanly via the API."
+                    ),
+                }
+            )
+    return warnings

--- a/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
@@ -107,6 +107,7 @@ def normalize_ga_steps(definition: dict[str, Any]) -> list[dict[str, Any]]:
                 label=label,
                 input_type=input_type,
                 accepted_formats=_as_list(state.get("format")),
+                acceptable_extensions=[],
                 collection_type=state.get("collection_type"),
                 parameter_type=state.get("parameter_type"),
                 optional=bool(state.get("optional", False)),
@@ -122,11 +123,12 @@ def _make_slot(
     label: str,
     input_type: str,
     accepted_formats: list,
+    acceptable_extensions: list,
     collection_type: str | None,
     parameter_type: str | None,
     optional: bool,
 ) -> dict[str, Any]:
-    """Build the 9-key slot contract dict shared by both normalizers."""
+    """Build the 10-key slot contract dict shared by both normalizers."""
     return {
         "step_index": step_index,
         "step_uuid": step_uuid,
@@ -134,6 +136,7 @@ def _make_slot(
         "input_type": input_type,
         "src": _SRC_MAP[input_type],
         "accepted_formats": accepted_formats,
+        "acceptable_extensions": acceptable_extensions,
         "collection_type": collection_type,
         "parameter_type": parameter_type,
         "optional": optional,
@@ -189,6 +192,7 @@ def normalize_run_model(run_dict: dict[str, Any]) -> list[dict[str, Any]]:
                 label=label,
                 input_type=input_type,
                 accepted_formats=_as_list(param.get("extensions")),
+                acceptable_extensions=_as_list(param.get("acceptable_extensions")),
                 collection_type=ctype,
                 parameter_type=param.get("parameter_type") or step.get("parameter_type"),
                 optional=bool(param.get("optional", False)),
@@ -243,6 +247,19 @@ def _collection_type_compatible(supplied: str | None, required: str | None) -> b
     # map-over: a list:paired collection can feed a 'paired' (or 'list:paired') slot.
     # Compare colon-delimited segments, not a raw string suffix.
     return supplied.split(":")[-1] == required or supplied.endswith(":" + required)
+
+
+def _ext_accepted(supplied_ext: str, slot: dict[str, Any], mapping: dict[str, Any]) -> bool:
+    """True if a dataset of supplied_ext is acceptable for this slot.
+
+    Prefer Galaxy's own converter+subclass-aware acceptable_extensions (exact GUI
+    parity, available from style=run); fall back to subclass closure on the
+    declared accepted_formats (the .ga path, which lacks the converter set).
+    """
+    acc = slot.get("acceptable_extensions") or []
+    if acc:
+        return supplied_ext in acc
+    return subtype_satisfies(supplied_ext, slot["accepted_formats"], mapping)
 
 
 def validate_inputs(
@@ -328,7 +345,7 @@ def validate_inputs(
                 )
                 continue
             ext = value.get("ext")
-            if ext and not subtype_satisfies(ext, slot["accepted_formats"], mapping):
+            if ext and not _ext_accepted(ext, slot, mapping):
                 rejects.append(
                     {
                         "step_index": slot["step_index"],
@@ -375,7 +392,7 @@ def validate_inputs(
                 )
                 continue
             for el_ext in value.get("element_extensions") or []:
-                if not subtype_satisfies(el_ext, slot["accepted_formats"], mapping):
+                if not _ext_accepted(el_ext, slot, mapping):
                     rejects.append(
                         {
                             "step_index": slot["step_index"],
@@ -418,9 +435,10 @@ def build_workflow_input_template(
     step_index, the per-slot constraint summary, the invoke key hint, and any
     legacy warnings.
     """
+    display_slots = [{k: v for k, v in s.items() if k != "acceptable_extensions"} for s in slots]
     return {
         "inputs_template": {str(s["step_index"]): _placeholder_for(s) for s in slots},
-        "slots": slots,
+        "slots": display_slots,
         "inputs_by": "step_index|step_uuid",
         "warnings": warnings or [],
     }

--- a/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
@@ -1,0 +1,35 @@
+"""Pure helpers for workflow input templates and invoke-time validation.
+
+No bioblend client, no network, no global state -- every function is a pure
+function of its arguments so it is trivially unit-testable. The I/O wiring
+(fetching style=run / .ga / datatypes via a Galaxy client, registering MCP
+tools) lives in server.py. Mirrors tool_inputs.py.
+"""
+
+from typing import Any
+
+
+def subtype_satisfies(supplied_ext: str, accepted_exts: list[str], mapping: dict[str, Any]) -> bool:
+    """True if a dataset of ``supplied_ext`` is acceptable where ``accepted_exts`` are required.
+
+    ``accepted_exts == []`` means the slot accepts any datatype. Uses Galaxy's
+    datatype class hierarchy: supplied satisfies accepted if some accepted
+    extension's class is in the supplied extension's class ancestry (so ``bed``
+    satisfies ``tabular``). Unknown supplied/accepted extensions are treated
+    permissively -- we only reject a *provable* mismatch.
+    """
+    if not accepted_exts:
+        return True
+    ext_to_class = mapping.get("ext_to_class_name", {})
+    class_to_classes = mapping.get("class_to_classes", {})
+    supplied_class = ext_to_class.get(supplied_ext)
+    if supplied_class is None:
+        return True  # cannot prove a mismatch for an unknown extension
+    ancestry = class_to_classes.get(supplied_class, {})
+    for accepted in accepted_exts:
+        accepted_class = ext_to_class.get(accepted)
+        if accepted_class is None:
+            return True  # unknown accepted extension -> don't claim a mismatch
+        if accepted_class == supplied_class or accepted_class in ancestry:
+            return True
+    return False

--- a/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
@@ -6,7 +6,29 @@ function of its arguments so it is trivially unit-testable. The I/O wiring
 tools) lives in server.py. Mirrors tool_inputs.py.
 """
 
+import json
 from typing import Any
+
+_INPUT_TYPE_MAP = {
+    "data_input": "data",
+    "data_collection_input": "data_collection",
+    "parameter_input": "parameter",
+}
+_SRC_MAP = {"data": "hda", "data_collection": "hdca", "parameter": None}
+_FALLBACK_LABEL = {
+    "data": "Input dataset",
+    "data_collection": "Input dataset collection",
+    "parameter": "Input parameter",
+}
+
+
+def _coerce_state(tool_state: Any) -> dict[str, Any]:
+    if isinstance(tool_state, str):
+        try:
+            return json.loads(tool_state)
+        except (ValueError, TypeError):
+            return {}
+    return tool_state if isinstance(tool_state, dict) else {}
 
 
 def subtype_satisfies(supplied_ext: str, accepted_exts: list[str], mapping: dict[str, Any]) -> bool:
@@ -33,3 +55,36 @@ def subtype_satisfies(supplied_ext: str, accepted_exts: list[str], mapping: dict
         if accepted_class == supplied_class or accepted_class in ancestry:
             return True
     return False
+
+
+def normalize_ga_steps(definition: dict[str, Any]) -> list[dict[str, Any]]:
+    """Normalize a .ga / IWC-manifest workflow ``definition`` into input slots.
+
+    Reads ``definition["steps"]`` (dict keyed by string order_index), keeps only
+    data_input / data_collection_input / parameter_input steps, and parses each
+    step's ``tool_state`` for the declared constraints. Absent ``format`` means
+    "no restriction" (empty accepted_formats).
+    """
+    steps = definition.get("steps", {})
+    slots: list[dict[str, Any]] = []
+    for key, step in sorted(steps.items(), key=lambda kv: int(kv[0])):
+        input_type = _INPUT_TYPE_MAP.get(step.get("type", ""))
+        if input_type is None:
+            continue
+        index = int(key)
+        state = _coerce_state(step.get("tool_state"))
+        label = step.get("label") or f"{_FALLBACK_LABEL[input_type]} (step {index})"
+        slots.append(
+            {
+                "step_index": index,
+                "step_uuid": step.get("uuid"),
+                "label": label,
+                "input_type": input_type,
+                "src": _SRC_MAP[input_type],
+                "accepted_formats": list(state.get("format") or []),
+                "collection_type": state.get("collection_type"),
+                "parameter_type": state.get("parameter_type"),
+                "optional": bool(state.get("optional", False)),
+            }
+        )
+    return slots

--- a/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
@@ -9,6 +9,26 @@ tools) lives in server.py. Mirrors tool_inputs.py.
 import json
 from typing import Any
 
+
+def _safe_int(value: Any, default: int | None = None) -> int | None:
+    """Best-effort int coercion; returns ``default`` instead of raising."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_list(value: Any) -> list:
+    """Coerce a possibly-scalar field to a list. A bare string becomes a single-element list."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+_SORT_SENTINEL = 10**9  # sorts non-numeric step keys to the end without crashing
+
 _INPUT_TYPE_MAP = {
     "data_input": "data",
     "data_collection_input": "data_collection",
@@ -67,27 +87,57 @@ def normalize_ga_steps(definition: dict[str, Any]) -> list[dict[str, Any]]:
     """
     steps = definition.get("steps", {})
     slots: list[dict[str, Any]] = []
-    for key, step in sorted(steps.items(), key=lambda kv: int(kv[0])):
+    # Sort numeric keys first (ascending), then non-numeric keys at the end.
+    # Non-numeric keys are skipped below; the sentinel just keeps sort() from crashing.
+    for key, step in sorted(
+        steps.items(), key=lambda kv: (_safe_int(kv[0], _SORT_SENTINEL), kv[0])
+    ):
+        index = _safe_int(key)
+        if index is None:
+            continue  # non-numeric key -- skip; .ga files should never have these
         input_type = _INPUT_TYPE_MAP.get(step.get("type", ""))
         if input_type is None:
             continue
-        index = int(key)
         state = _coerce_state(step.get("tool_state"))
         label = step.get("label") or f"{_FALLBACK_LABEL[input_type]} (step {index})"
         slots.append(
-            {
-                "step_index": index,
-                "step_uuid": step.get("uuid"),
-                "label": label,
-                "input_type": input_type,
-                "src": _SRC_MAP[input_type],
-                "accepted_formats": list(state.get("format") or []),
-                "collection_type": state.get("collection_type"),
-                "parameter_type": state.get("parameter_type"),
-                "optional": bool(state.get("optional", False)),
-            }
+            _make_slot(
+                step_index=index,
+                step_uuid=step.get("uuid"),
+                label=label,
+                input_type=input_type,
+                accepted_formats=_as_list(state.get("format")),
+                collection_type=state.get("collection_type"),
+                parameter_type=state.get("parameter_type"),
+                optional=bool(state.get("optional", False)),
+            )
         )
     return slots
+
+
+def _make_slot(
+    *,
+    step_index: int,
+    step_uuid: str | None,
+    label: str,
+    input_type: str,
+    accepted_formats: list,
+    collection_type: str | None,
+    parameter_type: str | None,
+    optional: bool,
+) -> dict[str, Any]:
+    """Build the 9-key slot contract dict shared by both normalizers."""
+    return {
+        "step_index": step_index,
+        "step_uuid": step_uuid,
+        "label": label,
+        "input_type": input_type,
+        "src": _SRC_MAP[input_type],
+        "accepted_formats": accepted_formats,
+        "collection_type": collection_type,
+        "parameter_type": parameter_type,
+        "optional": optional,
+    }
 
 
 # style=run step "step_type" -> our input_type. Galaxy uses the same
@@ -101,7 +151,10 @@ def normalize_run_model(run_dict: dict[str, Any]) -> list[dict[str, Any]]:
     """
     raw_steps = run_dict.get("steps")
     if isinstance(raw_steps, dict):
-        step_iter = [raw_steps[k] for k in sorted(raw_steps, key=lambda k: int(k))]
+        # non-numeric keys get sorted to the end and skipped below
+        step_iter = [
+            raw_steps[k] for k in sorted(raw_steps, key=lambda k: (_safe_int(k, _SORT_SENTINEL), k))
+        ]
     else:
         step_iter = list(raw_steps or [])
     slots: list[dict[str, Any]] = []
@@ -109,7 +162,12 @@ def normalize_run_model(run_dict: dict[str, Any]) -> list[dict[str, Any]]:
         input_type = _INPUT_TYPE_MAP.get(step.get("step_type") or step.get("type", ""))
         if input_type is None:
             continue
-        index = int(step.get("step_index", step.get("order_index", step.get("id"))))
+        # style=run can expose step_index, order_index, or id; all three may be absent
+        # or may be a hash string on unusual exports -- skip rather than crash.
+        raw_idx = step.get("step_index", step.get("order_index", step.get("id")))
+        index = _safe_int(raw_idx)
+        if index is None:
+            continue
         # The run model nests the actual param under "inputs"[0] for input steps.
         param = (step.get("inputs") or [{}])[0]
         ctype = param.get("collection_type")
@@ -122,18 +180,19 @@ def normalize_run_model(run_dict: dict[str, Any]) -> list[dict[str, Any]]:
             or param.get("label")
             or f"{_FALLBACK_LABEL[input_type]} (step {index})"
         )
+        # parameter_type: style=run puts it on param first, then step. The .ga path
+        # reads it only from tool_state -- different source schemas, intentional asymmetry.
         slots.append(
-            {
-                "step_index": index,
-                "step_uuid": step.get("uuid"),
-                "label": label,
-                "input_type": input_type,
-                "src": _SRC_MAP[input_type],
-                "accepted_formats": list(param.get("extensions") or []),
-                "collection_type": ctype,
-                "parameter_type": param.get("parameter_type") or step.get("parameter_type"),
-                "optional": bool(param.get("optional", False)),
-            }
+            _make_slot(
+                step_index=index,
+                step_uuid=step.get("uuid"),
+                label=label,
+                input_type=input_type,
+                accepted_formats=_as_list(param.get("extensions")),
+                collection_type=ctype,
+                parameter_type=param.get("parameter_type") or step.get("parameter_type"),
+                optional=bool(param.get("optional", False)),
+            )
         )
     return slots
 
@@ -155,7 +214,10 @@ def find_legacy_warnings(definition: dict[str, Any]) -> list[dict[str, str]]:
     and are NOT flagged.
     """
     warnings: list[dict[str, str]] = []
-    for key, step in sorted(definition.get("steps", {}).items(), key=lambda kv: int(kv[0])):
+    for key, step in sorted(
+        definition.get("steps", {}).items(),
+        key=lambda kv: (_safe_int(kv[0], _SORT_SENTINEL), kv[0]),
+    ):
         if step.get("type") != "tool":
             continue
         if _has_runtime_value(_coerce_state(step.get("tool_state"))):
@@ -178,8 +240,9 @@ def _collection_type_compatible(supplied: str | None, required: str | None) -> b
         return True
     if supplied == required:
         return True
-    # map-over: a list:paired can feed a 'paired' slot, etc. (suffix match)
-    return supplied.endswith(":" + required) or supplied.endswith(required)
+    # map-over: a list:paired collection can feed a 'paired' (or 'list:paired') slot.
+    # Compare colon-delimited segments, not a raw string suffix.
+    return supplied.split(":")[-1] == required or supplied.endswith(":" + required)
 
 
 def validate_inputs(
@@ -192,9 +255,25 @@ def validate_inputs(
     ``element_extensions``; parameter entries are scalars. Rejects are provable
     structural/datatype mismatches; warnings are inferred/uncertain.
     """
-    by_index = {str(s["step_index"]): s for s in slots}
     rejects: list[dict[str, Any]] = []
     warnings: list[dict[str, Any]] = []
+    # Detect duplicate step_index values before collapsing -- silent collision
+    # would validate only the last slot, hiding the schema problem.
+    seen: set[str] = set()
+    for s in slots:
+        idx = str(s["step_index"])
+        if idx in seen:
+            warnings.append(
+                {
+                    "step_index": idx,
+                    "message": (
+                        f"Workflow has multiple input slots sharing step_index {idx};"
+                        f" only one will be validated."
+                    ),
+                }
+            )
+        seen.add(idx)
+    by_index = {str(s["step_index"]): s for s in slots}
 
     for key, value in supplied.items():
         slot = by_index.get(str(key))

--- a/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
@@ -170,3 +170,155 @@ def find_legacy_warnings(definition: dict[str, Any]) -> list[dict[str, str]]:
                 }
             )
     return warnings
+
+
+def _collection_type_compatible(supplied: str | None, required: str | None) -> bool:
+    """Direct or map-over compatibility. None required == accept any shape."""
+    if not required or not supplied:
+        return True
+    if supplied == required:
+        return True
+    # map-over: a list:paired can feed a 'paired' slot, etc. (suffix match)
+    return supplied.endswith(":" + required) or supplied.endswith(required)
+
+
+def validate_inputs(
+    slots: list[dict[str, Any]],
+    supplied: dict[str, Any],
+    mapping: dict[str, Any],
+) -> dict[str, list[dict[str, Any]]]:
+    """Three-tier preflight. ``supplied`` keyed by str(step_index); data entries
+    carry ``ext``; collection entries carry ``collection_type`` and optional
+    ``element_extensions``; parameter entries are scalars. Rejects are provable
+    structural/datatype mismatches; warnings are inferred/uncertain.
+    """
+    by_index = {str(s["step_index"]): s for s in slots}
+    rejects: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+
+    for key, value in supplied.items():
+        slot = by_index.get(str(key))
+        if slot is None:
+            warnings.append(
+                {
+                    "step_index": key,
+                    "message": (
+                        f"Supplied input for step {key} has no matching workflow input slot."
+                    ),
+                }
+            )
+            continue
+        itype = slot["input_type"]
+        is_ref = isinstance(value, dict) and "src" in value
+
+        if itype == "parameter":
+            if is_ref:
+                rejects.append(
+                    {
+                        "step_index": slot["step_index"],
+                        "label": slot["label"],
+                        "reason": (
+                            "Parameter input given a dataset/collection reference;"
+                            " expected a scalar value."
+                        ),
+                    }
+                )
+            continue
+
+        if not is_ref:
+            rejects.append(
+                {
+                    "step_index": slot["step_index"],
+                    "label": slot["label"],
+                    "reason": f"{itype} input expects a {{'src','id'}} reference.",
+                }
+            )
+            continue
+
+        if itype == "data":
+            if value["src"] != "hda":
+                rejects.append(
+                    {
+                        "step_index": slot["step_index"],
+                        "label": slot["label"],
+                        "reason": (
+                            f"Slot expects a single dataset (hda);"
+                            f" got a collection ({value['src']})."
+                        ),
+                    }
+                )
+                continue
+            ext = value.get("ext")
+            if ext and not subtype_satisfies(ext, slot["accepted_formats"], mapping):
+                rejects.append(
+                    {
+                        "step_index": slot["step_index"],
+                        "label": slot["label"],
+                        "reason": (
+                            f"Dataset datatype '{ext}' is not accepted here "
+                            f"(expects: {', '.join(slot['accepted_formats'])})."
+                        ),
+                    }
+                )
+            elif not ext and slot["accepted_formats"]:
+                warnings.append(
+                    {
+                        "step_index": slot["step_index"],
+                        "message": (
+                            f"Could not determine datatype of the dataset for '{slot['label']}'; "
+                            f"slot expects {', '.join(slot['accepted_formats'])}."
+                        ),
+                    }
+                )
+
+        elif itype == "data_collection":
+            if value["src"] != "hdca":
+                rejects.append(
+                    {
+                        "step_index": slot["step_index"],
+                        "label": slot["label"],
+                        "reason": f"Slot expects a dataset collection (hdca); got {value['src']}.",
+                    }
+                )
+                continue
+            if not _collection_type_compatible(
+                value.get("collection_type"), slot["collection_type"]
+            ):
+                rejects.append(
+                    {
+                        "step_index": slot["step_index"],
+                        "label": slot["label"],
+                        "reason": (
+                            f"Collection type '{value.get('collection_type')}' is incompatible "
+                            f"with the slot's '{slot['collection_type']}'."
+                        ),
+                    }
+                )
+                continue
+            for el_ext in value.get("element_extensions") or []:
+                if not subtype_satisfies(el_ext, slot["accepted_formats"], mapping):
+                    rejects.append(
+                        {
+                            "step_index": slot["step_index"],
+                            "label": slot["label"],
+                            "reason": (
+                                f"Collection element datatype '{el_ext}' is not accepted here "
+                                f"(expects: {', '.join(slot['accepted_formats'])})."
+                            ),
+                        }
+                    )
+                    break
+
+    # warn on missing required slots (don't block -- the model may add them next call)
+    for slot in slots:
+        if not slot["optional"] and str(slot["step_index"]) not in supplied:
+            warnings.append(
+                {
+                    "step_index": slot["step_index"],
+                    "message": (
+                        f"Required input '{slot['label']}'"
+                        f" (step {slot['step_index']}) not supplied yet."
+                    ),
+                }
+            )
+    return {"rejects": rejects, "warnings": warnings}

--- a/mcp-server-galaxy-py/tests/conftest.py
+++ b/mcp-server-galaxy-py/tests/conftest.py
@@ -102,6 +102,7 @@ def mock_galaxy_instance():
 def _reset_galaxy_state():
     """Reset galaxy state for each test"""
     from galaxy_mcp.server import (
+        _DATATYPES_MAPPING_CACHE,
         _TOOL_SCHEMA_CACHE,
         _session_connections,
         galaxy_state,
@@ -111,8 +112,9 @@ def _reset_galaxy_state():
     # Clear lru_cache to prevent test pollution
     get_manifest_json.cache_clear()
 
-    # Clear schema cache to prevent cross-test pollution
+    # Clear schema caches to prevent cross-test pollution
     _TOOL_SCHEMA_CACHE.clear()
+    _DATATYPES_MAPPING_CACHE.clear()
 
     # Save original state
     original_state = galaxy_state.copy()

--- a/mcp-server-galaxy-py/tests/test_helpers.py
+++ b/mcp-server-galaxy-py/tests/test_helpers.py
@@ -32,6 +32,7 @@ from galaxy_mcp.server import (
     get_tool_run_examples,
     get_user,
     get_workflow_details,
+    get_workflow_input_template,
     import_workflow_from_iwc,
     invoke_workflow,
     list_history_ids,
@@ -78,6 +79,7 @@ get_tool_run_examples_fn = get_function(get_tool_run_examples)
 get_tool_panel_fn = get_function(get_tool_panel)
 get_user_fn = get_function(get_user)
 get_workflow_details_fn = get_function(get_workflow_details)
+get_workflow_input_template_fn = get_function(get_workflow_input_template)
 import_workflow_from_iwc_fn = get_function(import_workflow_from_iwc)
 invoke_workflow_fn = get_function(invoke_workflow)
 list_history_ids_fn = get_function(list_history_ids)
@@ -117,6 +119,7 @@ __all__ = [
     "get_tool_panel_fn",
     "get_user_fn",
     "get_workflow_details_fn",
+    "get_workflow_input_template_fn",
     "import_workflow_from_iwc_fn",
     "invoke_workflow_fn",
     "list_history_ids_fn",

--- a/mcp-server-galaxy-py/tests/test_workflow_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_inputs.py
@@ -106,6 +106,7 @@ def test_normalize_ga_steps_data_input_restricted():
         "input_type": "data",
         "src": "hda",
         "accepted_formats": ["tabular"],
+        "acceptable_extensions": [],
         "collection_type": None,
         "parameter_type": None,
         "optional": False,
@@ -153,6 +154,7 @@ def test_normalize_run_model_returns_slot_contract():
             "input_type",
             "src",
             "accepted_formats",
+            "acceptable_extensions",
             "collection_type",
             "parameter_type",
             "optional",
@@ -496,3 +498,76 @@ def test_validate_duplicate_step_index_warns():
     ]
     res = validate_inputs(dup_slots, {}, MAPPING)
     assert any("0" in w["message"] for w in res["warnings"])
+
+
+# ---------------------------------------------------------------------------
+# Converter parity: acceptable_extensions membership vs subclass closure
+# ---------------------------------------------------------------------------
+
+
+def test_validate_uses_acceptable_extensions_for_converter_parity():
+    slot = {
+        "step_index": 0,
+        "step_uuid": None,
+        "label": "counts",
+        "input_type": "data",
+        "src": "hda",
+        "accepted_formats": ["tabular"],
+        "acceptable_extensions": ["tabular", "tsv", "csv"],  # Galaxy's converter-aware set
+        "collection_type": None,
+        "parameter_type": None,
+        "optional": False,
+    }
+    # csv is NOT a Tabular subclass, but Galaxy lists it as acceptable -> must NOT reject
+    ok = validate_inputs([slot], {"0": {"src": "hda", "id": "d1", "ext": "csv"}}, MAPPING)
+    assert ok["rejects"] == []
+    # bam is not in Galaxy's accept-set -> provable reject
+    bad = validate_inputs([slot], {"0": {"src": "hda", "id": "d2", "ext": "bam"}}, MAPPING)
+    assert any(r["step_index"] == 0 for r in bad["rejects"])
+
+
+def test_validate_falls_back_to_subtype_closure_without_acceptable_extensions():
+    slot = {
+        "step_index": 0,
+        "step_uuid": None,
+        "label": "x",
+        "input_type": "data",
+        "src": "hda",
+        "accepted_formats": ["tabular"],
+        "acceptable_extensions": [],
+        "collection_type": None,
+        "parameter_type": None,
+        "optional": False,
+    }
+    # bed IS-A tabular per MAPPING -> accepted via closure
+    assert (
+        validate_inputs([slot], {"0": {"src": "hda", "id": "d1", "ext": "bed"}}, MAPPING)["rejects"]
+        == []
+    )
+    # bam is not -> rejected via closure
+    assert any(
+        r["step_index"] == 0
+        for r in validate_inputs([slot], {"0": {"src": "hda", "id": "d2", "ext": "bam"}}, MAPPING)[
+            "rejects"
+        ]
+    )
+
+
+def test_build_template_omits_acceptable_extensions_from_display_slots():
+    slots = [
+        {
+            "step_index": 0,
+            "step_uuid": None,
+            "label": "x",
+            "input_type": "data",
+            "src": "hda",
+            "accepted_formats": ["txt"],
+            "acceptable_extensions": ["txt", "csv", "tsv"],
+            "collection_type": None,
+            "parameter_type": None,
+            "optional": False,
+        }
+    ]
+    tmpl = build_workflow_input_template(slots)
+    assert "acceptable_extensions" not in tmpl["slots"][0]
+    assert tmpl["slots"][0]["accepted_formats"] == ["txt"]

--- a/mcp-server-galaxy-py/tests/test_workflow_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_inputs.py
@@ -1,4 +1,7 @@
-from galaxy_mcp.workflow_inputs import normalize_ga_steps, subtype_satisfies
+import json as _json
+from pathlib import Path
+
+from galaxy_mcp.workflow_inputs import normalize_ga_steps, normalize_run_model, subtype_satisfies
 
 # Minimal slice of /api/datatypes/types_and_mapping
 MAPPING = {
@@ -122,3 +125,33 @@ def test_normalize_ga_steps_parameter_input():
     assert s["src"] is None
     assert s["parameter_type"] == "text"
     assert s["optional"] is True
+
+
+# ---------------------------------------------------------------------------
+# Task 4: style=run normalizer (fixture-driven)
+# ---------------------------------------------------------------------------
+
+_FIXTURE = Path(__file__).parent / "testdata" / "wf_style_run_rnaseq.json"
+
+
+def test_normalize_run_model_returns_slot_contract():
+    run_dict = _json.loads(_FIXTURE.read_text())
+    slots = normalize_run_model(run_dict)
+    assert slots, "expected at least one input slot"
+    for s in slots:
+        assert set(s) == {
+            "step_index",
+            "step_uuid",
+            "label",
+            "input_type",
+            "src",
+            "accepted_formats",
+            "collection_type",
+            "parameter_type",
+            "optional",
+        }
+        assert s["input_type"] in {"data", "data_collection", "parameter"}
+        assert isinstance(s["accepted_formats"], list)
+    # step indices are ints and unique
+    idx = [s["step_index"] for s in slots]
+    assert idx == sorted(set(idx))

--- a/mcp-server-galaxy-py/tests/test_workflow_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_inputs.py
@@ -1,7 +1,12 @@
 import json as _json
 from pathlib import Path
 
-from galaxy_mcp.workflow_inputs import normalize_ga_steps, normalize_run_model, subtype_satisfies
+from galaxy_mcp.workflow_inputs import (
+    find_legacy_warnings,
+    normalize_ga_steps,
+    normalize_run_model,
+    subtype_satisfies,
+)
 
 # Minimal slice of /api/datatypes/types_and_mapping
 MAPPING = {
@@ -155,3 +160,38 @@ def test_normalize_run_model_returns_slot_contract():
     # step indices are ints and unique
     idx = [s["step_index"] for s in slots]
     assert idx == sorted(set(idx))
+
+
+# ---------------------------------------------------------------------------
+# Task 5: legacy RuntimeValue scanner
+# ---------------------------------------------------------------------------
+
+GA_LEGACY = {
+    "steps": {
+        "0": {
+            "type": "parameter_input",
+            "label": "p",
+            "tool_state": '{"parameter_type":"text"}',
+        },
+        "1": {  # tool step with an unconnected RuntimeValue -> legacy
+            "type": "tool",
+            "label": "Cut",
+            "tool_state": (
+                '{"col": {"__class__": "RuntimeValue"}, "ref": {"__class__": "ConnectedValue"}}'
+            ),
+        },
+        "2": {"type": "tool", "label": "Clean", "tool_state": '{"opt": "x"}'},
+    }
+}
+
+
+def test_find_legacy_warnings_flags_runtimevalue_not_parameter_input():
+    warns = find_legacy_warnings(GA_LEGACY)
+    joined = " ".join(w["message"] for w in warns)
+    assert "RuntimeValue" in joined
+    assert "Cut" in joined  # the offending tool step is named
+    assert "parameter_input" not in joined  # bare parameter_input is NOT flagged
+
+
+def test_find_legacy_warnings_clean_workflow_is_empty():
+    assert find_legacy_warnings({"steps": {"0": {"type": "tool", "tool_state": '{"a":1}'}}}) == []

--- a/mcp-server-galaxy-py/tests/test_workflow_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_inputs.py
@@ -6,6 +6,7 @@ from galaxy_mcp.workflow_inputs import (
     normalize_ga_steps,
     normalize_run_model,
     subtype_satisfies,
+    validate_inputs,
 )
 
 # Minimal slice of /api/datatypes/types_and_mapping
@@ -195,3 +196,89 @@ def test_find_legacy_warnings_flags_runtimevalue_not_parameter_input():
 
 def test_find_legacy_warnings_clean_workflow_is_empty():
     assert find_legacy_warnings({"steps": {"0": {"type": "tool", "tool_state": '{"a":1}'}}}) == []
+
+
+# ---------------------------------------------------------------------------
+# Task 6: three-tier validator
+# ---------------------------------------------------------------------------
+
+SLOTS = [
+    {
+        "step_index": 0,
+        "step_uuid": "u0",
+        "label": "barcodes",
+        "input_type": "data",
+        "src": "hda",
+        "accepted_formats": ["tabular"],
+        "collection_type": None,
+        "parameter_type": None,
+        "optional": False,
+    },
+    {
+        "step_index": 1,
+        "step_uuid": "u1",
+        "label": "reads",
+        "input_type": "data_collection",
+        "src": "hdca",
+        "accepted_formats": ["fastqsanger"],
+        "collection_type": "list:paired",
+        "parameter_type": None,
+        "optional": False,
+    },
+    {
+        "step_index": 2,
+        "step_uuid": "u2",
+        "label": "anyfile",
+        "input_type": "data",
+        "src": "hda",
+        "accepted_formats": [],
+        "collection_type": None,
+        "parameter_type": None,
+        "optional": True,
+    },
+]
+MAP = MAPPING  # from Task 1
+
+
+def test_validate_hard_rejects_wrong_datatype():
+    supplied = {"0": {"src": "hda", "id": "d1", "ext": "bam"}}  # bam into a tabular slot
+    res = validate_inputs(SLOTS, supplied, MAP)
+    assert any(r["step_index"] == 0 for r in res["rejects"])
+
+
+def test_validate_accepts_subtype():
+    supplied = {"0": {"src": "hda", "id": "d1", "ext": "bed"}}  # bed is-a tabular
+    res = validate_inputs(SLOTS, supplied, MAP)
+    assert res["rejects"] == []
+
+
+def test_validate_hard_rejects_wrong_src_kind():
+    supplied = {"0": {"src": "hdca", "id": "c1", "collection_type": "list"}}
+    res = validate_inputs(SLOTS, supplied, MAP)
+    assert any(r["step_index"] == 0 and "collection" in r["reason"].lower() for r in res["rejects"])
+
+
+def test_validate_hard_rejects_wrong_collection_type():
+    supplied = {
+        "1": {
+            "src": "hdca",
+            "id": "c1",
+            "collection_type": "list",
+            "element_extensions": ["fastqsanger"],
+        }
+    }
+    res = validate_inputs(SLOTS, supplied, MAP)
+    assert any(r["step_index"] == 1 for r in res["rejects"])
+
+
+def test_validate_generic_data_slot_does_not_reject():
+    supplied = {"2": {"src": "hda", "id": "d9", "ext": "bam"}}  # slot accepts any
+    res = validate_inputs(SLOTS, supplied, MAP)
+    assert res["rejects"] == []
+
+
+def test_validate_unknown_step_index_is_warned_not_rejected():
+    supplied = {"99": {"src": "hda", "id": "dx", "ext": "bam"}}
+    res = validate_inputs(SLOTS, supplied, MAP)
+    assert res["rejects"] == []
+    assert any("99" in w["message"] for w in res["warnings"])

--- a/mcp-server-galaxy-py/tests/test_workflow_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_inputs.py
@@ -2,6 +2,7 @@ import json as _json
 from pathlib import Path
 
 from galaxy_mcp.workflow_inputs import (
+    build_workflow_input_template,
     find_legacy_warnings,
     normalize_ga_steps,
     normalize_run_model,
@@ -282,3 +283,20 @@ def test_validate_unknown_step_index_is_warned_not_rejected():
     res = validate_inputs(SLOTS, supplied, MAP)
     assert res["rejects"] == []
     assert any("99" in w["message"] for w in res["warnings"])
+
+
+# ---------------------------------------------------------------------------
+# Task 7: template builder
+# ---------------------------------------------------------------------------
+
+
+def test_build_template_skeleton_and_slots():
+    tmpl = build_workflow_input_template(SLOTS, warnings=[{"kind": "x", "message": "m"}])
+    assert tmpl["inputs_by"] == "step_index|step_uuid"
+    # placeholders keyed by step_index
+    assert tmpl["inputs_template"]["0"] == {"src": "hda", "id": "<dataset_id>"}
+    assert tmpl["inputs_template"]["1"] == {"src": "hdca", "id": "<collection_id>"}
+    # slot summary carries the human-facing constraints
+    barcodes = next(s for s in tmpl["slots"] if s["step_index"] == 0)
+    assert barcodes["accepted_formats"] == ["tabular"]
+    assert tmpl["warnings"][0]["message"] == "m"

--- a/mcp-server-galaxy-py/tests/test_workflow_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_inputs.py
@@ -300,3 +300,199 @@ def test_build_template_skeleton_and_slots():
     barcodes = next(s for s in tmpl["slots"] if s["step_index"] == 0)
     assert barcodes["accepted_formats"] == ["tabular"]
     assert tmpl["warnings"][0]["message"] == "m"
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: _collection_type_compatible -- segment comparison, not raw suffix
+# ---------------------------------------------------------------------------
+
+from galaxy_mcp.workflow_inputs import _collection_type_compatible  # noqa: E402
+
+
+def test_collection_type_compatible_list_does_not_satisfy_paired():
+    # "list" does not end with ":paired"; the bare-suffix check wrongly passed before the fix
+    assert _collection_type_compatible("list", "paired") is False
+
+
+def test_collection_type_compatible_raw_suffix_regression():
+    # "list" ends with "st" as a raw string -- must be False
+    assert _collection_type_compatible("list", "st") is False
+
+
+def test_collection_type_compatible_map_over_list_paired():
+    # list:paired can feed a 'paired' slot via map-over
+    assert _collection_type_compatible("list:paired", "paired") is True
+
+
+def test_collection_type_compatible_exact():
+    assert _collection_type_compatible("paired", "paired") is True
+
+
+def test_collection_type_compatible_none_required():
+    assert _collection_type_compatible(None, "list") is True
+
+
+def test_collection_type_compatible_none_supplied():
+    assert _collection_type_compatible("list", None) is True
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: normalize_run_model -- missing/non-numeric step index
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_run_model_skips_steps_with_no_index():
+    """Steps missing all index keys AND steps with a hash-string id must not raise."""
+    run_dict = {
+        "steps": [
+            # well-formed input step
+            {
+                "step_type": "data_input",
+                "step_index": 0,
+                "uuid": "u0",
+                "step_label": "mydata",
+                "inputs": [{"extensions": ["bam"], "optional": False}],
+            },
+            # no step_index, no order_index, no id at all
+            {
+                "step_type": "data_input",
+                "uuid": "u-bad",
+                "step_label": "orphan",
+                "inputs": [{}],
+            },
+            # id is a hash string (Galaxy sometimes uses UUIDs as step ids)
+            {
+                "step_type": "data_input",
+                "id": "abc123def",
+                "uuid": "u-hash",
+                "step_label": "hashstep",
+                "inputs": [{}],
+            },
+        ]
+    }
+    slots = normalize_run_model(run_dict)
+    # only the well-formed slot survives; the two bad ones are skipped
+    assert len(slots) == 1
+    assert slots[0]["step_index"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: normalize_ga_steps / find_legacy_warnings -- non-numeric step keys
+# ---------------------------------------------------------------------------
+
+GA_DEF_NONNUMERIC = {
+    "steps": {
+        "0": {
+            "type": "data_input",
+            "label": "good_step",
+            "uuid": "u0",
+            "tool_state": '{"optional": false, "format": ["bam"]}',
+        },
+        # non-numeric key -- should be skipped gracefully
+        "x": {
+            "type": "data_input",
+            "label": "bad_key_step",
+            "uuid": "ux",
+            "tool_state": '{"optional": false}',
+        },
+    }
+}
+
+GA_LEGACY_NONNUMERIC = {
+    "steps": {
+        "0": {
+            "type": "tool",
+            "label": "NormalTool",
+            "tool_state": '{"col": {"__class__": "RuntimeValue"}}',
+        },
+        "x": {
+            "type": "tool",
+            "label": "WeirdKeyTool",
+            "tool_state": '{"val": 1}',
+        },
+    }
+}
+
+
+def test_normalize_ga_steps_nonnumeric_key_does_not_raise():
+    slots = normalize_ga_steps(GA_DEF_NONNUMERIC)
+    # the numeric step survives; the 'x' key is skipped
+    assert len(slots) == 1
+    assert slots[0]["step_index"] == 0
+
+
+def test_find_legacy_warnings_nonnumeric_key_does_not_raise():
+    # should not raise; the tool step with key "0" is flagged; "x" key is handled gracefully
+    warns = find_legacy_warnings(GA_LEGACY_NONNUMERIC)
+    assert any("NormalTool" in w["message"] for w in warns)
+
+
+# ---------------------------------------------------------------------------
+# Fix 4: format / extensions as a bare string
+# ---------------------------------------------------------------------------
+
+GA_DEF_FORMAT_STRING = {
+    "steps": {
+        "0": {
+            "type": "data_input",
+            "label": "bamfile",
+            "uuid": "u0",
+            "tool_state": '{"optional": false, "format": "bam"}',
+        },
+    }
+}
+
+
+def test_normalize_ga_steps_bare_string_format_is_single_element_list():
+    slots = normalize_ga_steps(GA_DEF_FORMAT_STRING)
+    assert slots[0]["accepted_formats"] == ["bam"]
+
+
+def test_normalize_run_model_bare_string_extensions_is_single_element_list():
+    run_dict = {
+        "steps": [
+            {
+                "step_type": "data_input",
+                "step_index": 0,
+                "uuid": "u0",
+                "step_label": "bamfile",
+                "inputs": [{"extensions": "bam", "optional": False}],
+            }
+        ]
+    }
+    slots = normalize_run_model(run_dict)
+    assert slots[0]["accepted_formats"] == ["bam"]
+
+
+# ---------------------------------------------------------------------------
+# Fix 5: duplicate step_index produces a warning
+# ---------------------------------------------------------------------------
+
+
+def test_validate_duplicate_step_index_warns():
+    dup_slots = [
+        {
+            "step_index": 0,
+            "step_uuid": "ua",
+            "label": "first",
+            "input_type": "data",
+            "src": "hda",
+            "accepted_formats": [],
+            "collection_type": None,
+            "parameter_type": None,
+            "optional": True,
+        },
+        {
+            "step_index": 0,
+            "step_uuid": "ub",
+            "label": "second",
+            "input_type": "data",
+            "src": "hda",
+            "accepted_formats": [],
+            "collection_type": None,
+            "parameter_type": None,
+            "optional": True,
+        },
+    ]
+    res = validate_inputs(dup_slots, {}, MAPPING)
+    assert any("0" in w["message"] for w in res["warnings"])

--- a/mcp-server-galaxy-py/tests/test_workflow_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_inputs.py
@@ -1,4 +1,4 @@
-from galaxy_mcp.workflow_inputs import subtype_satisfies
+from galaxy_mcp.workflow_inputs import normalize_ga_steps, subtype_satisfies
 
 # Minimal slice of /api/datatypes/types_and_mapping
 MAPPING = {
@@ -43,3 +43,82 @@ def test_subtype_satisfies_rejects_unrelated():
 def test_subtype_satisfies_unknown_supplied_ext_is_permissive():
     # unknown extension -> cannot prove a mismatch -> do not reject
     assert subtype_satisfies("mystery", ["bam"], MAPPING) is True
+
+
+# ---------------------------------------------------------------------------
+# Task 3: .ga / manifest normalizer
+# ---------------------------------------------------------------------------
+
+GA_DEF = {
+    "steps": {
+        "0": {  # restricted data input
+            "type": "data_input",
+            "label": "barcodes",
+            "uuid": "u0",
+            "tool_state": '{"optional": false, "format": ["tabular"], "tag": ""}',
+        },
+        "1": {  # unrestricted data input (format absent)
+            "type": "data_input",
+            "label": None,
+            "uuid": "u1",
+            "tool_state": '{"optional": false, "tag": ""}',
+        },
+        "2": {  # collection input
+            "type": "data_collection_input",
+            "label": "reads",
+            "uuid": "u2",
+            "tool_state": (
+                '{"optional": false, "format": ["fastqsanger"], "collection_type": "list:paired"}'
+            ),
+        },
+        "3": {  # scalar parameter input
+            "type": "parameter_input",
+            "label": "strandedness",
+            "uuid": "u3",
+            "tool_state": '{"parameter_type": "text", "optional": true}',
+        },
+        "4": {"type": "tool", "label": "FastQC", "tool_state": "{}"},  # ignored
+    }
+}
+
+
+def test_normalize_ga_steps_extracts_only_input_slots():
+    slots = normalize_ga_steps(GA_DEF)
+    assert [s["step_index"] for s in slots] == [0, 1, 2, 3]
+
+
+def test_normalize_ga_steps_data_input_restricted():
+    s = normalize_ga_steps(GA_DEF)[0]
+    assert s == {
+        "step_index": 0,
+        "step_uuid": "u0",
+        "label": "barcodes",
+        "input_type": "data",
+        "src": "hda",
+        "accepted_formats": ["tabular"],
+        "collection_type": None,
+        "parameter_type": None,
+        "optional": False,
+    }
+
+
+def test_normalize_ga_steps_unrestricted_data_input_has_empty_formats_and_fallback_label():
+    s = normalize_ga_steps(GA_DEF)[1]
+    assert s["accepted_formats"] == []
+    assert s["label"] == "Input dataset (step 1)"
+
+
+def test_normalize_ga_steps_collection_input():
+    s = normalize_ga_steps(GA_DEF)[2]
+    assert s["input_type"] == "data_collection"
+    assert s["src"] == "hdca"
+    assert s["collection_type"] == "list:paired"
+    assert s["accepted_formats"] == ["fastqsanger"]
+
+
+def test_normalize_ga_steps_parameter_input():
+    s = normalize_ga_steps(GA_DEF)[3]
+    assert s["input_type"] == "parameter"
+    assert s["src"] is None
+    assert s["parameter_type"] == "text"
+    assert s["optional"] is True

--- a/mcp-server-galaxy-py/tests/test_workflow_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_inputs.py
@@ -1,0 +1,45 @@
+from galaxy_mcp.workflow_inputs import subtype_satisfies
+
+# Minimal slice of /api/datatypes/types_and_mapping
+MAPPING = {
+    "ext_to_class_name": {
+        "bam": "galaxy.datatypes.binary.Bam",
+        "tabular": "galaxy.datatypes.tabular.Tabular",
+        "bed": "galaxy.datatypes.interval.Bed",
+        "fastqsanger": "galaxy.datatypes.sequence.FastqSanger",
+    },
+    # class -> its ancestor classes (membership-tested; dict per live API)
+    "class_to_classes": {
+        "galaxy.datatypes.binary.Bam": {"galaxy.datatypes.binary.Bam": True},
+        "galaxy.datatypes.interval.Bed": {
+            "galaxy.datatypes.interval.Bed": True,
+            "galaxy.datatypes.tabular.Tabular": True,
+        },
+        "galaxy.datatypes.sequence.FastqSanger": {
+            "galaxy.datatypes.sequence.FastqSanger": True,
+        },
+    },
+}
+
+
+def test_subtype_satisfies_empty_accepts_anything():
+    assert subtype_satisfies("bam", [], MAPPING) is True
+
+
+def test_subtype_satisfies_exact_match():
+    assert subtype_satisfies("bam", ["bam"], MAPPING) is True
+
+
+def test_subtype_satisfies_subclass():
+    # bed is-a tabular
+    assert subtype_satisfies("bed", ["tabular"], MAPPING) is True
+
+
+def test_subtype_satisfies_rejects_unrelated():
+    # bam is not fastqsanger/tabular
+    assert subtype_satisfies("bam", ["fastqsanger", "tabular"], MAPPING) is False
+
+
+def test_subtype_satisfies_unknown_supplied_ext_is_permissive():
+    # unknown extension -> cannot prove a mismatch -> do not reject
+    assert subtype_satisfies("mystery", ["bam"], MAPPING) is True

--- a/mcp-server-galaxy-py/tests/test_workflow_operations.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_operations.py
@@ -2,9 +2,14 @@
 Test workflow-related operations
 """
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
+
+from galaxy_mcp.server import (
+    _DATATYPES_MAPPING_CACHE,
+    _get_datatypes_mapping,
+)
 
 from .test_helpers import (
     cancel_workflow_invocation_fn,
@@ -362,3 +367,25 @@ class TestWorkflowOperations:
         with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
             with pytest.raises(ValueError, match="Cancel workflow invocation failed"):
                 cancel_workflow_invocation_fn("invalid_invocation")
+
+
+# ---------------------------------------------------------------------------
+# Task 8: cached datatypes-mapping fetch
+# ---------------------------------------------------------------------------
+
+
+def test_get_datatypes_mapping_caches_per_base_url():
+    _DATATYPES_MAPPING_CACHE.clear()
+    gi = Mock()
+    gi.base_url = "https://g.example/api"
+    gi.url = "https://g.example/api"
+    resp = Mock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "datatypes_mapping": {"ext_to_class_name": {"bam": "B"}, "class_to_classes": {}}
+    }
+    gi.make_get_request.return_value = resp
+    m1 = _get_datatypes_mapping(gi)
+    _ = _get_datatypes_mapping(gi)
+    assert m1["ext_to_class_name"]["bam"] == "B"
+    assert gi.make_get_request.call_count == 1  # second call served from cache

--- a/mcp-server-galaxy-py/tests/test_workflow_operations.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_operations.py
@@ -10,14 +10,15 @@ from galaxy_mcp.server import (
     _DATATYPES_MAPPING_CACHE,
     _get_datatypes_mapping,
     _resolve_workflow_slots,
+    galaxy_state,
 )
 
 from .test_helpers import (
     cancel_workflow_invocation_fn,
-    galaxy_state,
     get_invocations_fn,
     get_iwc_workflows_fn,
     get_workflow_details_fn,
+    get_workflow_input_template_fn,
     import_workflow_from_iwc_fn,
     invoke_workflow_fn,
     list_workflows_fn,
@@ -439,3 +440,32 @@ def test_resolve_slots_falls_back_to_ga_on_missing_tools_500():
     slots, provenance = _resolve_workflow_slots(gi, "wfid")
     assert provenance == "ga-fallback"
     assert slots[0]["accepted_formats"] == ["tabular"]
+
+
+# ---------------------------------------------------------------------------
+# Task 10: get_workflow_input_template MCP tool
+# ---------------------------------------------------------------------------
+
+
+def test_get_workflow_input_template_tool(mock_galaxy_instance):
+    mock_galaxy_instance.url = "https://g/api"
+    run_resp = Mock()
+    run_resp.status_code = 200
+    run_resp.json.return_value = {
+        "steps": [
+            {
+                "step_type": "data_input",
+                "step_index": 0,
+                "step_label": "barcodes",
+                "inputs": [{"extensions": ["tabular"], "optional": False}],
+            }
+        ]
+    }
+    mock_galaxy_instance.make_get_request.return_value = run_resp
+    mock_galaxy_instance.workflows.export_workflow_dict.return_value = {"steps": {}}
+    with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+        result = get_workflow_input_template_fn("wfid")
+    assert result.success is True
+    assert result.data["inputs_by"] == "step_index|step_uuid"
+    assert result.data["inputs_template"]["0"] == {"src": "hda", "id": "<dataset_id>"}
+    assert result.data["slots"][0]["label"] == "barcodes"

--- a/mcp-server-galaxy-py/tests/test_workflow_operations.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_operations.py
@@ -9,6 +9,7 @@ import pytest
 from galaxy_mcp.server import (
     _DATATYPES_MAPPING_CACHE,
     _get_datatypes_mapping,
+    _resolve_workflow_slots,
 )
 
 from .test_helpers import (
@@ -389,3 +390,52 @@ def test_get_datatypes_mapping_caches_per_base_url():
     _ = _get_datatypes_mapping(gi)
     assert m1["ext_to_class_name"]["bam"] == "B"
     assert gi.make_get_request.call_count == 1  # second call served from cache
+
+
+# ---------------------------------------------------------------------------
+# Task 9: slot resolver
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_slots_uses_style_run_when_ok():
+    gi = Mock()
+    gi.url = "https://g/api"
+    resp = Mock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "steps": [
+            {
+                "step_type": "data_input",
+                "step_index": 0,
+                "step_label": "barcodes",
+                "inputs": [{"extensions": ["tabular"], "optional": False}],
+            }
+        ]
+    }
+    gi.make_get_request.return_value = resp
+    slots, provenance = _resolve_workflow_slots(gi, "wfid")
+    assert provenance == "style=run"
+    assert slots[0]["accepted_formats"] == ["tabular"]
+    assert slots[0]["label"] == "barcodes"
+
+
+def test_resolve_slots_falls_back_to_ga_on_missing_tools_500():
+    gi = Mock()
+    gi.url = "https://g/api"
+    run_resp = Mock()
+    run_resp.status_code = 500
+    run_resp.text = "missing tools"
+    gi.make_get_request.return_value = run_resp
+    gi.workflows.export_workflow_dict.return_value = {
+        "steps": {
+            "0": {
+                "type": "data_input",
+                "label": "barcodes",
+                "uuid": "u0",
+                "tool_state": '{"format": ["tabular"]}',
+            }
+        }
+    }
+    slots, provenance = _resolve_workflow_slots(gi, "wfid")
+    assert provenance == "ga-fallback"
+    assert slots[0]["accepted_formats"] == ["tabular"]

--- a/mcp-server-galaxy-py/tests/test_workflow_operations.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_operations.py
@@ -546,3 +546,52 @@ def test_invoke_proceeds_for_valid_datatype(mock_galaxy_instance):
         )
     assert result.success is True
     mock_galaxy_instance.workflows.invoke_workflow.assert_called_once()
+
+
+def test_invoke_reject_message_is_clean_single_slot_dump(mock_galaxy_instance):
+    """Rejected invoke should produce a clean, single slot dump -- not double-wrapped."""
+    _DATATYPES_MAPPING_CACHE.clear()
+    mock_galaxy_instance.url = "https://g/api"
+    mock_galaxy_instance.base_url = "https://g"
+    mock_galaxy_instance.make_get_request.side_effect = _make_get_dispatch(
+        _run_resp_barcodes_tabular()
+    )
+    mock_galaxy_instance.workflows.export_workflow_dict.return_value = {"steps": {}}
+    mock_galaxy_instance.datasets.show_dataset.return_value = {"id": "d1", "extension": "bam"}
+    with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+        with pytest.raises(ValueError) as exc:
+            invoke_workflow_fn("wfid", inputs={"0": {"src": "hda", "id": "d1"}}, history_id="h1")
+
+    msg = str(exc.value)
+    # Must mention the offending type
+    assert "bam" in msg.lower()
+    # The preflight's own slot header appears exactly once
+    assert msg.count("Expected input slots") == 1, (
+        f"'Expected input slots' should appear exactly once, got:\n{msg}"
+    )
+    # The generic outer-handler hint must NOT appear -- that means no double-wrap
+    assert "Workflow input slots:" not in msg, (
+        f"'Workflow input slots:' (outer hint) must not appear in reject message, got:\n{msg}"
+    )
+
+
+def test_invoke_reject_resolves_slots_only_once(mock_galaxy_instance):
+    """The 'download' endpoint (slot resolution) must be called only once on a reject."""
+    _DATATYPES_MAPPING_CACHE.clear()
+    mock_galaxy_instance.url = "https://g/api"
+    mock_galaxy_instance.base_url = "https://g"
+    mock_galaxy_instance.make_get_request.side_effect = _make_get_dispatch(
+        _run_resp_barcodes_tabular()
+    )
+    mock_galaxy_instance.workflows.export_workflow_dict.return_value = {"steps": {}}
+    mock_galaxy_instance.datasets.show_dataset.return_value = {"id": "d1", "extension": "bam"}
+    with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+        with pytest.raises(ValueError):
+            invoke_workflow_fn("wfid", inputs={"0": {"src": "hda", "id": "d1"}}, history_id="h1")
+
+    download_calls = [
+        c for c in mock_galaxy_instance.make_get_request.call_args_list if "download" in c.args[0]
+    ]
+    assert len(download_calls) == 1, (
+        f"Expected 1 'download' call (slot resolution), got {len(download_calls)}"
+    )

--- a/mcp-server-galaxy-py/tests/test_workflow_operations.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_operations.py
@@ -469,3 +469,80 @@ def test_get_workflow_input_template_tool(mock_galaxy_instance):
     assert result.data["inputs_by"] == "step_index|step_uuid"
     assert result.data["inputs_template"]["0"] == {"src": "hda", "id": "<dataset_id>"}
     assert result.data["slots"][0]["label"] == "barcodes"
+
+
+# ---------------------------------------------------------------------------
+# Task 11: invoke_workflow preflight + enrich-on-failure
+# ---------------------------------------------------------------------------
+
+_TINY_DT = {
+    "datatypes_mapping": {
+        "ext_to_class_name": {
+            "bam": "galaxy.datatypes.binary.Bam",
+            "tabular": "galaxy.datatypes.tabular.Tabular",
+        },
+        "class_to_classes": {
+            "galaxy.datatypes.binary.Bam": {"galaxy.datatypes.binary.Bam": True},
+            "galaxy.datatypes.tabular.Tabular": {"galaxy.datatypes.tabular.Tabular": True},
+        },
+    }
+}
+
+
+def _run_resp_barcodes_tabular():
+    r = Mock()
+    r.status_code = 200
+    r.json.return_value = {
+        "steps": [
+            {
+                "step_type": "data_input",
+                "step_index": 0,
+                "step_label": "barcodes",
+                "inputs": [{"extensions": ["tabular"], "optional": False}],
+            }
+        ]
+    }
+    return r
+
+
+def _make_get_dispatch(run_resp):
+    dt = Mock()
+    dt.status_code = 200
+    dt.json.return_value = _TINY_DT
+
+    def _dispatch(url, *args, **kwargs):
+        return dt if "types_and_mapping" in url else run_resp
+
+    return _dispatch
+
+
+def test_invoke_rejects_wrong_datatype_before_submitting(mock_galaxy_instance):
+    mock_galaxy_instance.url = "https://g/api"
+    mock_galaxy_instance.base_url = "https://g"
+    mock_galaxy_instance.make_get_request.side_effect = _make_get_dispatch(
+        _run_resp_barcodes_tabular()
+    )
+    mock_galaxy_instance.workflows.export_workflow_dict.return_value = {"steps": {}}
+    mock_galaxy_instance.datasets.show_dataset.return_value = {"id": "d1", "extension": "bam"}
+    with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+        with pytest.raises(ValueError) as exc:
+            invoke_workflow_fn("wfid", inputs={"0": {"src": "hda", "id": "d1"}}, history_id="h1")
+    assert "bam" in str(exc.value).lower()
+    mock_galaxy_instance.workflows.invoke_workflow.assert_not_called()
+
+
+def test_invoke_proceeds_for_valid_datatype(mock_galaxy_instance):
+    mock_galaxy_instance.url = "https://g/api"
+    mock_galaxy_instance.base_url = "https://g"
+    mock_galaxy_instance.make_get_request.side_effect = _make_get_dispatch(
+        _run_resp_barcodes_tabular()
+    )
+    mock_galaxy_instance.workflows.export_workflow_dict.return_value = {"steps": {}}
+    mock_galaxy_instance.datasets.show_dataset.return_value = {"id": "d1", "extension": "tabular"}
+    mock_galaxy_instance.workflows.invoke_workflow.return_value = {"id": "inv1", "state": "new"}
+    with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+        result = invoke_workflow_fn(
+            "wfid", inputs={"0": {"src": "hda", "id": "d1"}}, history_id="h1"
+        )
+    assert result.success is True
+    mock_galaxy_instance.workflows.invoke_workflow.assert_called_once()

--- a/mcp-server-galaxy-py/tests/testdata/datatypes_mapping.json
+++ b/mcp-server-galaxy-py/tests/testdata/datatypes_mapping.json
@@ -1,0 +1,142 @@
+{
+  "ext_to_class_name": {
+    "data": "galaxy.datatypes.data.Data",
+    "txt": "galaxy.datatypes.data.Text",
+    "tabular": "galaxy.datatypes.tabular.Tabular",
+    "bam": "galaxy.datatypes.binary.Bam",
+    "bed": "galaxy.datatypes.interval.Bed",
+    "fastqsanger": "galaxy.datatypes.sequence.FastqSanger",
+    "fastqsanger.gz": "galaxy.datatypes.registry.FastqSangerGz",
+    "fastq": "galaxy.datatypes.sequence.Fastq",
+    "vcf": "galaxy.datatypes.tabular.Vcf",
+    "gff": "galaxy.datatypes.interval.Gff",
+    "gff3": "galaxy.datatypes.interval.Gff3",
+    "interval": "galaxy.datatypes.interval.Interval",
+    "csv": "galaxy.datatypes.tabular.CSV",
+    "fasta": "galaxy.datatypes.sequence.Fasta",
+    "fastqillumina": "galaxy.datatypes.sequence.FastqIllumina",
+    "sam": "galaxy.datatypes.tabular.Sam",
+    "cram": "galaxy.datatypes.binary.CRAM"
+  },
+  "class_to_classes": {
+    "galaxy.datatypes.data.Text": {
+      "galaxy.datatypes.data.Data": true,
+      "galaxy.datatypes.data.Text": true
+    },
+    "galaxy.datatypes.binary.CRAM": {
+      "galaxy.datatypes.binary.Binary": true,
+      "galaxy.datatypes.data.Data": true,
+      "galaxy.datatypes.binary.CRAM": true
+    },
+    "galaxy.datatypes.interval.Gff3": {
+      "galaxy.datatypes.tabular.Tabular": true,
+      "galaxy.datatypes.interval.Gff3": true,
+      "galaxy.datatypes.tabular.TabularData": true,
+      "galaxy.datatypes.data.Data": true,
+      "galaxy.datatypes.interval.Gff": true,
+      "galaxy.datatypes.data.Text": true
+    },
+    "galaxy.datatypes.tabular.CSV": {
+      "galaxy.datatypes.tabular.CSV": true,
+      "galaxy.datatypes.tabular.TabularData": true,
+      "galaxy.datatypes.data.Data": true,
+      "galaxy.datatypes.data.Text": true,
+      "galaxy.datatypes.tabular.BaseCSV": true
+    },
+    "galaxy.datatypes.data.Data": {
+      "galaxy.datatypes.data.Data": true
+    },
+    "galaxy.datatypes.tabular.Tabular": {
+      "galaxy.datatypes.tabular.Tabular": true,
+      "galaxy.datatypes.data.Data": true,
+      "galaxy.datatypes.tabular.TabularData": true,
+      "galaxy.datatypes.data.Text": true
+    },
+    "galaxy.datatypes.sequence.FastqIllumina": {
+      "galaxy.datatypes.sequence.Sequence": true,
+      "galaxy.datatypes.data.Data": true,
+      "galaxy.datatypes.sequence.FastqIllumina": true,
+      "galaxy.datatypes.sequence.BaseFastq": true,
+      "galaxy.datatypes.sequence.Fastq": true,
+      "galaxy.datatypes.data.Text": true
+    },
+    "galaxy.datatypes.interval.Bed": {
+      "galaxy.datatypes.tabular.Tabular": true,
+      "galaxy.datatypes.interval.Interval": true,
+      "galaxy.datatypes.interval.Bed": true,
+      "galaxy.datatypes.tabular.TabularData": true,
+      "galaxy.datatypes.data.Data": true,
+      "galaxy.datatypes.data.Text": true
+    },
+    "galaxy.datatypes.binary.Bam": {
+      "galaxy.datatypes.binary.Binary": true,
+      "galaxy.datatypes.data.Data": true,
+      "galaxy.datatypes.binary.Bam": true,
+      "galaxy.datatypes.binary.CompressedArchive": true,
+      "galaxy.datatypes.binary.BamNative": true
+    },
+    "galaxy.datatypes.sequence.Fasta": {
+      "galaxy.datatypes.data.Data": true,
+      "galaxy.datatypes.sequence.Sequence": true,
+      "galaxy.datatypes.sequence.Fasta": true,
+      "galaxy.datatypes.data.Text": true
+    },
+    "galaxy.datatypes.registry.FastqSangerGz": {
+      "galaxy.datatypes.binary.Binary": true,
+      "galaxy.datatypes.sequence.Sequence": true,
+      "galaxy.datatypes.data.Data": true,
+      "galaxy.datatypes.binary.GzDynamicCompressedArchive": true,
+      "galaxy.datatypes.sequence.FastqSanger": true,
+      "galaxy.datatypes.registry.FastqSangerGz": true,
+      "galaxy.datatypes.binary.DynamicCompressedArchive": true,
+      "galaxy.datatypes.sequence.BaseFastq": true,
+      "galaxy.datatypes.sequence.Fastq": true,
+      "galaxy.datatypes.data.Text": true,
+      "galaxy.datatypes.binary.CompressedArchive": true
+    },
+    "galaxy.datatypes.sequence.Fastq": {
+      "galaxy.datatypes.sequence.Sequence": true,
+      "galaxy.datatypes.data.Data": true,
+      "galaxy.datatypes.sequence.BaseFastq": true,
+      "galaxy.datatypes.sequence.Fastq": true,
+      "galaxy.datatypes.data.Text": true
+    },
+    "galaxy.datatypes.interval.Interval": {
+      "galaxy.datatypes.tabular.Tabular": true,
+      "galaxy.datatypes.interval.Interval": true,
+      "galaxy.datatypes.tabular.TabularData": true,
+      "galaxy.datatypes.data.Data": true,
+      "galaxy.datatypes.data.Text": true
+    },
+    "galaxy.datatypes.sequence.FastqSanger": {
+      "galaxy.datatypes.sequence.Sequence": true,
+      "galaxy.datatypes.data.Data": true,
+      "galaxy.datatypes.sequence.FastqSanger": true,
+      "galaxy.datatypes.sequence.BaseFastq": true,
+      "galaxy.datatypes.sequence.Fastq": true,
+      "galaxy.datatypes.data.Text": true
+    },
+    "galaxy.datatypes.tabular.Sam": {
+      "galaxy.datatypes.tabular.Tabular": true,
+      "galaxy.datatypes.tabular.TabularData": true,
+      "galaxy.datatypes.data.Data": true,
+      "galaxy.datatypes.tabular.Sam": true,
+      "galaxy.datatypes.data.Text": true
+    },
+    "galaxy.datatypes.tabular.Vcf": {
+      "galaxy.datatypes.tabular.Tabular": true,
+      "galaxy.datatypes.tabular.BaseVcf": true,
+      "galaxy.datatypes.tabular.TabularData": true,
+      "galaxy.datatypes.data.Data": true,
+      "galaxy.datatypes.data.Text": true,
+      "galaxy.datatypes.tabular.Vcf": true
+    },
+    "galaxy.datatypes.interval.Gff": {
+      "galaxy.datatypes.tabular.Tabular": true,
+      "galaxy.datatypes.tabular.TabularData": true,
+      "galaxy.datatypes.data.Data": true,
+      "galaxy.datatypes.interval.Gff": true,
+      "galaxy.datatypes.data.Text": true
+    }
+  }
+}

--- a/mcp-server-galaxy-py/tests/testdata/wf_ga_rnaseq.json
+++ b/mcp-server-galaxy-py/tests/testdata/wf_ga_rnaseq.json
@@ -1,0 +1,480 @@
+{
+  "a_galaxy_workflow": "true",
+  "comments": [],
+  "format-version": "0.1",
+  "name": "Protein Interaction Protocol - All against All",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Target Sequence"
+        }
+      ],
+      "label": "Target Sequence",
+      "name": "Input dataset collection",
+      "outputs": [],
+      "position": {
+        "bottom": 266.5,
+        "height": 63,
+        "left": 145.5,
+        "right": 345.5,
+        "top": 203.5,
+        "width": 200,
+        "x": 145.5,
+        "y": 203.5
+      },
+      "tool_id": null,
+      "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
+      "tool_version": null,
+      "type": "data_collection_input",
+      "uuid": "541ffc1c-a670-4722-8185-858a282e161b",
+      "when": null,
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "061c621d-2220-46ed-8890-f51a135fbcff"
+        }
+      ]
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Input Sequences"
+        }
+      ],
+      "label": "Input Sequences",
+      "name": "Input dataset collection",
+      "outputs": [],
+      "position": {
+        "bottom": 357.5,
+        "height": 63,
+        "left": 145.5,
+        "right": 345.5,
+        "top": 294.5,
+        "width": 200,
+        "x": 145.5,
+        "y": 294.5
+      },
+      "tool_id": null,
+      "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
+      "tool_version": null,
+      "type": "data_collection_input",
+      "uuid": "e272d95b-7ed4-42d0-bcc3-b2dbd50e067d",
+      "when": null,
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "78057d90-a114-43f2-a9e1-08ecc3fee272"
+        }
+      ]
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "SPRING Index"
+        }
+      ],
+      "label": "SPRING Index",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "bottom": 448.5,
+        "height": 63,
+        "left": 145.5,
+        "right": 345.5,
+        "top": 385.5,
+        "width": 200,
+        "x": 145.5,
+        "y": 385.5
+      },
+      "tool_id": null,
+      "tool_state": "{\"optional\": false, \"tag\": null}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "b4641ee9-0b1c-4ac4-b841-579331073d09",
+      "when": null,
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "a197c552-3fc8-4462-8825-86c2757ad958"
+        }
+      ]
+    },
+    "3": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 3,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "HHM Index"
+        }
+      ],
+      "label": "HHM Index",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "bottom": 539.5,
+        "height": 63,
+        "left": 145.5,
+        "right": 345.5,
+        "top": 476.5,
+        "width": 200,
+        "x": 145.5,
+        "y": 476.5
+      },
+      "tool_id": null,
+      "tool_state": "{\"optional\": false, \"tag\": null}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "4c5c1022-90ce-470f-8935-d09b23ed5d05",
+      "when": null,
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "50d47a9d-2113-4553-9248-bbe67951915d"
+        }
+      ]
+    },
+    "4": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 4,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "HHM Data"
+        }
+      ],
+      "label": "HHM Data",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "bottom": 630.5,
+        "height": 63,
+        "left": 145.5,
+        "right": 345.5,
+        "top": 567.5,
+        "width": 200,
+        "x": 145.5,
+        "y": 567.5
+      },
+      "tool_id": null,
+      "tool_state": "{\"optional\": false, \"tag\": null}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "fe74b7f0-502c-4c8b-b3d2-5e781c9ad38b",
+      "when": null,
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "b9f2bff7-1657-4895-b9bd-3c608ee6f36e"
+        }
+      ]
+    },
+    "5": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 5,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "cs219 Index"
+        }
+      ],
+      "label": "cs219 Index",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "bottom": 721.5,
+        "height": 63,
+        "left": 145.5,
+        "right": 345.5,
+        "top": 658.5,
+        "width": 200,
+        "x": 145.5,
+        "y": 658.5
+      },
+      "tool_id": null,
+      "tool_state": "{\"optional\": false, \"tag\": null}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "fb79b4d3-4877-4210-8c6b-8035e8a0f260",
+      "when": null,
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "2c307ddd-5ea7-4a9d-90f1-343b7dfa89bb"
+        }
+      ]
+    },
+    "6": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 6,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "cs219 Data"
+        }
+      ],
+      "label": "cs219 Data",
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "bottom": 812.5,
+        "height": 63,
+        "left": 145.5,
+        "right": 345.5,
+        "top": 749.5,
+        "width": 200,
+        "x": 145.5,
+        "y": 749.5
+      },
+      "tool_id": null,
+      "tool_state": "{\"optional\": false, \"tag\": null}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "1f947d18-c8e0-410e-989e-b7f766c21fb5",
+      "when": null,
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "343556b7-b582-4652-a920-1d6a6ddbce4c"
+        }
+      ]
+    },
+    "7": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/guerler/hhsuite/hhsearch/0.1.0",
+      "errors": null,
+      "id": 7,
+      "input_connections": {
+        "cs219_ffdata": {
+          "id": 6,
+          "output_name": "output"
+        },
+        "cs219_ffindex": {
+          "id": 5,
+          "output_name": "output"
+        },
+        "hhm_ffdata": {
+          "id": 4,
+          "output_name": "output"
+        },
+        "hhm_ffindex": {
+          "id": 3,
+          "output_name": "output"
+        },
+        "input": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "HHsearch",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "bottom": 457.5,
+        "height": 219,
+        "left": 427.5,
+        "right": 627.5,
+        "top": 238.5,
+        "width": 200,
+        "x": 427.5,
+        "y": 238.5
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/guerler/hhsuite/hhsearch/0.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "cec2aa4d6c0d",
+        "name": "hhsuite",
+        "owner": "guerler",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"cs219_ffdata\": {\"__class__\": \"ConnectedValue\"}, \"cs219_ffindex\": {\"__class__\": \"ConnectedValue\"}, \"e\": \"0.001\", \"hhm_ffdata\": {\"__class__\": \"ConnectedValue\"}, \"hhm_ffindex\": {\"__class__\": \"ConnectedValue\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"method\": \"hhsearch\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+      "tool_uuid": null,
+      "tool_version": null,
+      "type": "tool",
+      "uuid": "f6e764e2-6a21-4dc5-b541-9feb11704de0",
+      "when": null,
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "8c9f24c3-599b-4c53-bcd0-5fb9a4b83af4"
+        }
+      ]
+    },
+    "8": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/guerler/hhsuite/hhsearch/0.1.0",
+      "errors": null,
+      "id": 8,
+      "input_connections": {
+        "cs219_ffdata": {
+          "id": 6,
+          "output_name": "output"
+        },
+        "cs219_ffindex": {
+          "id": 5,
+          "output_name": "output"
+        },
+        "hhm_ffdata": {
+          "id": 4,
+          "output_name": "output"
+        },
+        "hhm_ffindex": {
+          "id": 3,
+          "output_name": "output"
+        },
+        "input": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "HHsearch",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "bottom": 765.5,
+        "height": 219,
+        "left": 428.5,
+        "right": 628.5,
+        "top": 546.5,
+        "width": 200,
+        "x": 428.5,
+        "y": 546.5
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/guerler/hhsuite/hhsearch/0.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "cec2aa4d6c0d",
+        "name": "hhsuite",
+        "owner": "guerler",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"cs219_ffdata\": {\"__class__\": \"ConnectedValue\"}, \"cs219_ffindex\": {\"__class__\": \"ConnectedValue\"}, \"e\": \"0.001\", \"hhm_ffdata\": {\"__class__\": \"ConnectedValue\"}, \"hhm_ffindex\": {\"__class__\": \"ConnectedValue\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"method\": \"hhsearch\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+      "tool_uuid": null,
+      "tool_version": null,
+      "type": "tool",
+      "uuid": "1990f66b-f909-45bf-a585-f14c9ebc5d2d",
+      "when": null,
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "83e01e09-9e80-4f70-93c4-5bfb8326b61a"
+        }
+      ]
+    },
+    "9": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/guerler/springsuite/spring_minz/0.1.0",
+      "errors": null,
+      "id": 9,
+      "input_connections": {
+        "crossreference": {
+          "id": 2,
+          "output_name": "output"
+        },
+        "inputs": {
+          "id": 8,
+          "output_name": "output"
+        },
+        "target": {
+          "id": 7,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "SPRING min-Z",
+      "outputs": [
+        {
+          "name": "output",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "bottom": 583.5,
+        "height": 157,
+        "left": 725.5,
+        "right": 925.5,
+        "top": 426.5,
+        "width": 200,
+        "x": 725.5,
+        "y": 426.5
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/guerler/springsuite/spring_minz/0.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "0ea00dce62ab",
+        "name": "springsuite",
+        "owner": "guerler",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"crossreference\": {\"__class__\": \"ConnectedValue\"}, \"idx\": \"6\", \"inputs\": {\"__class__\": \"ConnectedValue\"}, \"minscore\": \"10\", \"target\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+      "tool_uuid": null,
+      "tool_version": null,
+      "type": "tool",
+      "uuid": "410783f5-7b37-4753-9f41-8e8cf861be00",
+      "when": null,
+      "workflow_outputs": [
+        {
+          "label": null,
+          "output_name": "output",
+          "uuid": "a1357ef6-0e7b-4137-a7a5-3dbb5b6b10b9"
+        }
+      ]
+    }
+  },
+  "tags": [],
+  "uuid": "0d7a19f7-0dbe-49dc-b6c1-ff6763d97445",
+  "version": 4
+}

--- a/mcp-server-galaxy-py/tests/testdata/wf_style_run_rnaseq.json
+++ b/mcp-server-galaxy-py/tests/testdata/wf_style_run_rnaseq.json
@@ -16,8 +16,7 @@
             "a2m",
             "a3m",
             "ab1",
-            "acedb",
-            "...(+770 more, trimmed for fixture)"
+            "acedb"
           ],
           "argument": null,
           "collection_types": [
@@ -81,8 +80,7 @@
             "a2m",
             "a3m",
             "ab1",
-            "acedb",
-            "...(+770 more, trimmed for fixture)"
+            "acedb"
           ],
           "argument": null,
           "collection_types": [
@@ -146,8 +144,7 @@
             "a2m",
             "a3m",
             "acedb",
-            "affybatch",
-            "...(+490 more, trimmed for fixture)"
+            "affybatch"
           ],
           "argument": null,
           "edam": {
@@ -216,8 +213,7 @@
             "a2m",
             "a3m",
             "acedb",
-            "affybatch",
-            "...(+490 more, trimmed for fixture)"
+            "affybatch"
           ],
           "argument": null,
           "edam": {
@@ -292,8 +288,7 @@
             "a2m",
             "a3m",
             "ab1",
-            "acedb",
-            "...(+770 more, trimmed for fixture)"
+            "acedb"
           ],
           "argument": null,
           "edam": {
@@ -368,8 +363,7 @@
             "a2m",
             "a3m",
             "acedb",
-            "affybatch",
-            "...(+490 more, trimmed for fixture)"
+            "affybatch"
           ],
           "argument": null,
           "edam": {
@@ -444,8 +438,7 @@
             "a2m",
             "a3m",
             "ab1",
-            "acedb",
-            "...(+770 more, trimmed for fixture)"
+            "acedb"
           ],
           "argument": null,
           "edam": {
@@ -1647,5 +1640,5 @@
   "version": 4,
   "workflow_id": "509728dd2e69bcd0",
   "workflow_resource_parameters": null,
-  "_fixture_note": "Captured from test.galaxyproject.org 26.1.rc1 via style=run&instance=true (history required). owner/history_id scrubbed; acceptable_extensions trimmed (code consumes `extensions`)."
+  "_fixture_note": "Captured from test.galaxyproject.org 26.1.rc1 via style=run&instance=true (history required). owner/history_id scrubbed; acceptable_extensions arrays subset to the first real entries for fixture size."
 }

--- a/mcp-server-galaxy-py/tests/testdata/wf_style_run_rnaseq.json
+++ b/mcp-server-galaxy-py/tests/testdata/wf_style_run_rnaseq.json
@@ -1,0 +1,1651 @@
+{
+  "has_upgrade_messages": true,
+  "help": null,
+  "id": "cbfaeab6dcda4c1f",
+  "name": "RNA-Seq PE (fixture)",
+  "step_version_changes": [],
+  "steps": [
+    {
+      "inputs": [
+        {
+          "acceptable_extensions": [
+            "4dn_pairs",
+            "4dn_pairs.gz",
+            "4dn_pairsam",
+            "4dn_pairsam.gz",
+            "a2m",
+            "a3m",
+            "ab1",
+            "acedb",
+            "...(+770 more, trimmed for fixture)"
+          ],
+          "argument": null,
+          "collection_types": [
+            "list"
+          ],
+          "column_definitions": null,
+          "extensions": [
+            "data"
+          ],
+          "fields": null,
+          "help": null,
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "Target Sequence",
+          "model_class": "DataCollectionToolParameter",
+          "multiple": false,
+          "name": "input",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": []
+          },
+          "options_meta": {},
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "type": "data_collection",
+          "value": null
+        }
+      ],
+      "output_connections": [
+        {
+          "input_name": "input",
+          "input_step_index": 7,
+          "output_name": "output",
+          "output_step_index": 0
+        }
+      ],
+      "replacement_parameters": [],
+      "step_index": 0,
+      "step_label": "Target Sequence",
+      "step_name": "Input dataset collection",
+      "step_type": "data_collection_input",
+      "step_version": null,
+      "when": null
+    },
+    {
+      "inputs": [
+        {
+          "acceptable_extensions": [
+            "4dn_pairs",
+            "4dn_pairs.gz",
+            "4dn_pairsam",
+            "4dn_pairsam.gz",
+            "a2m",
+            "a3m",
+            "ab1",
+            "acedb",
+            "...(+770 more, trimmed for fixture)"
+          ],
+          "argument": null,
+          "collection_types": [
+            "list"
+          ],
+          "column_definitions": null,
+          "extensions": [
+            "data"
+          ],
+          "fields": null,
+          "help": null,
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "Input Sequences",
+          "model_class": "DataCollectionToolParameter",
+          "multiple": false,
+          "name": "input",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": []
+          },
+          "options_meta": {},
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "type": "data_collection",
+          "value": null
+        }
+      ],
+      "output_connections": [
+        {
+          "input_name": "input",
+          "input_step_index": 8,
+          "output_name": "output",
+          "output_step_index": 1
+        }
+      ],
+      "replacement_parameters": [],
+      "step_index": 1,
+      "step_label": "Input Sequences",
+      "step_name": "Input dataset collection",
+      "step_type": "data_collection_input",
+      "step_version": null,
+      "when": null
+    },
+    {
+      "inputs": [
+        {
+          "acceptable_extensions": [
+            "4dn_pairs",
+            "4dn_pairs.gz",
+            "4dn_pairsam",
+            "4dn_pairsam.gz",
+            "a2m",
+            "a3m",
+            "acedb",
+            "affybatch",
+            "...(+490 more, trimmed for fixture)"
+          ],
+          "argument": null,
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_2330"
+            ]
+          },
+          "extensions": [
+            "txt"
+          ],
+          "help": null,
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "SPRING Index",
+          "model_class": "DataToolParameter",
+          "multiple": false,
+          "name": "input",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "options_meta": {},
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "type": "data",
+          "value": null
+        }
+      ],
+      "output_connections": [
+        {
+          "input_name": "crossreference",
+          "input_step_index": 9,
+          "output_name": "output",
+          "output_step_index": 2
+        }
+      ],
+      "replacement_parameters": [],
+      "step_index": 2,
+      "step_label": "SPRING Index",
+      "step_name": "Input dataset",
+      "step_type": "data_input",
+      "step_version": null,
+      "when": null
+    },
+    {
+      "inputs": [
+        {
+          "acceptable_extensions": [
+            "4dn_pairs",
+            "4dn_pairs.gz",
+            "4dn_pairsam",
+            "4dn_pairsam.gz",
+            "a2m",
+            "a3m",
+            "acedb",
+            "affybatch",
+            "...(+490 more, trimmed for fixture)"
+          ],
+          "argument": null,
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_2330"
+            ]
+          },
+          "extensions": [
+            "txt"
+          ],
+          "help": null,
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "HHM Index",
+          "model_class": "DataToolParameter",
+          "multiple": false,
+          "name": "input",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "options_meta": {},
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "type": "data",
+          "value": null
+        }
+      ],
+      "output_connections": [
+        {
+          "input_name": "hhm_ffindex",
+          "input_step_index": 7,
+          "output_name": "output",
+          "output_step_index": 3
+        },
+        {
+          "input_name": "hhm_ffindex",
+          "input_step_index": 8,
+          "output_name": "output",
+          "output_step_index": 3
+        }
+      ],
+      "replacement_parameters": [],
+      "step_index": 3,
+      "step_label": "HHM Index",
+      "step_name": "Input dataset",
+      "step_type": "data_input",
+      "step_version": null,
+      "when": null
+    },
+    {
+      "inputs": [
+        {
+          "acceptable_extensions": [
+            "4dn_pairs",
+            "4dn_pairs.gz",
+            "4dn_pairsam",
+            "4dn_pairsam.gz",
+            "a2m",
+            "a3m",
+            "ab1",
+            "acedb",
+            "...(+770 more, trimmed for fixture)"
+          ],
+          "argument": null,
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_1915"
+            ]
+          },
+          "extensions": [
+            "data"
+          ],
+          "help": null,
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "HHM Data",
+          "model_class": "DataToolParameter",
+          "multiple": false,
+          "name": "input",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "options_meta": {},
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "type": "data",
+          "value": null
+        }
+      ],
+      "output_connections": [
+        {
+          "input_name": "hhm_ffdata",
+          "input_step_index": 7,
+          "output_name": "output",
+          "output_step_index": 4
+        },
+        {
+          "input_name": "hhm_ffdata",
+          "input_step_index": 8,
+          "output_name": "output",
+          "output_step_index": 4
+        }
+      ],
+      "replacement_parameters": [],
+      "step_index": 4,
+      "step_label": "HHM Data",
+      "step_name": "Input dataset",
+      "step_type": "data_input",
+      "step_version": null,
+      "when": null
+    },
+    {
+      "inputs": [
+        {
+          "acceptable_extensions": [
+            "4dn_pairs",
+            "4dn_pairs.gz",
+            "4dn_pairsam",
+            "4dn_pairsam.gz",
+            "a2m",
+            "a3m",
+            "acedb",
+            "affybatch",
+            "...(+490 more, trimmed for fixture)"
+          ],
+          "argument": null,
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_2330"
+            ]
+          },
+          "extensions": [
+            "txt"
+          ],
+          "help": null,
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "cs219 Index",
+          "model_class": "DataToolParameter",
+          "multiple": false,
+          "name": "input",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "options_meta": {},
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "type": "data",
+          "value": null
+        }
+      ],
+      "output_connections": [
+        {
+          "input_name": "cs219_ffindex",
+          "input_step_index": 7,
+          "output_name": "output",
+          "output_step_index": 5
+        },
+        {
+          "input_name": "cs219_ffindex",
+          "input_step_index": 8,
+          "output_name": "output",
+          "output_step_index": 5
+        }
+      ],
+      "replacement_parameters": [],
+      "step_index": 5,
+      "step_label": "cs219 Index",
+      "step_name": "Input dataset",
+      "step_type": "data_input",
+      "step_version": null,
+      "when": null
+    },
+    {
+      "inputs": [
+        {
+          "acceptable_extensions": [
+            "4dn_pairs",
+            "4dn_pairs.gz",
+            "4dn_pairsam",
+            "4dn_pairsam.gz",
+            "a2m",
+            "a3m",
+            "ab1",
+            "acedb",
+            "...(+770 more, trimmed for fixture)"
+          ],
+          "argument": null,
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_1915"
+            ]
+          },
+          "extensions": [
+            "data"
+          ],
+          "help": null,
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "cs219 Data",
+          "model_class": "DataToolParameter",
+          "multiple": false,
+          "name": "input",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "options_meta": {},
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "type": "data",
+          "value": null
+        }
+      ],
+      "output_connections": [
+        {
+          "input_name": "cs219_ffdata",
+          "input_step_index": 7,
+          "output_name": "output",
+          "output_step_index": 6
+        },
+        {
+          "input_name": "cs219_ffdata",
+          "input_step_index": 8,
+          "output_name": "output",
+          "output_step_index": 6
+        }
+      ],
+      "replacement_parameters": [],
+      "step_index": 6,
+      "step_label": "cs219 Data",
+      "step_name": "Input dataset",
+      "step_type": "data_input",
+      "step_version": null,
+      "when": null
+    },
+    {
+      "action": "/tool_runner/index",
+      "citations": true,
+      "config_file": "/cvmfs/test.galaxyproject.org/shed_tools/toolshed.g2.bx.psu.edu/repos/guerler/hhsuite/3e4d88784254/hhsuite/hhsearch.xml",
+      "creator": null,
+      "credentials": [],
+      "description": "detecting remote homologues of proteins",
+      "display": true,
+      "edam_operations": [],
+      "edam_topics": [],
+      "enctype": "application/x-www-form-urlencoded",
+      "errors": {},
+      "form_style": "regular",
+      "has_parameters": true,
+      "help": "<p>HHsearch aligns a profile HMM against a database of target profile HMMs. The search first aligns the\nquery HMM with each of the target HMMs using the Viterbi dynamic programming algorithm, which finds the\nalignment with the maximum score. The E-value for the target HMM is calculated from the Viterbi score.\nTarget HMMs that reach sufficient significance to be reported are realigned using the Maximum Accuracy algorithm (MAC).\nThis algorithm maximizes the expected number of correctly aligned pairs of residues minus a penalty between 0 and 1.\nValues near 0 produce greedy, long, nearly global alignments, values above 0.3 result in shorter, local alignments.</p>\n<p>HHblits is an accelerated version of HHsearch that is fast enough to perform iterative searches through millions of profile HMMs,\ne.g. through the Uniclust profile HMM databases, generated by clustering the UniProt database into clusters of globally alignable sequences.\nAnalogously to PSI-BLAST and HMMER3, such iterative searches can be used to build MSAs by starting from a single query sequence.\nSequences from matches to profile HMMs below some E-value threshold (e.g. 10\u22123) are added to the query MSA for the next search iteration.</p>\n<p>Download databases from: <a class=\"reference external\" href=\"http://wwwuser.gwdg.de/~compbiol/data/hhsuite/databases/hhsuite_dbs/\">http://wwwuser.gwdg.de/~compbiol/data/hhsuite/databases/hhsuite_dbs/</a></p>\n",
+      "help_format": "restructuredtext",
+      "hidden": "",
+      "hidden_versions": [],
+      "history_id": "1affb3d848eeea7c",
+      "icon": null,
+      "id": "toolshed.g2.bx.psu.edu/repos/guerler/hhsuite/hhsearch/0.1.0",
+      "inputs": [
+        {
+          "argument": null,
+          "default_value": null,
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_1915"
+            ]
+          },
+          "extensions": [
+            "data"
+          ],
+          "help": "Single sequence or multiple sequence alignment (MSA)                 in a3m, a2m, or FASTA format, or HMM in hhm format. (-i)",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "Query Sequence",
+          "model_class": "DataToolParameter",
+          "multiple": false,
+          "name": "input",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "options_meta": {
+            "hda": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            },
+            "hdca": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            }
+          },
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "text_value": "Not available.",
+          "type": "data",
+          "value": {
+            "__class__": "ConnectedValue"
+          }
+        },
+        {
+          "argument": null,
+          "default_value": null,
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_2330"
+            ]
+          },
+          "extensions": [
+            "txt"
+          ],
+          "help": "Database file ending with 'hhm.ffindex'.",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "HHM Index file",
+          "model_class": "DataToolParameter",
+          "multiple": false,
+          "name": "hhm_ffindex",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "options_meta": {
+            "hda": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            },
+            "hdca": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            }
+          },
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "text_value": "Not available.",
+          "type": "data",
+          "value": {
+            "__class__": "ConnectedValue"
+          }
+        },
+        {
+          "argument": null,
+          "default_value": null,
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_1915"
+            ]
+          },
+          "extensions": [
+            "data"
+          ],
+          "help": "Database file ending with 'hhm.ffdata'.",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "HHM Data file",
+          "model_class": "DataToolParameter",
+          "multiple": false,
+          "name": "hhm_ffdata",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "options_meta": {
+            "hda": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            },
+            "hdca": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            }
+          },
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "text_value": "Not available.",
+          "type": "data",
+          "value": {
+            "__class__": "ConnectedValue"
+          }
+        },
+        {
+          "argument": null,
+          "default_value": null,
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_2330"
+            ]
+          },
+          "extensions": [
+            "txt"
+          ],
+          "help": "Database file ending with 'cs219.ffindex'.",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "cs219 Index file",
+          "model_class": "DataToolParameter",
+          "multiple": false,
+          "name": "cs219_ffindex",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "options_meta": {
+            "hda": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            },
+            "hdca": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            }
+          },
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "text_value": "Not available.",
+          "type": "data",
+          "value": {
+            "__class__": "ConnectedValue"
+          }
+        },
+        {
+          "argument": null,
+          "default_value": null,
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_1915"
+            ]
+          },
+          "extensions": [
+            "data"
+          ],
+          "help": "Database file ending with 'cs219.ffdata'.",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "cs219 Data file",
+          "model_class": "DataToolParameter",
+          "multiple": false,
+          "name": "cs219_ffdata",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "options_meta": {
+            "hda": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            },
+            "hdca": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            }
+          },
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "text_value": "Not available.",
+          "type": "data",
+          "value": {
+            "__class__": "ConnectedValue"
+          }
+        },
+        {
+          "argument": null,
+          "default_value": "hhsearch",
+          "display": "radio",
+          "help": "Select a search method. See help below for more information.",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "Search Method",
+          "model_class": "SelectToolParameter",
+          "multiple": false,
+          "name": "method",
+          "optional": false,
+          "options": [
+            [
+              "HHsearch",
+              "hhsearch",
+              true
+            ],
+            [
+              "HHblits",
+              "hhblits",
+              false
+            ]
+          ],
+          "refresh_on_change": false,
+          "text_value": "HHsearch",
+          "textable": true,
+          "type": "select",
+          "value": "hhsearch"
+        },
+        {
+          "area": false,
+          "argument": null,
+          "datalist": [],
+          "default_value": "0.001",
+          "help": "",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "E-value cutoff for inclusion in result alignment. (-e)",
+          "max": 1.0,
+          "min": 0.0,
+          "model_class": "FloatToolParameter",
+          "name": "e",
+          "optional": false,
+          "refresh_on_change": false,
+          "text_value": "0.001",
+          "type": "float",
+          "value": "0.001"
+        }
+      ],
+      "is_workflow_compatible": true,
+      "job_credentials_context": null,
+      "job_id": null,
+      "job_remap": null,
+      "labels": [],
+      "license": null,
+      "message": "",
+      "method": "post",
+      "model_class": "Tool",
+      "name": "HHsearch",
+      "output_connections": [
+        {
+          "input_name": "target",
+          "input_step_index": 9,
+          "output_name": "output",
+          "output_step_index": 7
+        }
+      ],
+      "panel_section_id": "tool_toolshed.g2.bx.psu.edu/repos/guerler/hhsuite/hhsearch/0.1.0",
+      "panel_section_name": "HHsearch",
+      "post_job_actions": [],
+      "replacement_parameters": [],
+      "requirements": [
+        {
+          "name": "hhsuite",
+          "version": "3.2.0"
+        }
+      ],
+      "sharable_url": "https://toolshed.g2.bx.psu.edu/view/guerler/hhsuite",
+      "state_inputs": {
+        "cs219_ffdata": {
+          "__class__": "ConnectedValue"
+        },
+        "cs219_ffindex": {
+          "__class__": "ConnectedValue"
+        },
+        "e": "0.001",
+        "hhm_ffdata": {
+          "__class__": "ConnectedValue"
+        },
+        "hhm_ffindex": {
+          "__class__": "ConnectedValue"
+        },
+        "input": {
+          "__class__": "ConnectedValue"
+        },
+        "method": "hhsearch"
+      },
+      "step_index": 7,
+      "step_label": null,
+      "step_name": "HHsearch",
+      "step_type": "tool",
+      "step_version": "0.1.0",
+      "tool_errors": null,
+      "tool_shed_repository": {
+        "changeset_revision": "cec2aa4d6c0d",
+        "name": "hhsuite",
+        "owner": "guerler",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "version": "0.1.0",
+      "versions": [
+        "0.1.0"
+      ],
+      "warnings": null,
+      "when": null,
+      "xrefs": [
+        {
+          "type": "bio.tools",
+          "value": "hhsuite"
+        }
+      ]
+    },
+    {
+      "action": "/tool_runner/index",
+      "citations": true,
+      "config_file": "/cvmfs/test.galaxyproject.org/shed_tools/toolshed.g2.bx.psu.edu/repos/guerler/hhsuite/3e4d88784254/hhsuite/hhsearch.xml",
+      "creator": null,
+      "credentials": [],
+      "description": "detecting remote homologues of proteins",
+      "display": true,
+      "edam_operations": [],
+      "edam_topics": [],
+      "enctype": "application/x-www-form-urlencoded",
+      "errors": {},
+      "form_style": "regular",
+      "has_parameters": true,
+      "help": "<p>HHsearch aligns a profile HMM against a database of target profile HMMs. The search first aligns the\nquery HMM with each of the target HMMs using the Viterbi dynamic programming algorithm, which finds the\nalignment with the maximum score. The E-value for the target HMM is calculated from the Viterbi score.\nTarget HMMs that reach sufficient significance to be reported are realigned using the Maximum Accuracy algorithm (MAC).\nThis algorithm maximizes the expected number of correctly aligned pairs of residues minus a penalty between 0 and 1.\nValues near 0 produce greedy, long, nearly global alignments, values above 0.3 result in shorter, local alignments.</p>\n<p>HHblits is an accelerated version of HHsearch that is fast enough to perform iterative searches through millions of profile HMMs,\ne.g. through the Uniclust profile HMM databases, generated by clustering the UniProt database into clusters of globally alignable sequences.\nAnalogously to PSI-BLAST and HMMER3, such iterative searches can be used to build MSAs by starting from a single query sequence.\nSequences from matches to profile HMMs below some E-value threshold (e.g. 10\u22123) are added to the query MSA for the next search iteration.</p>\n<p>Download databases from: <a class=\"reference external\" href=\"http://wwwuser.gwdg.de/~compbiol/data/hhsuite/databases/hhsuite_dbs/\">http://wwwuser.gwdg.de/~compbiol/data/hhsuite/databases/hhsuite_dbs/</a></p>\n",
+      "help_format": "restructuredtext",
+      "hidden": "",
+      "hidden_versions": [],
+      "history_id": "1affb3d848eeea7c",
+      "icon": null,
+      "id": "toolshed.g2.bx.psu.edu/repos/guerler/hhsuite/hhsearch/0.1.0",
+      "inputs": [
+        {
+          "argument": null,
+          "default_value": null,
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_1915"
+            ]
+          },
+          "extensions": [
+            "data"
+          ],
+          "help": "Single sequence or multiple sequence alignment (MSA)                 in a3m, a2m, or FASTA format, or HMM in hhm format. (-i)",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "Query Sequence",
+          "model_class": "DataToolParameter",
+          "multiple": false,
+          "name": "input",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "options_meta": {
+            "hda": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            },
+            "hdca": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            }
+          },
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "text_value": "Not available.",
+          "type": "data",
+          "value": {
+            "__class__": "ConnectedValue"
+          }
+        },
+        {
+          "argument": null,
+          "default_value": null,
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_2330"
+            ]
+          },
+          "extensions": [
+            "txt"
+          ],
+          "help": "Database file ending with 'hhm.ffindex'.",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "HHM Index file",
+          "model_class": "DataToolParameter",
+          "multiple": false,
+          "name": "hhm_ffindex",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "options_meta": {
+            "hda": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            },
+            "hdca": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            }
+          },
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "text_value": "Not available.",
+          "type": "data",
+          "value": {
+            "__class__": "ConnectedValue"
+          }
+        },
+        {
+          "argument": null,
+          "default_value": null,
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_1915"
+            ]
+          },
+          "extensions": [
+            "data"
+          ],
+          "help": "Database file ending with 'hhm.ffdata'.",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "HHM Data file",
+          "model_class": "DataToolParameter",
+          "multiple": false,
+          "name": "hhm_ffdata",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "options_meta": {
+            "hda": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            },
+            "hdca": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            }
+          },
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "text_value": "Not available.",
+          "type": "data",
+          "value": {
+            "__class__": "ConnectedValue"
+          }
+        },
+        {
+          "argument": null,
+          "default_value": null,
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_2330"
+            ]
+          },
+          "extensions": [
+            "txt"
+          ],
+          "help": "Database file ending with 'cs219.ffindex'.",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "cs219 Index file",
+          "model_class": "DataToolParameter",
+          "multiple": false,
+          "name": "cs219_ffindex",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "options_meta": {
+            "hda": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            },
+            "hdca": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            }
+          },
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "text_value": "Not available.",
+          "type": "data",
+          "value": {
+            "__class__": "ConnectedValue"
+          }
+        },
+        {
+          "argument": null,
+          "default_value": null,
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_1915"
+            ]
+          },
+          "extensions": [
+            "data"
+          ],
+          "help": "Database file ending with 'cs219.ffdata'.",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "cs219 Data file",
+          "model_class": "DataToolParameter",
+          "multiple": false,
+          "name": "cs219_ffdata",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "options_meta": {
+            "hda": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            },
+            "hdca": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            }
+          },
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "text_value": "Not available.",
+          "type": "data",
+          "value": {
+            "__class__": "ConnectedValue"
+          }
+        },
+        {
+          "argument": null,
+          "default_value": "hhsearch",
+          "display": "radio",
+          "help": "Select a search method. See help below for more information.",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "Search Method",
+          "model_class": "SelectToolParameter",
+          "multiple": false,
+          "name": "method",
+          "optional": false,
+          "options": [
+            [
+              "HHsearch",
+              "hhsearch",
+              true
+            ],
+            [
+              "HHblits",
+              "hhblits",
+              false
+            ]
+          ],
+          "refresh_on_change": false,
+          "text_value": "HHsearch",
+          "textable": true,
+          "type": "select",
+          "value": "hhsearch"
+        },
+        {
+          "area": false,
+          "argument": null,
+          "datalist": [],
+          "default_value": "0.001",
+          "help": "",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "E-value cutoff for inclusion in result alignment. (-e)",
+          "max": 1.0,
+          "min": 0.0,
+          "model_class": "FloatToolParameter",
+          "name": "e",
+          "optional": false,
+          "refresh_on_change": false,
+          "text_value": "0.001",
+          "type": "float",
+          "value": "0.001"
+        }
+      ],
+      "is_workflow_compatible": true,
+      "job_credentials_context": null,
+      "job_id": null,
+      "job_remap": null,
+      "labels": [],
+      "license": null,
+      "message": "",
+      "method": "post",
+      "model_class": "Tool",
+      "name": "HHsearch",
+      "output_connections": [
+        {
+          "input_name": "inputs",
+          "input_step_index": 9,
+          "output_name": "output",
+          "output_step_index": 8
+        }
+      ],
+      "panel_section_id": "tool_toolshed.g2.bx.psu.edu/repos/guerler/hhsuite/hhsearch/0.1.0",
+      "panel_section_name": "HHsearch",
+      "post_job_actions": [],
+      "replacement_parameters": [],
+      "requirements": [
+        {
+          "name": "hhsuite",
+          "version": "3.2.0"
+        }
+      ],
+      "sharable_url": "https://toolshed.g2.bx.psu.edu/view/guerler/hhsuite",
+      "state_inputs": {
+        "cs219_ffdata": {
+          "__class__": "ConnectedValue"
+        },
+        "cs219_ffindex": {
+          "__class__": "ConnectedValue"
+        },
+        "e": "0.001",
+        "hhm_ffdata": {
+          "__class__": "ConnectedValue"
+        },
+        "hhm_ffindex": {
+          "__class__": "ConnectedValue"
+        },
+        "input": {
+          "__class__": "ConnectedValue"
+        },
+        "method": "hhsearch"
+      },
+      "step_index": 8,
+      "step_label": null,
+      "step_name": "HHsearch",
+      "step_type": "tool",
+      "step_version": "0.1.0",
+      "tool_errors": null,
+      "tool_shed_repository": {
+        "changeset_revision": "cec2aa4d6c0d",
+        "name": "hhsuite",
+        "owner": "guerler",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "version": "0.1.0",
+      "versions": [
+        "0.1.0"
+      ],
+      "warnings": null,
+      "when": null,
+      "xrefs": [
+        {
+          "type": "bio.tools",
+          "value": "hhsuite"
+        }
+      ]
+    },
+    {
+      "action": "/tool_runner/index",
+      "citations": true,
+      "config_file": "/cvmfs/test.galaxyproject.org/shed_tools/toolshed.g2.bx.psu.edu/repos/guerler/springsuite/860bd6f8f480/springsuite/spring_minz.xml",
+      "creator": null,
+      "credentials": [],
+      "description": "filter operation",
+      "display": true,
+      "edam_operations": [],
+      "edam_topics": [],
+      "enctype": "application/x-www-form-urlencoded",
+      "errors": {},
+      "form_style": "regular",
+      "has_parameters": true,
+      "help": "<p>This tool filters HH-search/HH-blits homology results through the protein interaction cross reference generated by SPRING. Putative interactions are identified by\nevaluating the min-Z score. The min-Z is the smaller of the two Z-scores for a pair of sequences matching an existing protein-protein complex structure.</p>\n",
+      "help_format": "restructuredtext",
+      "hidden": "",
+      "hidden_versions": [],
+      "history_id": "1affb3d848eeea7c",
+      "icon": null,
+      "id": "toolshed.g2.bx.psu.edu/repos/guerler/springsuite/spring_minz/0.1.0",
+      "inputs": [
+        {
+          "argument": null,
+          "collection_types": null,
+          "column_definitions": null,
+          "default_value": null,
+          "extensions": [
+            "txt"
+          ],
+          "fields": null,
+          "help": "Homology search result of target/query profiles `hhr`.",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "Target Profiles",
+          "model_class": "DataCollectionToolParameter",
+          "multiple": false,
+          "name": "targets",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": []
+          },
+          "options_meta": {
+            "hdca": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            }
+          },
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "text_value": "Not available.",
+          "type": "data_collection",
+          "value": {
+            "__class__": "RuntimeValue"
+          }
+        },
+        {
+          "argument": null,
+          "collection_types": [
+            "list"
+          ],
+          "column_definitions": null,
+          "default_value": null,
+          "extensions": [
+            "txt"
+          ],
+          "fields": null,
+          "help": "Homology search results of input profiles `hhr`.",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "Input Profiles",
+          "model_class": "DataCollectionToolParameter",
+          "multiple": false,
+          "name": "inputs",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": []
+          },
+          "options_meta": {
+            "hdca": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            }
+          },
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "text_value": "Not available.",
+          "type": "data_collection",
+          "value": {
+            "__class__": "ConnectedValue"
+          }
+        },
+        {
+          "argument": null,
+          "default_value": null,
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_2330"
+            ]
+          },
+          "extensions": [
+            "txt"
+          ],
+          "help": "Cross reference of interacting proteins `first_id metadata_id second_id`.",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "Cross Reference",
+          "model_class": "DataToolParameter",
+          "multiple": false,
+          "name": "crossreference",
+          "optional": false,
+          "options": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "options_meta": {
+            "hda": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            },
+            "hdca": {
+              "has_more": false,
+              "limit": 50,
+              "offset": 0,
+              "total_estimate": 0
+            }
+          },
+          "pinned": {
+            "dce": [],
+            "hda": [],
+            "hdca": [],
+            "ldda": []
+          },
+          "refresh_on_change": true,
+          "tag": null,
+          "text_value": "Not available.",
+          "type": "data",
+          "value": {
+            "__class__": "ConnectedValue"
+          }
+        },
+        {
+          "area": false,
+          "argument": null,
+          "datalist": [],
+          "default_value": "10",
+          "help": "Matching interaction pairs with a score lower than this threshold will be excluded.",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "min-Z score threshold",
+          "max": 100,
+          "min": 1,
+          "model_class": "IntegerToolParameter",
+          "name": "minscore",
+          "optional": false,
+          "refresh_on_change": false,
+          "text_value": "10",
+          "type": "integer",
+          "value": "10"
+        },
+        {
+          "area": false,
+          "argument": null,
+          "datalist": [],
+          "default_value": "6",
+          "help": "Specify the length of the identifier e.g. `1ACB_A` has length 6.",
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "Identifier length",
+          "max": 20,
+          "min": 1,
+          "model_class": "IntegerToolParameter",
+          "name": "idx",
+          "optional": false,
+          "refresh_on_change": false,
+          "text_value": "6",
+          "type": "integer",
+          "value": "6"
+        }
+      ],
+      "is_workflow_compatible": true,
+      "job_credentials_context": null,
+      "job_id": null,
+      "job_remap": null,
+      "labels": [],
+      "license": null,
+      "message": "",
+      "messages": {
+        "targets": "No value found for 'Target Profiles'. Using default: '<galaxy.tools.parameters.workflow_utils.RuntimeValue object at 0x7fdf4cb79270>'."
+      },
+      "method": "post",
+      "model_class": "Tool",
+      "name": "SPRING min-Z",
+      "output_connections": [],
+      "panel_section_id": "tool_toolshed.g2.bx.psu.edu/repos/guerler/springsuite/spring_minz/0.1.0",
+      "panel_section_name": "SPRING min-Z",
+      "post_job_actions": [],
+      "replacement_parameters": [],
+      "requirements": [],
+      "sharable_url": "https://toolshed.g2.bx.psu.edu/view/guerler/springsuite",
+      "state_inputs": {
+        "crossreference": {
+          "__class__": "ConnectedValue"
+        },
+        "idx": "6",
+        "inputs": {
+          "__class__": "ConnectedValue"
+        },
+        "minscore": "10",
+        "targets": {
+          "__class__": "RuntimeValue"
+        }
+      },
+      "step_index": 9,
+      "step_label": null,
+      "step_name": "SPRING min-Z",
+      "step_type": "tool",
+      "step_version": "0.1.0",
+      "tool_errors": null,
+      "tool_shed_repository": {
+        "changeset_revision": "0ea00dce62ab",
+        "name": "springsuite",
+        "owner": "guerler",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "version": "0.1.0",
+      "versions": [
+        "0.1.0",
+        "0.1.1",
+        "0.1.2"
+      ],
+      "warnings": null,
+      "when": null,
+      "xrefs": [
+        {
+          "type": "bio.tools",
+          "value": "spring"
+        }
+      ]
+    }
+  ],
+  "version": 4,
+  "workflow_id": "509728dd2e69bcd0",
+  "workflow_resource_parameters": null,
+  "_fixture_note": "Captured from test.galaxyproject.org 26.1.rc1 via style=run&instance=true (history required). owner/history_id scrubbed; acceptable_extensions trimmed (code consumes `extensions`)."
+}


### PR DESCRIPTION
This is the workflow-side companion to #51 (which did the same for tools). Same motivation: agents driving the MCP keep building structurally-broken runs -- the one that kicked this off was an agent dropping a BAM file into a "barcodes" input that wanted tabular, with Galaxy only complaining later via a confusing downstream tool error. Nothing gave the model the shape of a workflow's inputs up front, and `invoke_workflow` would submit whatever it was handed.

Two things here:

**`get_workflow_input_template`** -- call it before `invoke_workflow` to get a labeled, ready-to-fill template of a workflow's input slots: each slot's label, expected source (hda/hdca), accepted datatypes, and collection type, plus a placeholder `inputs` skeleton keyed by step index. It also flags legacy workflows (tool steps carrying `RuntimeValue` params set at runtime -- the old run-form pattern that doesn't invoke cleanly via the API).

**An invoke-time preflight** in `invoke_workflow` that validates supplied inputs against those slots before submitting, and hard-rejects *provable* mismatches (a BAM where the slot needs tabular, a dataset where it needs a collection, the wrong collection type) with a message that names the problem and hands back the slot template to fix and retry. Anything it can't prove -- unknown datatype, missing metadata, an unresolvable source -- degrades to a warning; the preflight never blocks a run on its own internal failure.

A few design notes:

- **Where slot info comes from:** primary source is the run-form serialization (`style=run`), the same thing the web client's run form uses, because for data inputs it already resolves the downstream-consumer datatype requirements (that's what catches BAM-into-barcodes). It needs a history, so when one isn't available (or the workflow has missing tools / subworkflows) it falls back to the `.ga` export -- weaker (declared formats only) but never wrong; it can only under-reject.
- **Datatype checks match the GUI, not a stricter reimplementation:** validation goes through Galaxy's own converter-aware `acceptable_extensions` (already in the `style=run` payload), so e.g. csv into a tabular slot is accepted just like the web UI accepts it (csv isn't a Tabular subclass, but there's an implicit converter). The `.ga` fallback uses datatype subclass closure via `/api/datatypes/types_and_mapping`. The point is to never reject something Galaxy itself would allow.
- This is purely a guardrail -- the actual submission is unchanged (raw inputs through bioblend). Galaxy's invocation path doesn't datatype-check at the input boundary today, so this fills a real gap rather than duplicating an existing check.

Validation logic lives in a small pure module (`workflow_inputs.py`, mirrors `tool_inputs.py`) with the I/O wiring in `server.py`. 173 tests pass (a new pure-module suite plus integration tests for the tool and the preflight), mypy and ruff clean.

Known follow-ups, not in this PR: legacy `RuntimeValue` warnings surface only through the template tool right now (not at invoke time); per-consumer intersection and subworkflow deep-inspection are warn-tier for now.
