### PR TITLE
Revive the gxy CLI as a human/AI scripting surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ uv sync
 uv run galaxy-mcp --transport streamable-http --host 0.0.0.0 --port 8000
 ```
 
+### `gxy` command-line interface
+
+The package also ships `gxy`, a JSON-first CLI over the same Galaxy operations --
+for humans, shell scripts, and CI (think IWC workflow discovery, history/dataset
+management, and workflow runs from the terminal). See the [CLI section in the
+package README](mcp-server-galaxy-py/README.md#gxy-command-line-interface) for
+configuration and examples. For LLM agents, prefer the MCP server / code-mode over
+the CLI.
+
 ## Container Usage
 
 The published image defaults to stdio transport (no HTTP listener):

--- a/mcp-server-galaxy-py/README.md
+++ b/mcp-server-galaxy-py/README.md
@@ -125,6 +125,51 @@ Default is `full`, which keeps the existing catalog unchanged. CodeMode is usefu
 
 The server also ships agent-facing usage guidance via the MCP `instructions` field (returned during the initial handshake). It explains the typical workflow, the difference between MCP tools and Galaxy tools (e.g. FastQC isn't an MCP tool -- find it via `search_tools_by_name`), and -- when code mode is active -- how to use `run_galaxy_tool` and `call_tool`. Agents that respect the `instructions` field will read this without you having to prompt them.
 
+## `gxy` command-line interface
+
+`gxy` is a JSON-first CLI over the same Galaxy operations the MCP server exposes,
+for humans, shell scripts, and CI. It reuses the server's tool functions directly
+-- no separate Galaxy logic -- so behavior matches the MCP server.
+
+> **Agents:** for LLM agents, prefer the MCP server (and `GALAXY_MCP_DISCOVERY_MODE=code`
+> code-mode) rather than this CLI. Agent-grade output guarantees are not part of this
+> tool yet.
+
+### Configuration
+
+Credentials resolve in this order: command-line flags > environment
+(`GALAXY_URL`, `GALAXY_API_KEY`) > `~/.galaxy-mcp/config.toml` > planemo profiles
+(`~/.planemo/profiles/<name>/`).
+
+```toml
+# ~/.galaxy-mcp/config.toml
+[default]
+url = "https://usegalaxy.org/"
+api_key = "your-api-key"
+
+[eu]
+url = "https://usegalaxy.eu/"
+api_key = "eu-api-key"
+```
+
+### Examples
+
+```bash
+# Discover curated IWC workflows -- no Galaxy account needed
+gxy iwc recommend "differential expression from RNA-seq" --limit 3
+
+# Search tools and inspect one (requires connection)
+gxy tools search fastqc
+gxy --pretty tools details toolshed.g2.bx.psu.edu/repos/.../fastqc/0.74
+
+# Script with jq
+HIST_ID=$(gxy history create "RNA-seq run" | jq -r '.data.id')
+gxy --profile eu history list | jq '.data[] | {id, name}'
+
+# Shell completion
+gxy --install-completion
+```
+
 ## Available MCP Tools
 
 The Python implementation provides the following MCP tools:

--- a/mcp-server-galaxy-py/README.md
+++ b/mcp-server-galaxy-py/README.md
@@ -162,9 +162,15 @@ gxy iwc recommend "differential expression from RNA-seq" --limit 3
 gxy tools search fastqc
 gxy --pretty tools details toolshed.g2.bx.psu.edu/repos/.../fastqc/0.74
 
+# List configured profiles (gxy config + planemo), then use one
+gxy profile list
+gxy --profile eu history list | jq '.data[] | {id, name}'
+
 # Script with jq
 HIST_ID=$(gxy history create "RNA-seq run" | jq -r '.data.id')
-gxy --profile eu history list | jq '.data[] | {id, name}'
+
+# Verify / debug credentials (surfaces the real auth error)
+gxy connect
 
 # Shell completion
 gxy --install-completion

--- a/mcp-server-galaxy-py/pyproject.toml
+++ b/mcp-server-galaxy-py/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
     "python-dotenv>=1.0.0,<2",
     "rank-bm25>=0.2.2,<1",
     "typing-extensions>=4.0.0,<5",
+    "typer>=0.12.0,<1",
+    "tomli>=2.0.0; python_version < '3.11'",
 ]
 
 [project.urls]
@@ -43,6 +45,7 @@ Issues = "https://github.com/galaxyproject/galaxy-mcp/issues"
 
 [project.scripts]
 galaxy-mcp = "galaxy_mcp.__main__:run"
+gxy = "galaxy_mcp.cli.main:app"
 
 [project.optional-dependencies]
 code-mode = [

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/__init__.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/__init__.py
@@ -1,0 +1,5 @@
+"""Galaxy MCP CLI - Command line interface for Galaxy bioinformatics platform."""
+
+from .main import app
+
+__all__ = ["app"]

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/__init__.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/__init__.py
@@ -1,0 +1,1 @@
+"""CLI command modules."""

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/collection.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/collection.py
@@ -1,0 +1,35 @@
+"""Collection commands for Galaxy CLI."""
+
+from typing import Annotated
+
+import typer
+
+from galaxy_mcp.server import get_collection_details
+
+from ..output import output_error, output_result
+
+app = typer.Typer(name="collection", help="Manage dataset collections", no_args_is_help=True)
+
+
+def _fn(tool):
+    """Extract the underlying function from a FastMCP tool."""
+    return tool.fn if hasattr(tool, "fn") else tool
+
+
+@app.command("details")
+def details(
+    collection_id: Annotated[str, typer.Argument(help="Collection ID")],
+    max_elements: Annotated[
+        int, typer.Option("--max-elements", help="Maximum elements to return")
+    ] = 100,
+) -> None:
+    """Get detailed information about a dataset collection."""
+    try:
+        result = _fn(get_collection_details)(
+            collection_id=collection_id,
+            max_elements=max_elements,
+        )
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/collection.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/collection.py
@@ -11,11 +11,6 @@ from ..output import output_error, output_result
 app = typer.Typer(name="collection", help="Manage dataset collections", no_args_is_help=True)
 
 
-def _fn(tool):
-    """Extract the underlying function from a FastMCP tool."""
-    return tool.fn if hasattr(tool, "fn") else tool
-
-
 @app.command("details")
 def details(
     collection_id: Annotated[str, typer.Argument(help="Collection ID")],
@@ -25,7 +20,7 @@ def details(
 ) -> None:
     """Get detailed information about a dataset collection."""
     try:
-        result = _fn(get_collection_details)(
+        result = get_collection_details(
             collection_id=collection_id,
             max_elements=max_elements,
         )

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/dataset.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/dataset.py
@@ -1,0 +1,125 @@
+"""Dataset commands for Galaxy CLI."""
+
+from typing import Annotated
+
+import typer
+
+from galaxy_mcp.server import (
+    download_dataset,
+    get_dataset_details,
+    get_job_details,
+    upload_file,
+    upload_file_from_url,
+)
+
+from ..output import output_error, output_result
+
+app = typer.Typer(name="dataset", help="Manage datasets", no_args_is_help=True)
+
+
+def _fn(tool):
+    """Extract the underlying function from a FastMCP tool."""
+    return tool.fn if hasattr(tool, "fn") else tool
+
+
+@app.command("details")
+def details(
+    dataset_id: Annotated[str, typer.Argument(help="Dataset ID")],
+    preview: Annotated[
+        bool, typer.Option("--preview/--no-preview", help="Include content preview")
+    ] = True,
+    preview_lines: Annotated[
+        int, typer.Option("--preview-lines", help="Number of preview lines")
+    ] = 10,
+) -> None:
+    """Get detailed information about a dataset."""
+    try:
+        result = _fn(get_dataset_details)(
+            dataset_id=dataset_id,
+            include_preview=preview,
+            preview_lines=preview_lines,
+        )
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("download")
+def download(
+    dataset_id: Annotated[str, typer.Argument(help="Dataset ID")],
+    output: Annotated[str | None, typer.Option("-o", "--output", help="Output file path")] = None,
+    force: Annotated[
+        bool, typer.Option("--force", help="Download even if not in 'ok' state")
+    ] = False,
+) -> None:
+    """Download a dataset from Galaxy."""
+    try:
+        result = _fn(download_dataset)(
+            dataset_id=dataset_id,
+            file_path=output,
+            require_ok_state=not force,
+        )
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("upload")
+def upload(
+    path: Annotated[str, typer.Argument(help="Local file path to upload")],
+    history_id: Annotated[
+        str | None, typer.Option("-h", "--history-id", help="Target history ID")
+    ] = None,
+) -> None:
+    """Upload a local file to Galaxy."""
+    try:
+        result = _fn(upload_file)(path=path, history_id=history_id)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("upload-url")
+def upload_url(
+    url: Annotated[str, typer.Argument(help="URL of file to upload")],
+    history_id: Annotated[
+        str | None, typer.Option("-h", "--history-id", help="Target history ID")
+    ] = None,
+    file_type: Annotated[
+        str, typer.Option("--type", help="File type (auto for auto-detection)")
+    ] = "auto",
+    dbkey: Annotated[str, typer.Option("--dbkey", help="Genome build")] = "?",
+    name: Annotated[str | None, typer.Option("--name", help="Name for uploaded file")] = None,
+) -> None:
+    """Upload a file from URL to Galaxy."""
+    try:
+        result = _fn(upload_file_from_url)(
+            url=url,
+            history_id=history_id,
+            file_type=file_type,
+            dbkey=dbkey,
+            file_name=name,
+        )
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("job")
+def job(
+    dataset_id: Annotated[str, typer.Argument(help="Dataset ID")],
+    history_id: Annotated[
+        str | None, typer.Option("-h", "--history-id", help="History ID (for performance)")
+    ] = None,
+) -> None:
+    """Get job details for a dataset."""
+    try:
+        result = _fn(get_job_details)(dataset_id=dataset_id, history_id=history_id)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/dataset.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/dataset.py
@@ -17,11 +17,6 @@ from ..output import output_error, output_result
 app = typer.Typer(name="dataset", help="Manage datasets", no_args_is_help=True)
 
 
-def _fn(tool):
-    """Extract the underlying function from a FastMCP tool."""
-    return tool.fn if hasattr(tool, "fn") else tool
-
-
 @app.command("details")
 def details(
     dataset_id: Annotated[str, typer.Argument(help="Dataset ID")],
@@ -34,7 +29,7 @@ def details(
 ) -> None:
     """Get detailed information about a dataset."""
     try:
-        result = _fn(get_dataset_details)(
+        result = get_dataset_details(
             dataset_id=dataset_id,
             include_preview=preview,
             preview_lines=preview_lines,
@@ -55,7 +50,7 @@ def download(
 ) -> None:
     """Download a dataset from Galaxy."""
     try:
-        result = _fn(download_dataset)(
+        result = download_dataset(
             dataset_id=dataset_id,
             file_path=output,
             require_ok_state=not force,
@@ -75,7 +70,7 @@ def upload(
 ) -> None:
     """Upload a local file to Galaxy."""
     try:
-        result = _fn(upload_file)(path=path, history_id=history_id)
+        result = upload_file(path=path, history_id=history_id)
         output_result(result)
     except Exception as e:
         output_error(str(e))
@@ -96,7 +91,7 @@ def upload_url(
 ) -> None:
     """Upload a file from URL to Galaxy."""
     try:
-        result = _fn(upload_file_from_url)(
+        result = upload_file_from_url(
             url=url,
             history_id=history_id,
             file_type=file_type,
@@ -118,7 +113,7 @@ def job(
 ) -> None:
     """Get job details for a dataset."""
     try:
-        result = _fn(get_job_details)(dataset_id=dataset_id, history_id=history_id)
+        result = get_job_details(dataset_id=dataset_id, history_id=history_id)
         output_result(result)
     except Exception as e:
         output_error(str(e))

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/history.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/history.py
@@ -1,0 +1,102 @@
+"""History commands for Galaxy CLI."""
+
+from typing import Annotated
+
+import typer
+
+from galaxy_mcp.server import (
+    create_history,
+    get_histories,
+    get_history_contents,
+    get_history_details,
+    list_history_ids,
+)
+
+from ..output import output_error, output_result
+
+app = typer.Typer(name="history", help="Manage Galaxy histories", no_args_is_help=True)
+
+
+def _fn(tool):
+    """Extract the underlying function from a FastMCP tool."""
+    return tool.fn if hasattr(tool, "fn") else tool
+
+
+@app.command("list")
+def list_histories(
+    limit: Annotated[int | None, typer.Option("-l", "--limit", help="Maximum histories")] = None,
+    offset: Annotated[int, typer.Option("-o", "--offset", help="Skip this many")] = 0,
+    name: Annotated[str | None, typer.Option("-n", "--name", help="Filter by name")] = None,
+) -> None:
+    """List user's histories with optional pagination."""
+    try:
+        result = _fn(get_histories)(limit=limit, offset=offset, name=name)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("ids")
+def ids() -> None:
+    """Get a simplified list of history IDs and names."""
+    try:
+        result = _fn(list_history_ids)()
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("create")
+def create(
+    name: Annotated[str, typer.Argument(help="Name for the new history")],
+) -> None:
+    """Create a new history."""
+    try:
+        result = _fn(create_history)(history_name=name)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("details")
+def details(
+    history_id: Annotated[str, typer.Argument(help="History ID")],
+) -> None:
+    """Get metadata and summary for a history."""
+    try:
+        result = _fn(get_history_details)(history_id=history_id)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("contents")
+def contents(
+    history_id: Annotated[str, typer.Argument(help="History ID")],
+    limit: Annotated[int, typer.Option("-l", "--limit", help="Maximum items")] = 100,
+    offset: Annotated[int, typer.Option("-o", "--offset", help="Skip this many")] = 0,
+    deleted: Annotated[bool, typer.Option("--deleted", help="Include deleted")] = False,
+    hidden: Annotated[bool, typer.Option("--hidden", help="Include hidden")] = False,
+    order: Annotated[
+        str, typer.Option("--order", help="Sort order (hid-asc, hid-dsc, create_time-dsc, etc.)")
+    ] = "hid-asc",
+) -> None:
+    """Get paginated contents of a history."""
+    try:
+        # visible is the inverse of hidden
+        result = _fn(get_history_contents)(
+            history_id=history_id,
+            limit=limit,
+            offset=offset,
+            deleted=deleted,
+            visible=not hidden,
+            order=order,
+        )
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/history.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/history.py
@@ -17,11 +17,6 @@ from ..output import output_error, output_result
 app = typer.Typer(name="history", help="Manage Galaxy histories", no_args_is_help=True)
 
 
-def _fn(tool):
-    """Extract the underlying function from a FastMCP tool."""
-    return tool.fn if hasattr(tool, "fn") else tool
-
-
 @app.command("list")
 def list_histories(
     limit: Annotated[int | None, typer.Option("-l", "--limit", help="Maximum histories")] = None,
@@ -30,7 +25,7 @@ def list_histories(
 ) -> None:
     """List user's histories with optional pagination."""
     try:
-        result = _fn(get_histories)(limit=limit, offset=offset, name=name)
+        result = get_histories(limit=limit, offset=offset, name=name)
         output_result(result)
     except Exception as e:
         output_error(str(e))
@@ -41,7 +36,7 @@ def list_histories(
 def ids() -> None:
     """Get a simplified list of history IDs and names."""
     try:
-        result = _fn(list_history_ids)()
+        result = list_history_ids()
         output_result(result)
     except Exception as e:
         output_error(str(e))
@@ -54,7 +49,7 @@ def create(
 ) -> None:
     """Create a new history."""
     try:
-        result = _fn(create_history)(history_name=name)
+        result = create_history(history_name=name)
         output_result(result)
     except Exception as e:
         output_error(str(e))
@@ -67,7 +62,7 @@ def details(
 ) -> None:
     """Get metadata and summary for a history."""
     try:
-        result = _fn(get_history_details)(history_id=history_id)
+        result = get_history_details(history_id=history_id)
         output_result(result)
     except Exception as e:
         output_error(str(e))
@@ -88,7 +83,7 @@ def contents(
     """Get paginated contents of a history."""
     try:
         # visible is the inverse of hidden
-        result = _fn(get_history_contents)(
+        result = get_history_contents(
             history_id=history_id,
             limit=limit,
             offset=offset,

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/iwc.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/iwc.py
@@ -1,0 +1,94 @@
+"""IWC (Intergalactic Workflow Commission) commands for Galaxy CLI."""
+
+from typing import Annotated
+
+import typer
+
+from galaxy_mcp.server import (
+    get_iwc_workflow_details,
+    get_iwc_workflows,
+    import_workflow_from_iwc,
+    recommend_iwc_workflows,
+    search_iwc_workflows,
+)
+
+from ..output import output_error, output_result
+
+app = typer.Typer(name="iwc", help="Browse and import IWC workflows", no_args_is_help=True)
+
+
+def _fn(tool):
+    """Extract the underlying function from a FastMCP tool."""
+    return tool.fn if hasattr(tool, "fn") else tool
+
+
+@app.command("list")
+def list_workflows() -> None:
+    """List all workflows in the IWC manifest."""
+    try:
+        result = _fn(get_iwc_workflows)()
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("search")
+def search(
+    query: Annotated[str, typer.Argument(help="Search query")],
+) -> None:
+    """Search IWC workflows by name, description, or tags."""
+    try:
+        result = _fn(search_iwc_workflows)(query=query)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("details")
+def details(
+    trs_id: Annotated[str, typer.Argument(help="TRS ID of the workflow")],
+) -> None:
+    """Get comprehensive details about an IWC workflow."""
+    try:
+        result = _fn(get_iwc_workflow_details)(trs_id=trs_id)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("recommend")
+def recommend(
+    intent: Annotated[str, typer.Argument(help="Natural language description of analysis goal")],
+    limit: Annotated[int, typer.Option("-l", "--limit", help="Maximum recommendations")] = 5,
+) -> None:
+    """
+    Get workflow recommendations based on natural language intent.
+
+    Uses BM25 ranking to find workflows matching your analysis description.
+
+    Examples:
+        gxy iwc recommend "differential expression from RNA-seq"
+        gxy iwc recommend "assemble bacterial genome from nanopore reads" --limit 3
+    """
+    try:
+        result = _fn(recommend_iwc_workflows)(intent=intent, limit=limit)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("import")
+def import_wf(
+    trs_id: Annotated[str, typer.Argument(help="TRS ID of the workflow to import")],
+) -> None:
+    """Import an IWC workflow into your Galaxy instance."""
+    try:
+        result = _fn(import_workflow_from_iwc)(trs_id=trs_id)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/iwc.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/iwc.py
@@ -17,16 +17,11 @@ from ..output import output_error, output_result
 app = typer.Typer(name="iwc", help="Browse and import IWC workflows", no_args_is_help=True)
 
 
-def _fn(tool):
-    """Extract the underlying function from a FastMCP tool."""
-    return tool.fn if hasattr(tool, "fn") else tool
-
-
 @app.command("list")
 def list_workflows() -> None:
     """List all workflows in the IWC manifest."""
     try:
-        result = _fn(get_iwc_workflows)()
+        result = get_iwc_workflows()
         output_result(result)
     except Exception as e:
         output_error(str(e))
@@ -39,7 +34,7 @@ def search(
 ) -> None:
     """Search IWC workflows by name, description, or tags."""
     try:
-        result = _fn(search_iwc_workflows)(query=query)
+        result = search_iwc_workflows(query=query)
         output_result(result)
     except Exception as e:
         output_error(str(e))
@@ -52,7 +47,7 @@ def details(
 ) -> None:
     """Get comprehensive details about an IWC workflow."""
     try:
-        result = _fn(get_iwc_workflow_details)(trs_id=trs_id)
+        result = get_iwc_workflow_details(trs_id=trs_id)
         output_result(result)
     except Exception as e:
         output_error(str(e))
@@ -74,7 +69,7 @@ def recommend(
         gxy iwc recommend "assemble bacterial genome from nanopore reads" --limit 3
     """
     try:
-        result = _fn(recommend_iwc_workflows)(intent=intent, limit=limit)
+        result = recommend_iwc_workflows(intent=intent, limit=limit)
         output_result(result)
     except Exception as e:
         output_error(str(e))
@@ -87,7 +82,7 @@ def import_wf(
 ) -> None:
     """Import an IWC workflow into your Galaxy instance."""
     try:
-        result = _fn(import_workflow_from_iwc)(trs_id=trs_id)
+        result = import_workflow_from_iwc(trs_id=trs_id)
         output_result(result)
     except Exception as e:
         output_error(str(e))

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/profile.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/profile.py
@@ -1,0 +1,30 @@
+"""Profile commands for Galaxy CLI."""
+
+import typer
+
+from galaxy_mcp.server import GalaxyResult
+
+from ..config import list_profiles
+from ..output import output_error, output_result
+
+app = typer.Typer(
+    name="profile", help="Inspect configured connection profiles", no_args_is_help=True
+)
+
+
+@app.command("list")
+def list_cmd() -> None:
+    """List connection profiles from the gxy config file and planemo. No connection needed."""
+    try:
+        names = list_profiles()
+        output_result(
+            GalaxyResult(
+                data=names,
+                success=True,
+                message=f"{len(names)} profiles available",
+                count=len(names),
+            )
+        )
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/server.py
@@ -1,0 +1,25 @@
+"""Server commands for Galaxy CLI."""
+
+import typer
+
+from galaxy_mcp.server import get_server_info
+
+from ..output import output_error, output_result
+
+app = typer.Typer(name="server", help="Galaxy server information", no_args_is_help=True)
+
+
+def _fn(tool):
+    """Extract the underlying function from a FastMCP tool."""
+    return tool.fn if hasattr(tool, "fn") else tool
+
+
+@app.command("info")
+def info() -> None:
+    """Get Galaxy server information including version and configuration."""
+    try:
+        result = _fn(get_server_info)()
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/server.py
@@ -9,16 +9,11 @@ from ..output import output_error, output_result
 app = typer.Typer(name="server", help="Galaxy server information", no_args_is_help=True)
 
 
-def _fn(tool):
-    """Extract the underlying function from a FastMCP tool."""
-    return tool.fn if hasattr(tool, "fn") else tool
-
-
 @app.command("info")
 def info() -> None:
     """Get Galaxy server information including version and configuration."""
     try:
-        result = _fn(get_server_info)()
+        result = get_server_info()
         output_result(result)
     except Exception as e:
         output_error(str(e))

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/tools.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/tools.py
@@ -1,0 +1,136 @@
+"""Tools commands for Galaxy CLI."""
+
+import json
+from typing import Annotated, Any
+
+import typer
+
+from galaxy_mcp.server import (
+    get_tool_citations,
+    get_tool_details,
+    get_tool_panel,
+    get_tool_run_examples,
+    run_tool,
+    search_tools_by_keywords,
+    search_tools_by_name,
+)
+
+from ..output import output_error, output_result
+
+app = typer.Typer(name="tools", help="Search and run Galaxy tools", no_args_is_help=True)
+
+
+def _fn(tool):
+    """Extract the underlying function from a FastMCP tool."""
+    return tool.fn if hasattr(tool, "fn") else tool
+
+
+@app.command("search")
+def search(
+    query: Annotated[str, typer.Argument(help="Search query for tool name/ID/description")],
+) -> None:
+    """Search Galaxy tools by name, ID, or description."""
+    try:
+        result = _fn(search_tools_by_name)(query=query)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("keywords")
+def keywords(
+    keywords: Annotated[list[str], typer.Argument(help="Keywords to search for (space-separated)")],
+) -> None:
+    """Search Galaxy tools by multiple keywords."""
+    try:
+        result = _fn(search_tools_by_keywords)(keywords=keywords)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("details")
+def details(
+    tool_id: Annotated[str, typer.Argument(help="Tool ID")],
+    io_details: Annotated[
+        bool, typer.Option("--io-details", "-i", help="Include input/output parameter details")
+    ] = False,
+) -> None:
+    """Get detailed information about a specific tool."""
+    try:
+        result = _fn(get_tool_details)(tool_id=tool_id, io_details=io_details)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("examples")
+def examples(
+    tool_id: Annotated[str, typer.Argument(help="Tool ID")],
+    version: Annotated[
+        str | None, typer.Option("--version", "-v", help="Tool version (use '*' for all)")
+    ] = None,
+) -> None:
+    """Get example test definitions for a tool."""
+    try:
+        result = _fn(get_tool_run_examples)(tool_id=tool_id, tool_version=version)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("citations")
+def citations(
+    tool_id: Annotated[str, typer.Argument(help="Tool ID")],
+) -> None:
+    """Get citation information for a tool."""
+    try:
+        result = _fn(get_tool_citations)(tool_id=tool_id)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("panel")
+def panel() -> None:
+    """Get the tool panel structure (toolbox)."""
+    try:
+        result = _fn(get_tool_panel)()
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("run")
+def run(
+    history_id: Annotated[str, typer.Argument(help="History ID to run tool in")],
+    tool_id: Annotated[str, typer.Argument(help="Tool ID to run")],
+    inputs: Annotated[str, typer.Argument(help="Tool inputs as JSON string")],
+) -> None:
+    """
+    Run a Galaxy tool with specified inputs.
+
+    INPUTS should be a JSON object mapping input names to values.
+    For dataset inputs, use: {"input_name": {"src": "hda", "id": "dataset_id"}}
+
+    Example:
+        gxy tools run abc123 fastqc '{"input_file": {"src": "hda", "id": "def456"}}'
+    """
+    try:
+        inputs_dict: dict[str, Any] = json.loads(inputs)
+    except json.JSONDecodeError as e:
+        output_error(f"Invalid JSON for inputs: {e}")
+        raise typer.Exit(1)
+
+    try:
+        result = _fn(run_tool)(history_id=history_id, tool_id=tool_id, inputs=inputs_dict)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/tools.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/tools.py
@@ -20,18 +20,13 @@ from ..output import output_error, output_result
 app = typer.Typer(name="tools", help="Search and run Galaxy tools", no_args_is_help=True)
 
 
-def _fn(tool):
-    """Extract the underlying function from a FastMCP tool."""
-    return tool.fn if hasattr(tool, "fn") else tool
-
-
 @app.command("search")
 def search(
     query: Annotated[str, typer.Argument(help="Search query for tool name/ID/description")],
 ) -> None:
     """Search Galaxy tools by name, ID, or description."""
     try:
-        result = _fn(search_tools_by_name)(query=query)
+        result = search_tools_by_name(query=query)
         output_result(result)
     except Exception as e:
         output_error(str(e))
@@ -44,7 +39,7 @@ def keywords(
 ) -> None:
     """Search Galaxy tools by multiple keywords."""
     try:
-        result = _fn(search_tools_by_keywords)(keywords=keywords)
+        result = search_tools_by_keywords(keywords=keywords)
         output_result(result)
     except Exception as e:
         output_error(str(e))
@@ -60,7 +55,7 @@ def details(
 ) -> None:
     """Get detailed information about a specific tool."""
     try:
-        result = _fn(get_tool_details)(tool_id=tool_id, io_details=io_details)
+        result = get_tool_details(tool_id=tool_id, io_details=io_details)
         output_result(result)
     except Exception as e:
         output_error(str(e))
@@ -76,7 +71,7 @@ def examples(
 ) -> None:
     """Get example test definitions for a tool."""
     try:
-        result = _fn(get_tool_run_examples)(tool_id=tool_id, tool_version=version)
+        result = get_tool_run_examples(tool_id=tool_id, tool_version=version)
         output_result(result)
     except Exception as e:
         output_error(str(e))
@@ -89,7 +84,7 @@ def citations(
 ) -> None:
     """Get citation information for a tool."""
     try:
-        result = _fn(get_tool_citations)(tool_id=tool_id)
+        result = get_tool_citations(tool_id=tool_id)
         output_result(result)
     except Exception as e:
         output_error(str(e))
@@ -100,7 +95,7 @@ def citations(
 def panel() -> None:
     """Get the tool panel structure (toolbox)."""
     try:
-        result = _fn(get_tool_panel)()
+        result = get_tool_panel()
         output_result(result)
     except Exception as e:
         output_error(str(e))
@@ -129,7 +124,7 @@ def run(
         raise typer.Exit(1)
 
     try:
-        result = _fn(run_tool)(history_id=history_id, tool_id=tool_id, inputs=inputs_dict)
+        result = run_tool(history_id=history_id, tool_id=tool_id, inputs=inputs_dict)
         output_result(result)
     except Exception as e:
         output_error(str(e))

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/user.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/user.py
@@ -1,0 +1,25 @@
+"""User commands for Galaxy CLI."""
+
+import typer
+
+from galaxy_mcp.server import get_user
+
+from ..output import output_error, output_result
+
+app = typer.Typer(name="user", help="User information", no_args_is_help=True)
+
+
+def _fn(tool):
+    """Extract the underlying function from a FastMCP tool."""
+    return tool.fn if hasattr(tool, "fn") else tool
+
+
+@app.command("info")
+def info() -> None:
+    """Get current user information."""
+    try:
+        result = _fn(get_user)()
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/user.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/user.py
@@ -9,16 +9,11 @@ from ..output import output_error, output_result
 app = typer.Typer(name="user", help="User information", no_args_is_help=True)
 
 
-def _fn(tool):
-    """Extract the underlying function from a FastMCP tool."""
-    return tool.fn if hasattr(tool, "fn") else tool
-
-
 @app.command("info")
 def info() -> None:
     """Get current user information."""
     try:
-        result = _fn(get_user)()
+        result = get_user()
         output_result(result)
     except Exception as e:
         output_error(str(e))

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/workflow.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/workflow.py
@@ -1,0 +1,156 @@
+"""Workflow commands for Galaxy CLI."""
+
+import json
+from typing import Annotated, Any
+
+import typer
+
+from galaxy_mcp.server import (
+    cancel_workflow_invocation,
+    get_invocations,
+    get_workflow_details,
+    invoke_workflow,
+    list_workflows,
+)
+
+from ..output import output_error, output_result
+
+app = typer.Typer(name="workflow", help="Manage and run workflows", no_args_is_help=True)
+
+
+def _fn(tool):
+    """Extract the underlying function from a FastMCP tool."""
+    return tool.fn if hasattr(tool, "fn") else tool
+
+
+@app.command("list")
+def list_wf(
+    workflow_id: Annotated[str | None, typer.Option("--id", help="Specific workflow ID")] = None,
+    name: Annotated[str | None, typer.Option("-n", "--name", help="Filter by name")] = None,
+    published: Annotated[bool, typer.Option("--published", help="Include published")] = False,
+) -> None:
+    """List workflows available in Galaxy."""
+    try:
+        result = _fn(list_workflows)(workflow_id=workflow_id, name=name, published=published)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("details")
+def details(
+    workflow_id: Annotated[str, typer.Argument(help="Workflow ID")],
+    version: Annotated[int | None, typer.Option("-v", "--version", help="Specific version")] = None,
+) -> None:
+    """Get detailed information about a workflow."""
+    try:
+        result = _fn(get_workflow_details)(workflow_id=workflow_id, version=version)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("invoke")
+def invoke(
+    workflow_id: Annotated[str, typer.Argument(help="Workflow ID")],
+    inputs: Annotated[
+        str | None, typer.Option("-i", "--inputs", help="Workflow inputs as JSON")
+    ] = None,
+    params: Annotated[
+        str | None, typer.Option("-p", "--params", help="Tool parameters as JSON")
+    ] = None,
+    history_id: Annotated[
+        str | None, typer.Option("-h", "--history-id", help="Target history ID")
+    ] = None,
+    history_name: Annotated[
+        str | None, typer.Option("--history-name", help="Name for new history")
+    ] = None,
+    inputs_by: Annotated[
+        str,
+        typer.Option("--inputs-by", help="How to identify inputs (step_index, step_uuid, name)"),
+    ] = "step_index",
+) -> None:
+    """
+    Invoke (run) a workflow.
+
+    INPUTS and PARAMS should be JSON objects.
+
+    Example:
+        gxy workflow invoke abc123 -i '{"0": {"src": "hda", "id": "def456"}}'
+    """
+    inputs_dict: dict[str, Any] | None = None
+    params_dict: dict[str, Any] | None = None
+
+    if inputs:
+        try:
+            inputs_dict = json.loads(inputs)
+        except json.JSONDecodeError as e:
+            output_error(f"Invalid JSON for inputs: {e}")
+            raise typer.Exit(1)
+
+    if params:
+        try:
+            params_dict = json.loads(params)
+        except json.JSONDecodeError as e:
+            output_error(f"Invalid JSON for params: {e}")
+            raise typer.Exit(1)
+
+    try:
+        result = _fn(invoke_workflow)(
+            workflow_id=workflow_id,
+            inputs=inputs_dict,
+            params=params_dict,
+            history_id=history_id,
+            history_name=history_name,
+            inputs_by=inputs_by,
+        )
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("invocations")
+def invocations(
+    invocation_id: Annotated[
+        str | None, typer.Option("--id", help="Specific invocation ID")
+    ] = None,
+    workflow_id: Annotated[
+        str | None, typer.Option("-w", "--workflow-id", help="Filter by workflow")
+    ] = None,
+    history_id: Annotated[
+        str | None, typer.Option("-h", "--history-id", help="Filter by history")
+    ] = None,
+    limit: Annotated[int | None, typer.Option("-l", "--limit", help="Maximum to return")] = None,
+    detailed: Annotated[bool, typer.Option("--detailed", help="Include step details")] = False,
+) -> None:
+    """View workflow invocations."""
+    try:
+        view = "element" if detailed else "collection"
+        result = _fn(get_invocations)(
+            invocation_id=invocation_id,
+            workflow_id=workflow_id,
+            history_id=history_id,
+            limit=limit,
+            view=view,
+            step_details=detailed,
+        )
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+@app.command("cancel")
+def cancel(
+    invocation_id: Annotated[str, typer.Argument(help="Invocation ID to cancel")],
+) -> None:
+    """Cancel a running workflow invocation."""
+    try:
+        result = _fn(cancel_workflow_invocation)(invocation_id=invocation_id)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/workflow.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/commands/workflow.py
@@ -18,11 +18,6 @@ from ..output import output_error, output_result
 app = typer.Typer(name="workflow", help="Manage and run workflows", no_args_is_help=True)
 
 
-def _fn(tool):
-    """Extract the underlying function from a FastMCP tool."""
-    return tool.fn if hasattr(tool, "fn") else tool
-
-
 @app.command("list")
 def list_wf(
     workflow_id: Annotated[str | None, typer.Option("--id", help="Specific workflow ID")] = None,
@@ -31,7 +26,7 @@ def list_wf(
 ) -> None:
     """List workflows available in Galaxy."""
     try:
-        result = _fn(list_workflows)(workflow_id=workflow_id, name=name, published=published)
+        result = list_workflows(workflow_id=workflow_id, name=name, published=published)
         output_result(result)
     except Exception as e:
         output_error(str(e))
@@ -45,7 +40,7 @@ def details(
 ) -> None:
     """Get detailed information about a workflow."""
     try:
-        result = _fn(get_workflow_details)(workflow_id=workflow_id, version=version)
+        result = get_workflow_details(workflow_id=workflow_id, version=version)
         output_result(result)
     except Exception as e:
         output_error(str(e))
@@ -98,7 +93,7 @@ def invoke(
             raise typer.Exit(1)
 
     try:
-        result = _fn(invoke_workflow)(
+        result = invoke_workflow(
             workflow_id=workflow_id,
             inputs=inputs_dict,
             params=params_dict,
@@ -129,7 +124,7 @@ def invocations(
     """View workflow invocations."""
     try:
         view = "element" if detailed else "collection"
-        result = _fn(get_invocations)(
+        result = get_invocations(
             invocation_id=invocation_id,
             workflow_id=workflow_id,
             history_id=history_id,
@@ -149,7 +144,7 @@ def cancel(
 ) -> None:
     """Cancel a running workflow invocation."""
     try:
-        result = _fn(cancel_workflow_invocation)(invocation_id=invocation_id)
+        result = cancel_workflow_invocation(invocation_id=invocation_id)
         output_result(result)
     except Exception as e:
         output_error(str(e))

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/config.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/config.py
@@ -1,0 +1,173 @@
+"""Configuration file handling for Galaxy MCP CLI."""
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+
+class GalaxyConfig(NamedTuple):
+    """Galaxy connection configuration."""
+
+    url: str | None
+    api_key: str | None
+
+
+CONFIG_DIR = Path.home() / ".galaxy-mcp"
+CONFIG_FILE = CONFIG_DIR / "config.toml"
+
+PLANEMO_PROFILES_DIR = Path.home() / ".planemo" / "profiles"
+PLANEMO_PROFILE_OPTIONS = "planemo_profile_options.json"
+
+
+def get_config_path() -> Path:
+    """Get the path to the config file."""
+    return CONFIG_FILE
+
+
+def _load_planemo_profile(profile_name: str) -> GalaxyConfig | None:
+    """
+    Try to load a profile from planemo's profile directory.
+
+    Planemo stores external Galaxy profiles as JSON at:
+    ~/.planemo/profiles/<name>/planemo_profile_options.json
+
+    Only external_galaxy engine profiles are usable (they have url + key).
+    """
+    profile_dir = PLANEMO_PROFILES_DIR / profile_name
+    options_file = profile_dir / PLANEMO_PROFILE_OPTIONS
+    if not options_file.exists():
+        return None
+
+    try:
+        with open(options_file) as f:
+            options = json.load(f)
+    except Exception:
+        return None
+
+    # Only external Galaxy profiles have connection credentials
+    if options.get("engine") != "external_galaxy":
+        return None
+
+    url = options.get("galaxy_url")
+    api_key = options.get("galaxy_user_key") or options.get("galaxy_admin_key")
+    if url and api_key:
+        return GalaxyConfig(url=url, api_key=api_key)
+
+    return None
+
+
+def _list_planemo_profiles() -> list[str]:
+    """List planemo profiles that are usable external Galaxy connections."""
+    if not PLANEMO_PROFILES_DIR.exists():
+        return []
+
+    profiles = []
+    try:
+        for entry in PLANEMO_PROFILES_DIR.iterdir():
+            if not entry.is_dir():
+                continue
+            options_file = entry / PLANEMO_PROFILE_OPTIONS
+            if not options_file.exists():
+                continue
+            try:
+                with open(options_file) as f:
+                    options = json.load(f)
+                if options.get("engine") == "external_galaxy":
+                    profiles.append(entry.name)
+            except Exception:
+                continue
+    except Exception:
+        pass
+
+    return profiles
+
+
+def load_profile(profile: str | None = None) -> GalaxyConfig:
+    """
+    Load Galaxy configuration from profile.
+
+    Priority:
+    1. Environment variables (GALAXY_URL, GALAXY_API_KEY)
+    2. gxy config file (~/.galaxy-mcp/config.toml)
+    3. Planemo profiles (~/.planemo/profiles/<name>/)
+
+    When a profile name is given explicitly, it is looked up first in the
+    gxy config file, then in planemo profiles. When no profile is given,
+    the 'default' entry in the gxy config file is used.
+
+    Args:
+        profile: Profile name to load from config file
+
+    Returns:
+        GalaxyConfig with url and api_key
+    """
+    # Start with environment variables
+    url = os.environ.get("GALAXY_URL")
+    api_key = os.environ.get("GALAXY_API_KEY")
+
+    # If both are set from environment, use them
+    if url and api_key:
+        return GalaxyConfig(url=url, api_key=api_key)
+
+    # Try to load from gxy config file
+    if CONFIG_FILE.exists():
+        try:
+            with open(CONFIG_FILE, "rb") as f:
+                config = tomllib.load(f)
+
+            profile_name = profile or "default"
+            if profile_name in config:
+                profile_config = config[profile_name]
+                if not url:
+                    url = profile_config.get("url")
+                if not api_key:
+                    api_key = profile_config.get("api_key")
+
+                if url and api_key:
+                    return GalaxyConfig(url=url, api_key=api_key)
+        except Exception:
+            pass
+
+    # Fall back to planemo profiles when an explicit profile name was given
+    if profile:
+        planemo_config = _load_planemo_profile(profile)
+        if planemo_config:
+            return GalaxyConfig(
+                url=url or planemo_config.url,
+                api_key=api_key or planemo_config.api_key,
+            )
+
+    return GalaxyConfig(url=url, api_key=api_key)
+
+
+def list_profiles() -> list[str]:
+    """List available profiles from gxy config and planemo."""
+    profiles: list[str] = []
+
+    if CONFIG_FILE.exists():
+        try:
+            with open(CONFIG_FILE, "rb") as f:
+                config = tomllib.load(f)
+            profiles.extend(config.keys())
+        except Exception:
+            pass
+
+    # Add planemo profiles that aren't already listed
+    for name in _list_planemo_profiles():
+        if name not in profiles:
+            profiles.append(name)
+
+    return profiles
+
+
+def ensure_config_dir() -> Path:
+    """Ensure the config directory exists."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    return CONFIG_DIR

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/config.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/config.py
@@ -26,11 +26,6 @@ PLANEMO_PROFILES_DIR = Path.home() / ".planemo" / "profiles"
 PLANEMO_PROFILE_OPTIONS = "planemo_profile_options.json"
 
 
-def get_config_path() -> Path:
-    """Get the path to the config file."""
-    return CONFIG_FILE
-
-
 def _load_planemo_profile(profile_name: str) -> GalaxyConfig | None:
     """
     Try to load a profile from planemo's profile directory.
@@ -165,9 +160,3 @@ def list_profiles() -> list[str]:
             profiles.append(name)
 
     return profiles
-
-
-def ensure_config_dir() -> Path:
-    """Ensure the config directory exists."""
-    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    return CONFIG_DIR

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/main.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/main.py
@@ -1,0 +1,102 @@
+"""Main CLI application for Galaxy MCP."""
+
+from typing import Annotated
+
+import typer
+
+from galaxy_mcp.server import connect as connect_tool
+
+from .commands import collection, dataset, history, iwc, server, tools, user, workflow
+from .config import load_profile
+from .output import output_error, output_result, set_pretty_output
+
+app = typer.Typer(
+    name="gxy",
+    help="Galaxy command-line interface for bioinformatics operations.",
+    no_args_is_help=True,
+)
+
+# Register command groups
+app.add_typer(tools.app, name="tools", help="Search and run Galaxy tools")
+app.add_typer(history.app, name="history", help="Manage Galaxy histories")
+app.add_typer(dataset.app, name="dataset", help="Manage datasets")
+app.add_typer(collection.app, name="collection", help="Manage dataset collections")
+app.add_typer(workflow.app, name="workflow", help="Manage and run workflows")
+app.add_typer(iwc.app, name="iwc", help="Browse and import IWC workflows")
+app.add_typer(server.app, name="server", help="Galaxy server information")
+app.add_typer(user.app, name="user", help="User information")
+
+
+def _get_underlying_fn(tool):
+    """Extract the underlying function from a FastMCP tool."""
+    return tool.fn if hasattr(tool, "fn") else tool
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    url: Annotated[
+        str | None,
+        typer.Option("--url", "-u", help="Galaxy server URL", envvar="GALAXY_URL"),
+    ] = None,
+    api_key: Annotated[
+        str | None,
+        typer.Option("--api-key", "-k", help="Galaxy API key", envvar="GALAXY_API_KEY"),
+    ] = None,
+    profile: Annotated[
+        str | None,
+        typer.Option("--profile", "-p", help="Config profile to use"),
+    ] = None,
+    pretty: Annotated[
+        bool,
+        typer.Option("--pretty", help="Pretty-print JSON output"),
+    ] = False,
+) -> None:
+    """
+    Galaxy CLI - Command line interface for Galaxy bioinformatics platform.
+
+    Configure credentials via:
+    - Environment variables: GALAXY_URL and GALAXY_API_KEY
+    - Config file: ~/.galaxy-mcp/config.toml
+    - Command line options: --url and --api-key
+    """
+    set_pretty_output(pretty)
+
+    # Load configuration
+    config = load_profile(profile)
+
+    # Command-line options override config
+    final_url = url or config.url
+    final_api_key = api_key or config.api_key
+
+    # Store in context for commands to use
+    ctx.ensure_object(dict)
+    ctx.obj["url"] = final_url
+    ctx.obj["api_key"] = final_api_key
+    ctx.obj["profile"] = profile
+
+
+@app.command()
+def connect(ctx: typer.Context) -> None:
+    """Connect to Galaxy and verify credentials."""
+    url = ctx.obj.get("url")
+    api_key = ctx.obj.get("api_key")
+
+    if not url or not api_key:
+        output_error(
+            "Missing credentials. Set GALAXY_URL and GALAXY_API_KEY environment variables, "
+            "use --url and --api-key options, or configure ~/.galaxy-mcp/config.toml"
+        )
+        raise typer.Exit(1)
+
+    try:
+        fn = _get_underlying_fn(connect_tool)
+        result = fn(url=url, api_key=api_key)
+        output_result(result)
+    except Exception as e:
+        output_error(str(e))
+        raise typer.Exit(1)
+
+
+if __name__ == "__main__":
+    app()

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/main.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/main.py
@@ -7,7 +7,7 @@ import typer
 
 from galaxy_mcp.server import connect_global
 
-from .commands import collection, dataset, history, iwc, server, tools, user, workflow
+from .commands import collection, dataset, history, iwc, profile, server, tools, user, workflow
 from .config import load_profile
 from .output import output_error, output_result, set_pretty_output
 
@@ -26,6 +26,7 @@ app.add_typer(workflow.app, name="workflow", help="Manage and run workflows")
 app.add_typer(iwc.app, name="iwc", help="Browse and import IWC workflows")
 app.add_typer(server.app, name="server", help="Galaxy server information")
 app.add_typer(user.app, name="user", help="User information")
+app.add_typer(profile.app, name="profile", help="Inspect configured connection profiles")
 
 
 @app.callback()

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/main.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/main.py
@@ -1,10 +1,11 @@
 """Main CLI application for Galaxy MCP."""
 
+import contextlib
 from typing import Annotated
 
 import typer
 
-from galaxy_mcp.server import connect as connect_tool
+from galaxy_mcp.server import connect_global
 
 from .commands import collection, dataset, history, iwc, server, tools, user, workflow
 from .config import load_profile
@@ -25,11 +26,6 @@ app.add_typer(workflow.app, name="workflow", help="Manage and run workflows")
 app.add_typer(iwc.app, name="iwc", help="Browse and import IWC workflows")
 app.add_typer(server.app, name="server", help="Galaxy server information")
 app.add_typer(user.app, name="user", help="User information")
-
-
-def _get_underlying_fn(tool):
-    """Extract the underlying function from a FastMCP tool."""
-    return tool.fn if hasattr(tool, "fn") else tool
 
 
 @app.callback()
@@ -75,6 +71,14 @@ def main(
     ctx.obj["api_key"] = final_api_key
     ctx.obj["profile"] = profile
 
+    # Seed a process-global connection for commands that talk to Galaxy.
+    # Best-effort: IWC discovery commands need no connection, and `connect`
+    # handles its own. Commands that DO need Galaxy will surface a clean
+    # "Not connected" error if creds are missing or invalid.
+    if final_url and final_api_key and ctx.invoked_subcommand not in (None, "connect"):
+        with contextlib.suppress(Exception):
+            connect_global(final_url, final_api_key)
+
 
 @app.command()
 def connect(ctx: typer.Context) -> None:
@@ -90,8 +94,7 @@ def connect(ctx: typer.Context) -> None:
         raise typer.Exit(1)
 
     try:
-        fn = _get_underlying_fn(connect_tool)
-        result = fn(url=url, api_key=api_key)
+        result = connect_global(url=url, api_key=api_key)
         output_result(result)
     except Exception as e:
         output_error(str(e))

--- a/mcp-server-galaxy-py/src/galaxy_mcp/cli/output.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/cli/output.py
@@ -1,0 +1,47 @@
+"""Output formatting for Galaxy MCP CLI."""
+
+import json
+import sys
+from typing import Any
+
+# Global state for output formatting
+_pretty_output = False
+
+
+def set_pretty_output(pretty: bool) -> None:
+    """Set whether to use pretty output formatting."""
+    global _pretty_output
+    _pretty_output = pretty
+
+
+def is_pretty_output() -> bool:
+    """Check if pretty output is enabled."""
+    return _pretty_output
+
+
+def output_result(result: Any) -> None:
+    """
+    Output a result to stdout.
+
+    If the result has a model_dump method (Pydantic model), use it.
+    Otherwise, output as JSON directly.
+
+    Args:
+        result: The result to output (GalaxyResult or dict)
+    """
+    # Handle Pydantic models
+    data = result.model_dump() if hasattr(result, "model_dump") else result
+
+    if _pretty_output:
+        print(json.dumps(data, indent=2, default=str))
+    else:
+        print(json.dumps(data, default=str))
+
+
+def output_error(message: str) -> None:
+    """Output an error message to stderr."""
+    error_data = {"error": message, "success": False}
+    if _pretty_output:
+        print(json.dumps(error_data, indent=2), file=sys.stderr)
+    else:
+        print(json.dumps(error_data), file=sys.stderr)

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -739,6 +739,29 @@ def connect(url: str | None = None, api_key: str | None = None) -> GalaxyResult:
         raise ValueError(error_msg) from e
 
 
+def connect_global(url: str, api_key: str) -> GalaxyResult:
+    """Establish a process-global Galaxy connection for single-user clients.
+
+    Unlike the connect() MCP tool -- which is OAuth/session-aware for multi-user
+    servers and deliberately does not write global state -- this always seeds the
+    module-global galaxy_state. It is intended ONLY for single-user, single-process
+    contexts such as the gxy CLI, and must never be called inside the multi-tenant
+    HTTP server, where it would leak one user's credentials into the global default.
+    """
+    normalized = url if url.endswith("/") else f"{url}/"
+    gi = _make_thread_safe(GalaxyInstance(url=normalized, key=api_key, user_agent=USER_AGENT))
+    user_info = gi.users.get_current_user()  # validates the credentials
+    galaxy_state["url"] = normalized
+    galaxy_state["api_key"] = api_key
+    galaxy_state["gi"] = gi
+    galaxy_state["connected"] = True
+    return GalaxyResult(
+        data={"connected": True, "user": user_info, "url": normalized, "auth": "global"},
+        success=True,
+        message=f"Connected to Galaxy at {normalized}",
+    )
+
+
 @mcp.tool(tags={"tools", "read", "extended"})
 def search_tools_by_name(query: str) -> GalaxyResult:
     """

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -318,7 +318,9 @@ def _format_tool_input_error(
 dotenv_path = find_dotenv(usecwd=True)
 if dotenv_path:
     load_dotenv(dotenv_path)
-    print(f"Loaded environment variables from {dotenv_path}")
+    # Log to stderr, not stdout -- stdout is the data channel for the gxy CLI
+    # (JSON) and the MCP stdio transport (JSON-RPC); a stray print corrupts both.
+    logger.info("Loaded environment variables from %s", dotenv_path)
 
 # Configure Galaxy target and client state
 raw_galaxy_url = os.environ.get("GALAXY_URL")

--- a/mcp-server-galaxy-py/tests/test_cli.py
+++ b/mcp-server-galaxy-py/tests/test_cli.py
@@ -454,3 +454,29 @@ class TestPlanemoProfiles:
         assert result.exit_code == 0
         output = json.loads(result.stdout)
         assert output["data"]["connected"] is True
+
+
+class TestConnectGlobal:
+    """server.connect_global seeds the process-global connection for the CLI."""
+
+    def test_connect_global_seeds_state_and_validates(self, monkeypatch):
+        import galaxy_mcp.server as server
+
+        fake_user = {"username": "testuser"}
+        fake_gi = Mock()
+        fake_gi.users.get_current_user.return_value = fake_user
+
+        # Reset global state, then stub the GalaxyInstance constructor + thread-safe wrap.
+        monkeypatch.setitem(server.galaxy_state, "gi", None)
+        monkeypatch.setitem(server.galaxy_state, "connected", False)
+        monkeypatch.setattr(server, "GalaxyInstance", Mock(return_value=fake_gi))
+        monkeypatch.setattr(server, "_make_thread_safe", lambda gi: gi)
+
+        result = server.connect_global("https://example.org", "key123")
+
+        assert result.success is True
+        assert result.data["connected"] is True
+        assert result.data["url"] == "https://example.org/"  # normalized trailing slash
+        assert server.galaxy_state["connected"] is True
+        assert server.galaxy_state["gi"] is fake_gi
+        fake_gi.users.get_current_user.assert_called_once()

--- a/mcp-server-galaxy-py/tests/test_cli.py
+++ b/mcp-server-galaxy-py/tests/test_cli.py
@@ -15,9 +15,16 @@ runner = CliRunner()
 
 @pytest.fixture(autouse=True)
 def _mock_env(monkeypatch):
-    """Set up mock environment for CLI tests."""
+    """Provide credentials and a no-op connection for command tests."""
     monkeypatch.setenv("GALAXY_URL", "https://test.galaxy.com")
     monkeypatch.setenv("GALAXY_API_KEY", "test_api_key")
+    # The CLI callback seeds a connection from resolved creds; stub it so
+    # command tests stay hermetic. Tests that exercise the bootstrap or the
+    # connect command patch connect_global themselves and override this.
+    monkeypatch.setattr(
+        "galaxy_mcp.cli.main.connect_global",
+        Mock(return_value=None),
+    )
 
 
 class TestCliHelp:
@@ -62,8 +69,7 @@ class TestConnectCommand:
             message="Connected to Galaxy",
         )
 
-        with patch("galaxy_mcp.cli.main.connect_tool") as mock_connect:
-            mock_connect.fn = Mock(return_value=mock_result)
+        with patch("galaxy_mcp.cli.main.connect_global", return_value=mock_result):
             result = runner.invoke(app, ["connect"])
 
         assert result.exit_code == 0
@@ -446,9 +452,8 @@ class TestPlanemoProfiles:
         with (
             patch("galaxy_mcp.cli.config.CONFIG_FILE", fake_config),
             patch("galaxy_mcp.cli.config.PLANEMO_PROFILES_DIR", tmp_path / "planemo_profiles"),
-            patch("galaxy_mcp.cli.main.connect_tool") as mock_connect,
+            patch("galaxy_mcp.cli.main.connect_global", return_value=mock_result),
         ):
-            mock_connect.fn = Mock(return_value=mock_result)
             result = runner.invoke(app, ["--profile", "test-server", "connect"])
 
         assert result.exit_code == 0
@@ -480,3 +485,35 @@ class TestConnectGlobal:
         assert server.galaxy_state["connected"] is True
         assert server.galaxy_state["gi"] is fake_gi
         fake_gi.users.get_current_user.assert_called_once()
+
+
+class TestConnectionBootstrap:
+    def test_data_command_connects_from_flags(self, monkeypatch):
+        """A data command run with --url/--api-key seeds the connection via connect_global."""
+        monkeypatch.delenv("GALAXY_URL", raising=False)
+        monkeypatch.delenv("GALAXY_API_KEY", raising=False)
+
+        called = {}
+
+        def fake_connect_global(url, api_key):
+            called["url"] = url
+            called["api_key"] = api_key
+            from galaxy_mcp.server import GalaxyResult
+
+            return GalaxyResult(data={"connected": True}, success=True, message="ok")
+
+        with (
+            patch("galaxy_mcp.cli.main.connect_global", side_effect=fake_connect_global),
+            patch("galaxy_mcp.cli.commands.history.get_histories") as mock_hist,
+        ):
+            mock_hist.return_value = __import__(
+                "galaxy_mcp.server", fromlist=["GalaxyResult"]
+            ).GalaxyResult(data=[], success=True, message="none", count=0)
+            result = runner.invoke(
+                app,
+                ["--url", "https://flagged.example.org", "--api-key", "flagkey", "history", "list"],
+            )
+
+        assert result.exit_code == 0
+        assert called["url"] == "https://flagged.example.org"
+        assert called["api_key"] == "flagkey"

--- a/mcp-server-galaxy-py/tests/test_cli.py
+++ b/mcp-server-galaxy-py/tests/test_cli.py
@@ -1,0 +1,456 @@
+"""Tests for the Galaxy MCP CLI (gxy)."""
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from galaxy_mcp.cli.config import _load_planemo_profile, list_profiles, load_profile
+from galaxy_mcp.cli.main import app
+from galaxy_mcp.server import GalaxyResult
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _mock_env(monkeypatch):
+    """Set up mock environment for CLI tests."""
+    monkeypatch.setenv("GALAXY_URL", "https://test.galaxy.com")
+    monkeypatch.setenv("GALAXY_API_KEY", "test_api_key")
+
+
+class TestCliHelp:
+    """Test CLI help and basic functionality."""
+
+    def test_help(self):
+        """Test that --help works."""
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "Galaxy command-line interface" in result.stdout
+
+    def test_tools_help(self):
+        """Test tools subcommand help."""
+        result = runner.invoke(app, ["tools", "--help"])
+        assert result.exit_code == 0
+        assert "search" in result.stdout
+        assert "details" in result.stdout
+
+    def test_history_help(self):
+        """Test history subcommand help."""
+        result = runner.invoke(app, ["history", "--help"])
+        assert result.exit_code == 0
+        assert "list" in result.stdout
+        assert "create" in result.stdout
+
+    def test_iwc_help(self):
+        """Test iwc subcommand help."""
+        result = runner.invoke(app, ["iwc", "--help"])
+        assert result.exit_code == 0
+        assert "search" in result.stdout
+        assert "recommend" in result.stdout
+
+
+class TestConnectCommand:
+    """Test the connect command."""
+
+    def test_connect_success(self):
+        """Test successful connection."""
+        mock_result = GalaxyResult(
+            data={"connected": True, "user": {"username": "testuser"}},
+            success=True,
+            message="Connected to Galaxy",
+        )
+
+        with patch("galaxy_mcp.cli.main.connect_tool") as mock_connect:
+            mock_connect.fn = Mock(return_value=mock_result)
+            result = runner.invoke(app, ["connect"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["success"] is True
+        assert output["data"]["connected"] is True
+
+    def test_connect_missing_credentials(self, monkeypatch):
+        """Test connection without credentials."""
+        monkeypatch.delenv("GALAXY_URL", raising=False)
+        monkeypatch.delenv("GALAXY_API_KEY", raising=False)
+
+        result = runner.invoke(app, ["connect"])
+
+        assert result.exit_code == 1
+        output = json.loads(result.stderr)
+        assert "Missing credentials" in output["error"]
+
+
+class TestToolsCommands:
+    """Test tools commands."""
+
+    def test_search(self):
+        """Test tools search command."""
+        mock_result = GalaxyResult(
+            data=[{"id": "fastqc", "name": "FastQC"}],
+            success=True,
+            message="Found 1 tools",
+            count=1,
+        )
+
+        with patch("galaxy_mcp.cli.commands.tools.search_tools_by_name") as mock:
+            mock.fn = Mock(return_value=mock_result)
+            result = runner.invoke(app, ["tools", "search", "fastqc"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["count"] == 1
+        assert output["data"][0]["id"] == "fastqc"
+
+    def test_search_pretty(self):
+        """Test tools search with pretty output."""
+        mock_result = GalaxyResult(
+            data=[{"id": "fastqc", "name": "FastQC"}],
+            success=True,
+            message="Found 1 tools",
+            count=1,
+        )
+
+        with patch("galaxy_mcp.cli.commands.tools.search_tools_by_name") as mock:
+            mock.fn = Mock(return_value=mock_result)
+            result = runner.invoke(app, ["--pretty", "tools", "search", "fastqc"])
+
+        assert result.exit_code == 0
+        # Pretty output should be indented
+        assert "  " in result.stdout
+
+    def test_details(self):
+        """Test tools details command."""
+        mock_result = GalaxyResult(
+            data={"id": "fastqc", "name": "FastQC", "inputs": []},
+            success=True,
+            message="Retrieved details",
+        )
+
+        with patch("galaxy_mcp.cli.commands.tools.get_tool_details") as mock:
+            mock.fn = Mock(return_value=mock_result)
+            result = runner.invoke(app, ["tools", "details", "fastqc"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["data"]["id"] == "fastqc"
+
+
+class TestHistoryCommands:
+    """Test history commands."""
+
+    def test_list(self):
+        """Test history list command."""
+        mock_result = GalaxyResult(
+            data=[{"id": "hist1", "name": "My History"}],
+            success=True,
+            message="Retrieved 1 histories",
+            count=1,
+        )
+
+        with patch("galaxy_mcp.cli.commands.history.get_histories") as mock:
+            mock.fn = Mock(return_value=mock_result)
+            result = runner.invoke(app, ["history", "list"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["count"] == 1
+
+    def test_create(self):
+        """Test history create command."""
+        mock_result = GalaxyResult(
+            data={"id": "new_hist", "name": "New History"},
+            success=True,
+            message="Created history",
+        )
+
+        with patch("galaxy_mcp.cli.commands.history.create_history") as mock:
+            mock.fn = Mock(return_value=mock_result)
+            result = runner.invoke(app, ["history", "create", "New History"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["data"]["name"] == "New History"
+
+
+class TestIWCCommands:
+    """Test IWC commands."""
+
+    def test_search(self):
+        """Test iwc search command."""
+        mock_result = GalaxyResult(
+            data=[{"trsID": "#workflow/test", "name": "RNA-seq"}],
+            success=True,
+            message="Found 1 workflows",
+            count=1,
+        )
+
+        with patch("galaxy_mcp.cli.commands.iwc.search_iwc_workflows") as mock:
+            mock.fn = Mock(return_value=mock_result)
+            result = runner.invoke(app, ["iwc", "search", "rna-seq"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["count"] == 1
+
+    def test_recommend(self):
+        """Test iwc recommend command."""
+        mock_result = GalaxyResult(
+            data=[{"trsID": "#workflow/test", "name": "RNA-seq", "match_score": 10.5}],
+            success=True,
+            message="Found 1 workflows",
+            count=1,
+        )
+
+        with patch("galaxy_mcp.cli.commands.iwc.recommend_iwc_workflows") as mock:
+            mock.fn = Mock(return_value=mock_result)
+            result = runner.invoke(
+                app, ["iwc", "recommend", "differential expression from RNA-seq"]
+            )
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["data"][0]["match_score"] == 10.5
+
+
+class TestDatasetCommands:
+    """Test dataset commands."""
+
+    def test_details(self):
+        """Test dataset details command."""
+        mock_result = GalaxyResult(
+            data={"dataset": {"id": "ds1", "name": "data.txt"}},
+            success=True,
+            message="Retrieved details",
+        )
+
+        with patch("galaxy_mcp.cli.commands.dataset.get_dataset_details") as mock:
+            mock.fn = Mock(return_value=mock_result)
+            result = runner.invoke(app, ["dataset", "details", "ds1"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["data"]["dataset"]["id"] == "ds1"
+
+
+class TestWorkflowCommands:
+    """Test workflow commands."""
+
+    def test_list(self):
+        """Test workflow list command."""
+        mock_result = GalaxyResult(
+            data=[{"id": "wf1", "name": "My Workflow"}],
+            success=True,
+            message="Found 1 workflows",
+            count=1,
+        )
+
+        with patch("galaxy_mcp.cli.commands.workflow.list_workflows") as mock:
+            mock.fn = Mock(return_value=mock_result)
+            result = runner.invoke(app, ["workflow", "list"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["count"] == 1
+
+
+class TestErrorHandling:
+    """Test error handling."""
+
+    def test_tool_error(self):
+        """Test error handling in tool commands."""
+        with patch("galaxy_mcp.cli.commands.tools.search_tools_by_name") as mock:
+            mock.fn = Mock(side_effect=ValueError("Connection failed"))
+            result = runner.invoke(app, ["tools", "search", "test"])
+
+        assert result.exit_code == 1
+        output = json.loads(result.stderr)
+        assert "Connection failed" in output["error"]
+
+
+class TestPlanemoProfiles:
+    """Test planemo profile reading."""
+
+    def test_load_planemo_profile(self, tmp_path):
+        """Test loading an external_galaxy planemo profile."""
+        profile_dir = tmp_path / "myserver"
+        profile_dir.mkdir()
+        options = {
+            "galaxy_url": "https://usegalaxy.eu/",
+            "galaxy_user_key": "eu-key-123",
+            "galaxy_admin_key": None,
+            "engine": "external_galaxy",
+        }
+        (profile_dir / "planemo_profile_options.json").write_text(json.dumps(options))
+
+        with patch("galaxy_mcp.cli.config.PLANEMO_PROFILES_DIR", tmp_path):
+            result = _load_planemo_profile("myserver")
+
+        assert result is not None
+        assert result.url == "https://usegalaxy.eu/"
+        assert result.api_key == "eu-key-123"
+
+    def test_load_planemo_profile_admin_key(self, tmp_path):
+        """Test that admin key is used when user key is absent."""
+        profile_dir = tmp_path / "admin"
+        profile_dir.mkdir()
+        options = {
+            "galaxy_url": "https://galaxy.example.com/",
+            "galaxy_admin_key": "admin-key-456",
+            "engine": "external_galaxy",
+        }
+        (profile_dir / "planemo_profile_options.json").write_text(json.dumps(options))
+
+        with patch("galaxy_mcp.cli.config.PLANEMO_PROFILES_DIR", tmp_path):
+            result = _load_planemo_profile("admin")
+
+        assert result is not None
+        assert result.api_key == "admin-key-456"
+
+    def test_load_planemo_profile_skips_local_engine(self, tmp_path):
+        """Test that local Galaxy profiles are ignored."""
+        profile_dir = tmp_path / "local"
+        profile_dir.mkdir()
+        options = {
+            "database_type": "sqlite",
+            "database_connection": "sqlite:///foo.sqlite",
+            "engine": "galaxy",
+        }
+        (profile_dir / "planemo_profile_options.json").write_text(json.dumps(options))
+
+        with patch("galaxy_mcp.cli.config.PLANEMO_PROFILES_DIR", tmp_path):
+            result = _load_planemo_profile("local")
+
+        assert result is None
+
+    def test_load_planemo_profile_missing(self, tmp_path):
+        """Test that a missing profile returns None."""
+        with patch("galaxy_mcp.cli.config.PLANEMO_PROFILES_DIR", tmp_path):
+            result = _load_planemo_profile("nonexistent")
+
+        assert result is None
+
+    def test_load_profile_falls_back_to_planemo(self, tmp_path, monkeypatch):
+        """Test that load_profile falls back to planemo when gxy config doesn't have the profile."""
+        monkeypatch.delenv("GALAXY_URL", raising=False)
+        monkeypatch.delenv("GALAXY_API_KEY", raising=False)
+
+        # Create a planemo profile
+        profile_dir = tmp_path / "planemo_profiles" / "usegalaxy-eu"
+        profile_dir.mkdir(parents=True)
+        options = {
+            "galaxy_url": "https://usegalaxy.eu/",
+            "galaxy_user_key": "eu-key",
+            "engine": "external_galaxy",
+        }
+        (profile_dir / "planemo_profile_options.json").write_text(json.dumps(options))
+
+        # Point to a nonexistent gxy config so it gets skipped
+        fake_config = tmp_path / "config.toml"
+
+        with (
+            patch("galaxy_mcp.cli.config.CONFIG_FILE", fake_config),
+            patch("galaxy_mcp.cli.config.PLANEMO_PROFILES_DIR", tmp_path / "planemo_profiles"),
+        ):
+            result = load_profile("usegalaxy-eu")
+
+        assert result.url == "https://usegalaxy.eu/"
+        assert result.api_key == "eu-key"
+
+    def test_gxy_profile_takes_precedence(self, tmp_path, monkeypatch):
+        """Test that gxy config profile wins over planemo profile of the same name."""
+        monkeypatch.delenv("GALAXY_URL", raising=False)
+        monkeypatch.delenv("GALAXY_API_KEY", raising=False)
+
+        # Create gxy config
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            '[myserver]\nurl = "https://gxy.example.com/"\napi_key = "gxy-key"\n'
+        )
+
+        # Create planemo profile with same name
+        profile_dir = tmp_path / "planemo_profiles" / "myserver"
+        profile_dir.mkdir(parents=True)
+        options = {
+            "galaxy_url": "https://planemo.example.com/",
+            "galaxy_user_key": "planemo-key",
+            "engine": "external_galaxy",
+        }
+        (profile_dir / "planemo_profile_options.json").write_text(json.dumps(options))
+
+        with (
+            patch("galaxy_mcp.cli.config.CONFIG_FILE", config_file),
+            patch("galaxy_mcp.cli.config.PLANEMO_PROFILES_DIR", tmp_path / "planemo_profiles"),
+        ):
+            result = load_profile("myserver")
+
+        assert result.url == "https://gxy.example.com/"
+        assert result.api_key == "gxy-key"
+
+    def test_list_profiles_includes_planemo(self, tmp_path, monkeypatch):
+        """Test that list_profiles includes planemo external profiles."""
+        # Create gxy config with one profile
+        config_file = tmp_path / "config.toml"
+        config_file.write_text('[default]\nurl = "https://usegalaxy.org/"\napi_key = "key"\n')
+
+        # Create planemo profile
+        profile_dir = tmp_path / "planemo_profiles" / "usegalaxy-eu"
+        profile_dir.mkdir(parents=True)
+        options = {
+            "galaxy_url": "https://usegalaxy.eu/",
+            "galaxy_user_key": "eu-key",
+            "engine": "external_galaxy",
+        }
+        (profile_dir / "planemo_profile_options.json").write_text(json.dumps(options))
+
+        # Create a local-engine planemo profile (should be excluded)
+        local_dir = tmp_path / "planemo_profiles" / "local-dev"
+        local_dir.mkdir(parents=True)
+        local_options = {"engine": "galaxy", "database_type": "sqlite"}
+        (local_dir / "planemo_profile_options.json").write_text(json.dumps(local_options))
+
+        with (
+            patch("galaxy_mcp.cli.config.CONFIG_FILE", config_file),
+            patch("galaxy_mcp.cli.config.PLANEMO_PROFILES_DIR", tmp_path / "planemo_profiles"),
+        ):
+            profiles = list_profiles()
+
+        assert "default" in profiles
+        assert "usegalaxy-eu" in profiles
+        assert "local-dev" not in profiles
+
+    def test_connect_with_planemo_profile(self, monkeypatch, tmp_path):
+        """Test that --profile can load a planemo profile for the connect command."""
+        monkeypatch.delenv("GALAXY_URL", raising=False)
+        monkeypatch.delenv("GALAXY_API_KEY", raising=False)
+
+        profile_dir = tmp_path / "planemo_profiles" / "test-server"
+        profile_dir.mkdir(parents=True)
+        options = {
+            "galaxy_url": "https://test.galaxy.org/",
+            "galaxy_user_key": "test-key",
+            "engine": "external_galaxy",
+        }
+        (profile_dir / "planemo_profile_options.json").write_text(json.dumps(options))
+
+        mock_result = GalaxyResult(
+            data={"connected": True, "user": {"username": "testuser"}},
+            success=True,
+            message="Connected",
+        )
+
+        fake_config = tmp_path / "config.toml"
+
+        with (
+            patch("galaxy_mcp.cli.config.CONFIG_FILE", fake_config),
+            patch("galaxy_mcp.cli.config.PLANEMO_PROFILES_DIR", tmp_path / "planemo_profiles"),
+            patch("galaxy_mcp.cli.main.connect_tool") as mock_connect,
+        ):
+            mock_connect.fn = Mock(return_value=mock_result)
+            result = runner.invoke(app, ["--profile", "test-server", "connect"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["data"]["connected"] is True

--- a/mcp-server-galaxy-py/tests/test_cli.py
+++ b/mcp-server-galaxy-py/tests/test_cli.py
@@ -102,7 +102,7 @@ class TestToolsCommands:
         )
 
         with patch("galaxy_mcp.cli.commands.tools.search_tools_by_name") as mock:
-            mock.fn = Mock(return_value=mock_result)
+            mock.return_value = mock_result
             result = runner.invoke(app, ["tools", "search", "fastqc"])
 
         assert result.exit_code == 0
@@ -120,7 +120,7 @@ class TestToolsCommands:
         )
 
         with patch("galaxy_mcp.cli.commands.tools.search_tools_by_name") as mock:
-            mock.fn = Mock(return_value=mock_result)
+            mock.return_value = mock_result
             result = runner.invoke(app, ["--pretty", "tools", "search", "fastqc"])
 
         assert result.exit_code == 0
@@ -136,7 +136,7 @@ class TestToolsCommands:
         )
 
         with patch("galaxy_mcp.cli.commands.tools.get_tool_details") as mock:
-            mock.fn = Mock(return_value=mock_result)
+            mock.return_value = mock_result
             result = runner.invoke(app, ["tools", "details", "fastqc"])
 
         assert result.exit_code == 0
@@ -157,7 +157,7 @@ class TestHistoryCommands:
         )
 
         with patch("galaxy_mcp.cli.commands.history.get_histories") as mock:
-            mock.fn = Mock(return_value=mock_result)
+            mock.return_value = mock_result
             result = runner.invoke(app, ["history", "list"])
 
         assert result.exit_code == 0
@@ -173,7 +173,7 @@ class TestHistoryCommands:
         )
 
         with patch("galaxy_mcp.cli.commands.history.create_history") as mock:
-            mock.fn = Mock(return_value=mock_result)
+            mock.return_value = mock_result
             result = runner.invoke(app, ["history", "create", "New History"])
 
         assert result.exit_code == 0
@@ -194,7 +194,7 @@ class TestIWCCommands:
         )
 
         with patch("galaxy_mcp.cli.commands.iwc.search_iwc_workflows") as mock:
-            mock.fn = Mock(return_value=mock_result)
+            mock.return_value = mock_result
             result = runner.invoke(app, ["iwc", "search", "rna-seq"])
 
         assert result.exit_code == 0
@@ -211,7 +211,7 @@ class TestIWCCommands:
         )
 
         with patch("galaxy_mcp.cli.commands.iwc.recommend_iwc_workflows") as mock:
-            mock.fn = Mock(return_value=mock_result)
+            mock.return_value = mock_result
             result = runner.invoke(
                 app, ["iwc", "recommend", "differential expression from RNA-seq"]
             )
@@ -233,7 +233,7 @@ class TestDatasetCommands:
         )
 
         with patch("galaxy_mcp.cli.commands.dataset.get_dataset_details") as mock:
-            mock.fn = Mock(return_value=mock_result)
+            mock.return_value = mock_result
             result = runner.invoke(app, ["dataset", "details", "ds1"])
 
         assert result.exit_code == 0
@@ -254,7 +254,7 @@ class TestWorkflowCommands:
         )
 
         with patch("galaxy_mcp.cli.commands.workflow.list_workflows") as mock:
-            mock.fn = Mock(return_value=mock_result)
+            mock.return_value = mock_result
             result = runner.invoke(app, ["workflow", "list"])
 
         assert result.exit_code == 0
@@ -268,7 +268,7 @@ class TestErrorHandling:
     def test_tool_error(self):
         """Test error handling in tool commands."""
         with patch("galaxy_mcp.cli.commands.tools.search_tools_by_name") as mock:
-            mock.fn = Mock(side_effect=ValueError("Connection failed"))
+            mock.side_effect = ValueError("Connection failed")
             result = runner.invoke(app, ["tools", "search", "test"])
 
         assert result.exit_code == 1

--- a/mcp-server-galaxy-py/tests/test_cli.py
+++ b/mcp-server-galaxy-py/tests/test_cli.py
@@ -517,3 +517,29 @@ class TestConnectionBootstrap:
         assert result.exit_code == 0
         assert called["url"] == "https://flagged.example.org"
         assert called["api_key"] == "flagkey"
+
+
+class TestIwcWithoutCredentials:
+    def test_recommend_works_without_any_credentials(self, monkeypatch):
+        """IWC discovery must not require a Galaxy connection."""
+        monkeypatch.delenv("GALAXY_URL", raising=False)
+        monkeypatch.delenv("GALAXY_API_KEY", raising=False)
+
+        from galaxy_mcp.server import GalaxyResult
+
+        mock_result = GalaxyResult(
+            data=[{"trsID": "wf1", "name": "RNA-seq DE"}],
+            success=True,
+            message="1 recommendation",
+            count=1,
+        )
+        with patch(
+            "galaxy_mcp.cli.commands.iwc.recommend_iwc_workflows",
+            return_value=mock_result,
+        ) as mock:
+            result = runner.invoke(app, ["iwc", "recommend", "differential expression"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["count"] == 1
+        mock.assert_called_once()

--- a/mcp-server-galaxy-py/tests/test_cli.py
+++ b/mcp-server-galaxy-py/tests/test_cli.py
@@ -1,6 +1,8 @@
 """Tests for the Galaxy MCP CLI (gxy)."""
 
 import json
+import subprocess
+import sys
 from unittest.mock import Mock, patch
 
 import pytest
@@ -543,3 +545,40 @@ class TestIwcWithoutCredentials:
         output = json.loads(result.stdout)
         assert output["count"] == 1
         mock.assert_called_once()
+
+
+class TestStdoutCleanliness:
+    """stdout is the JSON data channel; nothing diagnostic may leak onto it.
+
+    This runs gxy as a real subprocess because the offending message is emitted
+    at server-module import time, which the in-process CliRunner never captures.
+    """
+
+    def test_dotenv_message_does_not_pollute_stdout(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("GALAXY_URL=https://example.org/\nGALAXY_API_KEY=dummy\n")
+
+        proc = subprocess.run(
+            [sys.executable, "-m", "galaxy_mcp.cli.main", "--help"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+
+        assert "Loaded environment variables" not in proc.stdout
+        # Confirm it was relocated to stderr, not silently dropped.
+        assert "Loaded environment variables" in proc.stderr
+
+
+class TestProfileCommand:
+    def test_profile_list_outputs_configured_profiles(self):
+        with patch(
+            "galaxy_mcp.cli.commands.profile.list_profiles",
+            return_value=["default", "eu"],
+        ):
+            result = runner.invoke(app, ["profile", "list"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["count"] == 2
+        assert output["data"] == ["default", "eu"]

--- a/mcp-server-galaxy-py/uv.lock
+++ b/mcp-server-galaxy-py/uv.lock
@@ -178,6 +178,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -921,6 +930,8 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "rank-bm25" },
     { name = "requests" },
+    { name = "tomli", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typer" },
     { name = "typing-extensions" },
 ]
 
@@ -966,8 +977,10 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.3,<3" },
     { name = "responses", marker = "extra == 'dev'", specifier = ">=0.25.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.2" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
     { name = "tox", marker = "extra == 'dev'", specifier = ">=4.11.0" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=5.0.0" },
+    { name = "typer", specifier = ">=0.12.0,<1" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.31.0" },
     { name = "typing-extensions", specifier = ">=4.0.0,<5" },
 ]
@@ -2604,6 +2617,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2799,6 +2821,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c8/a2/6df94fc5c8e2170d21d7134a565c3a8fb84f9797c1dd65a5976aaf714418/twine-6.1.0.tar.gz", hash = "sha256:be324f6272eff91d07ee93f251edf232fc647935dd585ac003539b42404a8dbd", size = 168404, upload-time = "2025-01-21T18:45:26.758Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/b6/74e927715a285743351233f33ea3c684528a0d374d2e43ff9ce9585b73fe/twine-6.1.0-py3-none-any.whl", hash = "sha256:a47f973caf122930bf0fbbf17f80b83bc1602c9ce393c7845f289a3001dc5384", size = 40791, upload-time = "2025-01-21T18:45:24.584Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This brings the `gxy` command-line tool from the old `cli-exploration` branch onto current `main`, packaged properly and with a working credential path. `gxy` is a thin Typer adapter -- one of three surfaces over the same ~37 `@mcp.tool` functions in `server.py` (alongside full-MCP and code-mode), so there's no duplicated Galaxy logic. It's JSON-first, for humans, shell scripts, and CI; the headline feature is IWC workflow discovery (search/recommend/import), which needs no Galaxy account and makes it a real successor to the unmaintained `parsec`.

The one structural fix beyond packaging is `server.connect_global()`: the multi-user `connect()` tool deliberately stopped writing module-global state (#50), so a single-user in-process client had no way to seed a connection from resolved creds. `connect_global()` does exactly that, with an explicit contract that it's single-user-only and must never run inside the multi-tenant HTTP server.

Positioning is deliberate: agents should probably continue to use the MCP server / code-mode, not this CLI. Agent-grade output hardening (mandatory `--json`, deterministic status strings, an exit-code contract, output-contract tests) is intentionally deferred to a follow-up (Option C). This PR keeps the existing JSON output and adds no agent guarantees.

## What's here

- Imports the CLI source (`src/galaxy_mcp/cli/`) unchanged, then packages it: declares `typer`/`tomli`, adds the `gxy` console script, relocks.
- `connect_global()` for single-user CLI connections (TDD'd).
- Wires `--url`/`--api-key`/`--profile` into an actual connection via a best-effort callback (IWC discovery still works with zero creds; `connect`/`--help` skip it).
- Drops the vestigial `_fn` tool-unwrap helper -- FastMCP 3 returns plain functions from `@mcp.tool`, so the CLI calls them directly.
- Docs in both READMEs with config precedence, runnable examples, and the "agents -> MCP/code-mode" positioning.

## Verification

200 tests pass (server + CLI), mypy and lint clean. Smoke-tested with no credentials: `gxy iwc recommend ...` returns ranked workflows (exit 0), and a data command like `gxy history list` fails cleanly with a JSON "not connected" error (exit 1, no traceback).
