### PR TITLE
Fix style=run resolving the wrong workflow (instance flag)

### DIFF
--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -2959,7 +2959,11 @@ def _resolve_workflow_slots(
     """Resolve a workflow's input slots. Primary: style=run (webapp's source),
     behind our normalizer. Fallback: the .ga export. Returns (slots, provenance).
     """
-    params = "style=run&instance=true"
+    # instance=false: workflow_id here is a StoredWorkflow id (what show_workflow /
+    # list_workflows hand back). instance=true reinterprets it as a Workflow-version
+    # id and silently resolves a *different* workflow, so we'd template/validate the
+    # wrong inputs.
+    params = "style=run&instance=false"
     if history_id:
         params += f"&history_id={history_id}"
     try:

--- a/mcp-server-galaxy-py/tests/test_workflow_operations.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_operations.py
@@ -442,6 +442,30 @@ def test_resolve_slots_falls_back_to_ga_on_missing_tools_500():
     assert slots[0]["accepted_formats"] == ["tabular"]
 
 
+def test_resolve_slots_requests_instance_false():
+    # Guard the instance flag: workflow_id is a StoredWorkflow id, so the download
+    # must use instance=false -- instance=true silently resolves a different workflow.
+    gi = Mock()
+    gi.url = "https://g/api"
+    resp = Mock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "steps": [
+            {
+                "step_type": "data_input",
+                "step_index": 0,
+                "step_label": "in",
+                "inputs": [{"extensions": ["tabular"], "optional": False}],
+            }
+        ]
+    }
+    gi.make_get_request.return_value = resp
+    _resolve_workflow_slots(gi, "wfid", history_id="h1")
+    url = gi.make_get_request.call_args.args[0]
+    assert "instance=false" in url
+    assert "instance=true" not in url
+
+
 # ---------------------------------------------------------------------------
 # Task 10: get_workflow_input_template MCP tool
 # ---------------------------------------------------------------------------

--- a/mcp-server-galaxy-py/tests/testdata/wf_style_run_rnaseq.json
+++ b/mcp-server-galaxy-py/tests/testdata/wf_style_run_rnaseq.json
@@ -1,11 +1,12 @@
 {
-  "has_upgrade_messages": true,
+  "has_upgrade_messages": false,
   "help": null,
-  "id": "cbfaeab6dcda4c1f",
-  "name": "RNA-Seq PE (fixture)",
+  "id": "509728dd2e69bcd0",
+  "name": "RNA-Seq PE (fixture, instance=false)",
   "step_version_changes": [],
   "steps": [
     {
+      "annotation": "Should be a list of paired-end RNA-seq fastqs",
       "inputs": [
         {
           "acceptable_extensions": [
@@ -20,7 +21,7 @@
           ],
           "argument": null,
           "collection_types": [
-            "list"
+            "list:paired"
           ],
           "column_definitions": null,
           "extensions": [
@@ -31,7 +32,7 @@
           "help_format": "html",
           "hidden": false,
           "is_dynamic": false,
-          "label": "Target Sequence",
+          "label": "Collection paired FASTQ files",
           "model_class": "DataCollectionToolParameter",
           "multiple": false,
           "name": "input",
@@ -48,386 +49,234 @@
             "hdca": []
           },
           "refresh_on_change": true,
-          "tag": null,
+          "tag": "",
           "type": "data_collection",
           "value": null
         }
       ],
       "output_connections": [
         {
+          "input_name": "single_paired|paired_input",
+          "input_step_index": 12,
+          "output_name": "output",
+          "output_step_index": 0
+        },
+        {
           "input_name": "input",
-          "input_step_index": 7,
+          "input_step_index": 11,
           "output_name": "output",
           "output_step_index": 0
         }
       ],
       "replacement_parameters": [],
       "step_index": 0,
-      "step_label": "Target Sequence",
+      "step_label": "Collection paired FASTQ files",
       "step_name": "Input dataset collection",
       "step_type": "data_collection_input",
       "step_version": null,
       "when": null
     },
     {
+      "annotation": "This is optional. Fastp will use overlapping. If you want to specify, for Nextera use: CTGTCTCTTATACACATCTCCGAGCCCACGAGAC, for TruSeq: GATCGGAAGAGCACACGTCTGAACTCCAGTCAC or AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC",
       "inputs": [
         {
-          "acceptable_extensions": [
-            "4dn_pairs",
-            "4dn_pairs.gz",
-            "4dn_pairsam",
-            "4dn_pairsam.gz",
-            "a2m",
-            "a3m",
-            "ab1",
-            "acedb"
-          ],
+          "area": false,
           "argument": null,
-          "collection_types": [
-            "list"
-          ],
-          "column_definitions": null,
-          "extensions": [
-            "data"
-          ],
-          "fields": null,
+          "datalist": [],
           "help": null,
           "help_format": "html",
           "hidden": false,
           "is_dynamic": false,
-          "label": "Input Sequences",
-          "model_class": "DataCollectionToolParameter",
-          "multiple": false,
+          "label": "Forward adapter",
+          "model_class": "TextToolParameter",
           "name": "input",
-          "optional": false,
-          "options": {
-            "dce": [],
-            "hda": [],
-            "hdca": []
-          },
-          "options_meta": {},
-          "pinned": {
-            "dce": [],
-            "hda": [],
-            "hdca": []
-          },
-          "refresh_on_change": true,
-          "tag": null,
-          "type": "data_collection",
+          "optional": true,
+          "refresh_on_change": false,
+          "type": "text",
           "value": null
         }
       ],
       "output_connections": [
         {
-          "input_name": "input",
-          "input_step_index": 8,
+          "input_name": "single_paired|adapter_trimming_options|adapter_sequence1",
+          "input_step_index": 12,
           "output_name": "output",
           "output_step_index": 1
         }
       ],
       "replacement_parameters": [],
       "step_index": 1,
-      "step_label": "Input Sequences",
-      "step_name": "Input dataset collection",
-      "step_type": "data_collection_input",
+      "step_label": "Forward adapter",
+      "step_name": "Input parameter",
+      "step_type": "parameter_input",
       "step_version": null,
       "when": null
     },
     {
+      "annotation": "This is optional. Fastp will use overlapping. If you want to specify, for Nextera use: CTGTCTCTTATACACATCTGACGCTGCCGACGA, for TruSeq: GATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT or AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT",
       "inputs": [
         {
-          "acceptable_extensions": [
-            "4dn_pairs",
-            "4dn_pairs.gz",
-            "4dn_pairsam",
-            "4dn_pairsam.gz",
-            "a2m",
-            "a3m",
-            "acedb",
-            "affybatch"
-          ],
+          "area": false,
           "argument": null,
-          "edam": {
-            "edam_data": [
-              "data_0006"
-            ],
-            "edam_formats": [
-              "format_2330"
-            ]
-          },
-          "extensions": [
-            "txt"
-          ],
+          "datalist": [],
           "help": null,
           "help_format": "html",
           "hidden": false,
           "is_dynamic": false,
-          "label": "SPRING Index",
-          "model_class": "DataToolParameter",
-          "multiple": false,
+          "label": "Reverse adapter",
+          "model_class": "TextToolParameter",
           "name": "input",
-          "optional": false,
-          "options": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "options_meta": {},
-          "pinned": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "refresh_on_change": true,
-          "tag": null,
-          "type": "data",
+          "optional": true,
+          "refresh_on_change": false,
+          "type": "text",
           "value": null
         }
       ],
       "output_connections": [
         {
-          "input_name": "crossreference",
-          "input_step_index": 9,
+          "input_name": "single_paired|adapter_trimming_options|adapter_sequence2",
+          "input_step_index": 12,
           "output_name": "output",
           "output_step_index": 2
         }
       ],
       "replacement_parameters": [],
       "step_index": 2,
-      "step_label": "SPRING Index",
-      "step_name": "Input dataset",
-      "step_type": "data_input",
+      "step_label": "Reverse adapter",
+      "step_name": "Input parameter",
+      "step_type": "parameter_input",
       "step_version": null,
       "when": null
     },
     {
+      "annotation": "Whether to compute additional QC like fastQC, gene body coverage etc...",
       "inputs": [
         {
-          "acceptable_extensions": [
-            "4dn_pairs",
-            "4dn_pairs.gz",
-            "4dn_pairsam",
-            "4dn_pairsam.gz",
-            "a2m",
-            "a3m",
-            "acedb",
-            "affybatch"
-          ],
           "argument": null,
-          "edam": {
-            "edam_data": [
-              "data_0006"
-            ],
-            "edam_formats": [
-              "format_2330"
-            ]
-          },
-          "extensions": [
-            "txt"
-          ],
+          "falsevalue": "false",
           "help": null,
           "help_format": "html",
           "hidden": false,
           "is_dynamic": false,
-          "label": "HHM Index",
-          "model_class": "DataToolParameter",
-          "multiple": false,
+          "label": "Generate additional QC reports",
+          "model_class": "BooleanToolParameter",
           "name": "input",
           "optional": false,
-          "options": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "options_meta": {},
-          "pinned": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "refresh_on_change": true,
-          "tag": null,
-          "type": "data",
-          "value": null
+          "refresh_on_change": false,
+          "truevalue": "true",
+          "type": "boolean",
+          "value": false
         }
       ],
       "output_connections": [
         {
-          "input_name": "hhm_ffindex",
-          "input_step_index": 7,
+          "input_name": "input_param_type|input_param",
+          "input_step_index": 13,
           "output_name": "output",
           "output_step_index": 3
         },
         {
-          "input_name": "hhm_ffindex",
-          "input_step_index": 8,
+          "input_name": "when",
+          "input_step_index": 26,
           "output_name": "output",
           "output_step_index": 3
         }
       ],
       "replacement_parameters": [],
       "step_index": 3,
-      "step_label": "HHM Index",
-      "step_name": "Input dataset",
-      "step_type": "data_input",
+      "step_label": "Generate additional QC reports",
+      "step_name": "Input parameter",
+      "step_type": "parameter_input",
       "step_version": null,
       "when": null
     },
     {
+      "annotation": "Select the reference genome",
       "inputs": [
         {
-          "acceptable_extensions": [
-            "4dn_pairs",
-            "4dn_pairs.gz",
-            "4dn_pairsam",
-            "4dn_pairsam.gz",
-            "a2m",
-            "a3m",
-            "ab1",
-            "acedb"
-          ],
           "argument": null,
-          "edam": {
-            "edam_data": [
-              "data_0006"
-            ],
-            "edam_formats": [
-              "format_1915"
-            ]
-          },
-          "extensions": [
-            "data"
-          ],
+          "display": null,
           "help": null,
           "help_format": "html",
           "hidden": false,
           "is_dynamic": false,
-          "label": "HHM Data",
-          "model_class": "DataToolParameter",
+          "label": "Reference genome",
+          "model_class": "SelectToolParameter",
           "multiple": false,
           "name": "input",
           "optional": false,
-          "options": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "options_meta": {},
-          "pinned": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "refresh_on_change": true,
-          "tag": null,
-          "type": "data",
-          "value": null
+          "options": [
+            [
+              "A. mellifera 04 Nov 2010 (Amel_4.5/apiMel4) (apiMel4)",
+              "apiMel4",
+              false
+            ],
+            [
+              "A. mellifera Nov. 2010 (GCF_000002195.4/Amel_4.5) (Amel_4.5)",
+              "Amel_4.5",
+              false
+            ],
+            [
+              "Abiotrophia defectiva (GCF_013267415.1_ASM1326741v1)",
+              "GCF_013267415.1",
+              false
+            ],
+            [
+              "Acanthamoeba astronyxis (GCA_000826245.1_Acanthamoeba_astronyxis)",
+              "GCA_000826245.1",
+              false
+            ],
+            [
+              "Acanthamoeba castellanii (GCA_000193105.1_Acas_2.0)",
+              "GCA_000193105.1",
+              false
+            ],
+            [
+              "Acanthamoeba castellanii (GCA_000826485.1_Acanthamoeba_castellanii)",
+              "GCA_000826485.1",
+              false
+            ],
+            [
+              "Acanthamoeba castellanii (GCA_021020595.1_ASM2102059v1)",
+              "GCA_021020595.1",
+              false
+            ],
+            [
+              "Acanthamoeba castellanii (GCA_021020605.1_ASM2102060v1)",
+              "GCA_021020605.1",
+              false
+            ]
+          ],
+          "refresh_on_change": false,
+          "textable": true,
+          "type": "select",
+          "value": "apiMel4"
         }
       ],
       "output_connections": [
         {
-          "input_name": "hhm_ffdata",
-          "input_step_index": 7,
+          "input_name": "components_0|param_type|component_value",
+          "input_step_index": 14,
           "output_name": "output",
           "output_step_index": 4
         },
         {
-          "input_name": "hhm_ffdata",
-          "input_step_index": 8,
+          "input_name": "refGenomeSource|GTFconditional|genomeDir",
+          "input_step_index": 18,
           "output_name": "output",
           "output_step_index": 4
         }
       ],
       "replacement_parameters": [],
       "step_index": 4,
-      "step_label": "HHM Data",
-      "step_name": "Input dataset",
-      "step_type": "data_input",
+      "step_label": "Reference genome",
+      "step_name": "Input parameter",
+      "step_type": "parameter_input",
       "step_version": null,
       "when": null
     },
     {
-      "inputs": [
-        {
-          "acceptable_extensions": [
-            "4dn_pairs",
-            "4dn_pairs.gz",
-            "4dn_pairsam",
-            "4dn_pairsam.gz",
-            "a2m",
-            "a3m",
-            "acedb",
-            "affybatch"
-          ],
-          "argument": null,
-          "edam": {
-            "edam_data": [
-              "data_0006"
-            ],
-            "edam_formats": [
-              "format_2330"
-            ]
-          },
-          "extensions": [
-            "txt"
-          ],
-          "help": null,
-          "help_format": "html",
-          "hidden": false,
-          "is_dynamic": false,
-          "label": "cs219 Index",
-          "model_class": "DataToolParameter",
-          "multiple": false,
-          "name": "input",
-          "optional": false,
-          "options": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "options_meta": {},
-          "pinned": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "refresh_on_change": true,
-          "tag": null,
-          "type": "data",
-          "value": null
-        }
-      ],
-      "output_connections": [
-        {
-          "input_name": "cs219_ffindex",
-          "input_step_index": 7,
-          "output_name": "output",
-          "output_step_index": 5
-        },
-        {
-          "input_name": "cs219_ffindex",
-          "input_step_index": 8,
-          "output_name": "output",
-          "output_step_index": 5
-        }
-      ],
-      "replacement_parameters": [],
-      "step_index": 5,
-      "step_label": "cs219 Index",
-      "step_name": "Input dataset",
-      "step_type": "data_input",
-      "step_version": null,
-      "when": null
-    },
-    {
+      "annotation": "GTF compatible with the reference genome. Mind the UCSC/Ensembl differences in chromosome naming.",
       "inputs": [
         {
           "acceptable_extensions": [
@@ -443,20 +292,29 @@
           "argument": null,
           "edam": {
             "edam_data": [
-              "data_0006"
+              "data_0006",
+              "data_1255",
+              "data_1255",
+              "data_1255"
             ],
             "edam_formats": [
-              "format_1915"
+              "format_1915",
+              "format_2305",
+              "format_1975",
+              "format_2306"
             ]
           },
           "extensions": [
-            "data"
+            "data",
+            "gff",
+            "gff3",
+            "gtf"
           ],
           "help": null,
           "help_format": "html",
           "hidden": false,
           "is_dynamic": false,
-          "label": "cs219 Data",
+          "label": "GTF file of annotation",
           "model_class": "DataToolParameter",
           "multiple": false,
           "name": "input",
@@ -475,1052 +333,243 @@
             "ldda": []
           },
           "refresh_on_change": true,
-          "tag": null,
+          "tag": "",
           "type": "data",
           "value": null
         }
       ],
       "output_connections": [
         {
-          "input_name": "cs219_ffdata",
-          "input_step_index": 7,
+          "input_name": "reference_annotation|reference_annotation_file",
+          "input_step_index": 23,
           "output_name": "output",
-          "output_step_index": 6
+          "output_step_index": 5
         },
         {
-          "input_name": "cs219_ffdata",
-          "input_step_index": 8,
+          "input_name": "guide|guide_source|ref_hist",
+          "input_step_index": 22,
           "output_name": "output",
-          "output_step_index": 6
+          "output_step_index": 5
+        },
+        {
+          "input_name": "anno|reference_gene_sets",
+          "input_step_index": 21,
+          "output_name": "output",
+          "output_step_index": 5
+        },
+        {
+          "input_name": "refGenomeSource|GTFconditional|sjdbGTFfile",
+          "input_step_index": 18,
+          "output_name": "output",
+          "output_step_index": 5
+        },
+        {
+          "input_name": "reference_annotation_gtf",
+          "input_step_index": 26,
+          "output_name": "output",
+          "output_step_index": 5
         }
       ],
       "replacement_parameters": [],
-      "step_index": 6,
-      "step_label": "cs219 Data",
+      "step_index": 5,
+      "step_label": "GTF file of annotation",
       "step_name": "Input dataset",
       "step_type": "data_input",
       "step_version": null,
       "when": null
     },
     {
-      "action": "/tool_runner/index",
-      "citations": true,
-      "config_file": "/cvmfs/test.galaxyproject.org/shed_tools/toolshed.g2.bx.psu.edu/repos/guerler/hhsuite/3e4d88784254/hhsuite/hhsearch.xml",
-      "creator": null,
-      "credentials": [],
-      "description": "detecting remote homologues of proteins",
-      "display": true,
-      "edam_operations": [],
-      "edam_topics": [],
-      "enctype": "application/x-www-form-urlencoded",
-      "errors": {},
-      "form_style": "regular",
-      "has_parameters": true,
-      "help": "<p>HHsearch aligns a profile HMM against a database of target profile HMMs. The search first aligns the\nquery HMM with each of the target HMMs using the Viterbi dynamic programming algorithm, which finds the\nalignment with the maximum score. The E-value for the target HMM is calculated from the Viterbi score.\nTarget HMMs that reach sufficient significance to be reported are realigned using the Maximum Accuracy algorithm (MAC).\nThis algorithm maximizes the expected number of correctly aligned pairs of residues minus a penalty between 0 and 1.\nValues near 0 produce greedy, long, nearly global alignments, values above 0.3 result in shorter, local alignments.</p>\n<p>HHblits is an accelerated version of HHsearch that is fast enough to perform iterative searches through millions of profile HMMs,\ne.g. through the Uniclust profile HMM databases, generated by clustering the UniProt database into clusters of globally alignable sequences.\nAnalogously to PSI-BLAST and HMMER3, such iterative searches can be used to build MSAs by starting from a single query sequence.\nSequences from matches to profile HMMs below some E-value threshold (e.g. 10\u22123) are added to the query MSA for the next search iteration.</p>\n<p>Download databases from: <a class=\"reference external\" href=\"http://wwwuser.gwdg.de/~compbiol/data/hhsuite/databases/hhsuite_dbs/\">http://wwwuser.gwdg.de/~compbiol/data/hhsuite/databases/hhsuite_dbs/</a></p>\n",
-      "help_format": "restructuredtext",
-      "hidden": "",
-      "hidden_versions": [],
-      "history_id": "1affb3d848eeea7c",
-      "icon": null,
-      "id": "toolshed.g2.bx.psu.edu/repos/guerler/hhsuite/hhsearch/0.1.0",
+      "annotation": "For stranded RNA, reverse means that the read is complementary to the coding sequence, forward means that the read is in the same orientation as the coding sequence",
       "inputs": [
         {
           "argument": null,
-          "default_value": null,
-          "edam": {
-            "edam_data": [
-              "data_0006"
-            ],
-            "edam_formats": [
-              "format_1915"
-            ]
-          },
-          "extensions": [
-            "data"
-          ],
-          "help": "Single sequence or multiple sequence alignment (MSA)                 in a3m, a2m, or FASTA format, or HMM in hhm format. (-i)",
+          "display": null,
+          "help": null,
           "help_format": "html",
           "hidden": false,
           "is_dynamic": false,
-          "label": "Query Sequence",
-          "model_class": "DataToolParameter",
+          "label": "Strandedness",
+          "model_class": "SelectToolParameter",
           "multiple": false,
           "name": "input",
           "optional": false,
-          "options": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "options_meta": {
-            "hda": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            },
-            "hdca": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            }
-          },
-          "pinned": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "refresh_on_change": true,
-          "tag": null,
-          "text_value": "Not available.",
-          "type": "data",
-          "value": {
-            "__class__": "ConnectedValue"
-          }
-        },
-        {
-          "argument": null,
-          "default_value": null,
-          "edam": {
-            "edam_data": [
-              "data_0006"
-            ],
-            "edam_formats": [
-              "format_2330"
-            ]
-          },
-          "extensions": [
-            "txt"
-          ],
-          "help": "Database file ending with 'hhm.ffindex'.",
-          "help_format": "html",
-          "hidden": false,
-          "is_dynamic": false,
-          "label": "HHM Index file",
-          "model_class": "DataToolParameter",
-          "multiple": false,
-          "name": "hhm_ffindex",
-          "optional": false,
-          "options": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "options_meta": {
-            "hda": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            },
-            "hdca": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            }
-          },
-          "pinned": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "refresh_on_change": true,
-          "tag": null,
-          "text_value": "Not available.",
-          "type": "data",
-          "value": {
-            "__class__": "ConnectedValue"
-          }
-        },
-        {
-          "argument": null,
-          "default_value": null,
-          "edam": {
-            "edam_data": [
-              "data_0006"
-            ],
-            "edam_formats": [
-              "format_1915"
-            ]
-          },
-          "extensions": [
-            "data"
-          ],
-          "help": "Database file ending with 'hhm.ffdata'.",
-          "help_format": "html",
-          "hidden": false,
-          "is_dynamic": false,
-          "label": "HHM Data file",
-          "model_class": "DataToolParameter",
-          "multiple": false,
-          "name": "hhm_ffdata",
-          "optional": false,
-          "options": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "options_meta": {
-            "hda": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            },
-            "hdca": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            }
-          },
-          "pinned": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "refresh_on_change": true,
-          "tag": null,
-          "text_value": "Not available.",
-          "type": "data",
-          "value": {
-            "__class__": "ConnectedValue"
-          }
-        },
-        {
-          "argument": null,
-          "default_value": null,
-          "edam": {
-            "edam_data": [
-              "data_0006"
-            ],
-            "edam_formats": [
-              "format_2330"
-            ]
-          },
-          "extensions": [
-            "txt"
-          ],
-          "help": "Database file ending with 'cs219.ffindex'.",
-          "help_format": "html",
-          "hidden": false,
-          "is_dynamic": false,
-          "label": "cs219 Index file",
-          "model_class": "DataToolParameter",
-          "multiple": false,
-          "name": "cs219_ffindex",
-          "optional": false,
-          "options": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "options_meta": {
-            "hda": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            },
-            "hdca": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            }
-          },
-          "pinned": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "refresh_on_change": true,
-          "tag": null,
-          "text_value": "Not available.",
-          "type": "data",
-          "value": {
-            "__class__": "ConnectedValue"
-          }
-        },
-        {
-          "argument": null,
-          "default_value": null,
-          "edam": {
-            "edam_data": [
-              "data_0006"
-            ],
-            "edam_formats": [
-              "format_1915"
-            ]
-          },
-          "extensions": [
-            "data"
-          ],
-          "help": "Database file ending with 'cs219.ffdata'.",
-          "help_format": "html",
-          "hidden": false,
-          "is_dynamic": false,
-          "label": "cs219 Data file",
-          "model_class": "DataToolParameter",
-          "multiple": false,
-          "name": "cs219_ffdata",
-          "optional": false,
-          "options": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "options_meta": {
-            "hda": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            },
-            "hdca": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            }
-          },
-          "pinned": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "refresh_on_change": true,
-          "tag": null,
-          "text_value": "Not available.",
-          "type": "data",
-          "value": {
-            "__class__": "ConnectedValue"
-          }
-        },
-        {
-          "argument": null,
-          "default_value": "hhsearch",
-          "display": "radio",
-          "help": "Select a search method. See help below for more information.",
-          "help_format": "html",
-          "hidden": false,
-          "is_dynamic": false,
-          "label": "Search Method",
-          "model_class": "SelectToolParameter",
-          "multiple": false,
-          "name": "method",
-          "optional": false,
           "options": [
             [
-              "HHsearch",
-              "hhsearch",
-              true
+              "stranded - forward",
+              "stranded - forward",
+              false
             ],
             [
-              "HHblits",
-              "hhblits",
+              "stranded - reverse",
+              "stranded - reverse",
+              false
+            ],
+            [
+              "unstranded",
+              "unstranded",
               false
             ]
           ],
           "refresh_on_change": false,
-          "text_value": "HHsearch",
           "textable": true,
           "type": "select",
-          "value": "hhsearch"
+          "value": "stranded - forward"
+        }
+      ],
+      "output_connections": [
+        {
+          "input_name": "strandedness",
+          "input_step_index": 20,
+          "output_name": "output",
+          "output_step_index": 6
         },
         {
-          "area": false,
+          "input_name": "input_param_type|input_param",
+          "input_step_index": 17,
+          "output_name": "output",
+          "output_step_index": 6
+        },
+        {
+          "input_name": "input_param_type|input_param",
+          "input_step_index": 16,
+          "output_name": "output",
+          "output_step_index": 6
+        },
+        {
+          "input_name": "input_param_type|input_param",
+          "input_step_index": 15,
+          "output_name": "output",
+          "output_step_index": 6
+        },
+        {
+          "input_name": "Strandness param",
+          "input_step_index": 24,
+          "output_name": "output",
+          "output_step_index": 6
+        }
+      ],
+      "replacement_parameters": [],
+      "step_index": 6,
+      "step_label": "Strandedness",
+      "step_name": "Input parameter",
+      "step_type": "parameter_input",
+      "step_version": null,
+      "when": null
+    },
+    {
+      "annotation": "Use featureCounts tool instead of RNA STAR?",
+      "inputs": [
+        {
           "argument": null,
-          "datalist": [],
-          "default_value": "0.001",
-          "help": "",
+          "falsevalue": "false",
+          "help": null,
           "help_format": "html",
           "hidden": false,
           "is_dynamic": false,
-          "label": "E-value cutoff for inclusion in result alignment. (-e)",
-          "max": 1.0,
-          "min": 0.0,
-          "model_class": "FloatToolParameter",
-          "name": "e",
+          "label": "Use featureCounts for generating count tables",
+          "model_class": "BooleanToolParameter",
+          "name": "input",
           "optional": false,
           "refresh_on_change": false,
-          "text_value": "0.001",
-          "type": "float",
-          "value": "0.001"
+          "truevalue": "true",
+          "type": "boolean",
+          "value": false
         }
       ],
-      "is_workflow_compatible": true,
-      "job_credentials_context": null,
-      "job_id": null,
-      "job_remap": null,
-      "labels": [],
-      "license": null,
-      "message": "",
-      "method": "post",
-      "model_class": "Tool",
-      "name": "HHsearch",
       "output_connections": [
         {
-          "input_name": "target",
-          "input_step_index": 9,
+          "input_name": "when",
+          "input_step_index": 21,
           "output_name": "output",
           "output_step_index": 7
         }
       ],
-      "panel_section_id": "tool_toolshed.g2.bx.psu.edu/repos/guerler/hhsuite/hhsearch/0.1.0",
-      "panel_section_name": "HHsearch",
-      "post_job_actions": [],
       "replacement_parameters": [],
-      "requirements": [
-        {
-          "name": "hhsuite",
-          "version": "3.2.0"
-        }
-      ],
-      "sharable_url": "https://toolshed.g2.bx.psu.edu/view/guerler/hhsuite",
-      "state_inputs": {
-        "cs219_ffdata": {
-          "__class__": "ConnectedValue"
-        },
-        "cs219_ffindex": {
-          "__class__": "ConnectedValue"
-        },
-        "e": "0.001",
-        "hhm_ffdata": {
-          "__class__": "ConnectedValue"
-        },
-        "hhm_ffindex": {
-          "__class__": "ConnectedValue"
-        },
-        "input": {
-          "__class__": "ConnectedValue"
-        },
-        "method": "hhsearch"
-      },
       "step_index": 7,
-      "step_label": null,
-      "step_name": "HHsearch",
-      "step_type": "tool",
-      "step_version": "0.1.0",
-      "tool_errors": null,
-      "tool_shed_repository": {
-        "changeset_revision": "cec2aa4d6c0d",
-        "name": "hhsuite",
-        "owner": "guerler",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "version": "0.1.0",
-      "versions": [
-        "0.1.0"
-      ],
-      "warnings": null,
-      "when": null,
-      "xrefs": [
-        {
-          "type": "bio.tools",
-          "value": "hhsuite"
-        }
-      ]
+      "step_label": "Use featureCounts for generating count tables",
+      "step_name": "Input parameter",
+      "step_type": "parameter_input",
+      "step_version": null,
+      "when": null
     },
     {
-      "action": "/tool_runner/index",
-      "citations": true,
-      "config_file": "/cvmfs/test.galaxyproject.org/shed_tools/toolshed.g2.bx.psu.edu/repos/guerler/hhsuite/3e4d88784254/hhsuite/hhsearch.xml",
-      "creator": null,
-      "credentials": [],
-      "description": "detecting remote homologues of proteins",
-      "display": true,
-      "edam_operations": [],
-      "edam_topics": [],
-      "enctype": "application/x-www-form-urlencoded",
-      "errors": {},
-      "form_style": "regular",
-      "has_parameters": true,
-      "help": "<p>HHsearch aligns a profile HMM against a database of target profile HMMs. The search first aligns the\nquery HMM with each of the target HMMs using the Viterbi dynamic programming algorithm, which finds the\nalignment with the maximum score. The E-value for the target HMM is calculated from the Viterbi score.\nTarget HMMs that reach sufficient significance to be reported are realigned using the Maximum Accuracy algorithm (MAC).\nThis algorithm maximizes the expected number of correctly aligned pairs of residues minus a penalty between 0 and 1.\nValues near 0 produce greedy, long, nearly global alignments, values above 0.3 result in shorter, local alignments.</p>\n<p>HHblits is an accelerated version of HHsearch that is fast enough to perform iterative searches through millions of profile HMMs,\ne.g. through the Uniclust profile HMM databases, generated by clustering the UniProt database into clusters of globally alignable sequences.\nAnalogously to PSI-BLAST and HMMER3, such iterative searches can be used to build MSAs by starting from a single query sequence.\nSequences from matches to profile HMMs below some E-value threshold (e.g. 10\u22123) are added to the query MSA for the next search iteration.</p>\n<p>Download databases from: <a class=\"reference external\" href=\"http://wwwuser.gwdg.de/~compbiol/data/hhsuite/databases/hhsuite_dbs/\">http://wwwuser.gwdg.de/~compbiol/data/hhsuite/databases/hhsuite_dbs/</a></p>\n",
-      "help_format": "restructuredtext",
-      "hidden": "",
-      "hidden_versions": [],
-      "history_id": "1affb3d848eeea7c",
-      "icon": null,
-      "id": "toolshed.g2.bx.psu.edu/repos/guerler/hhsuite/hhsearch/0.1.0",
+      "annotation": "Whether FPKM values should be computed with Cufflinks",
       "inputs": [
         {
           "argument": null,
-          "default_value": null,
-          "edam": {
-            "edam_data": [
-              "data_0006"
-            ],
-            "edam_formats": [
-              "format_1915"
-            ]
-          },
-          "extensions": [
-            "data"
-          ],
-          "help": "Single sequence or multiple sequence alignment (MSA)                 in a3m, a2m, or FASTA format, or HMM in hhm format. (-i)",
+          "falsevalue": "false",
+          "help": null,
           "help_format": "html",
           "hidden": false,
           "is_dynamic": false,
-          "label": "Query Sequence",
-          "model_class": "DataToolParameter",
-          "multiple": false,
+          "label": "Compute Cufflinks FPKM",
+          "model_class": "BooleanToolParameter",
           "name": "input",
           "optional": false,
-          "options": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "options_meta": {
-            "hda": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            },
-            "hdca": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            }
-          },
-          "pinned": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "refresh_on_change": true,
-          "tag": null,
-          "text_value": "Not available.",
-          "type": "data",
-          "value": {
-            "__class__": "ConnectedValue"
-          }
-        },
-        {
-          "argument": null,
-          "default_value": null,
-          "edam": {
-            "edam_data": [
-              "data_0006"
-            ],
-            "edam_formats": [
-              "format_2330"
-            ]
-          },
-          "extensions": [
-            "txt"
-          ],
-          "help": "Database file ending with 'hhm.ffindex'.",
-          "help_format": "html",
-          "hidden": false,
-          "is_dynamic": false,
-          "label": "HHM Index file",
-          "model_class": "DataToolParameter",
-          "multiple": false,
-          "name": "hhm_ffindex",
-          "optional": false,
-          "options": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "options_meta": {
-            "hda": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            },
-            "hdca": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            }
-          },
-          "pinned": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "refresh_on_change": true,
-          "tag": null,
-          "text_value": "Not available.",
-          "type": "data",
-          "value": {
-            "__class__": "ConnectedValue"
-          }
-        },
-        {
-          "argument": null,
-          "default_value": null,
-          "edam": {
-            "edam_data": [
-              "data_0006"
-            ],
-            "edam_formats": [
-              "format_1915"
-            ]
-          },
-          "extensions": [
-            "data"
-          ],
-          "help": "Database file ending with 'hhm.ffdata'.",
-          "help_format": "html",
-          "hidden": false,
-          "is_dynamic": false,
-          "label": "HHM Data file",
-          "model_class": "DataToolParameter",
-          "multiple": false,
-          "name": "hhm_ffdata",
-          "optional": false,
-          "options": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "options_meta": {
-            "hda": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            },
-            "hdca": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            }
-          },
-          "pinned": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "refresh_on_change": true,
-          "tag": null,
-          "text_value": "Not available.",
-          "type": "data",
-          "value": {
-            "__class__": "ConnectedValue"
-          }
-        },
-        {
-          "argument": null,
-          "default_value": null,
-          "edam": {
-            "edam_data": [
-              "data_0006"
-            ],
-            "edam_formats": [
-              "format_2330"
-            ]
-          },
-          "extensions": [
-            "txt"
-          ],
-          "help": "Database file ending with 'cs219.ffindex'.",
-          "help_format": "html",
-          "hidden": false,
-          "is_dynamic": false,
-          "label": "cs219 Index file",
-          "model_class": "DataToolParameter",
-          "multiple": false,
-          "name": "cs219_ffindex",
-          "optional": false,
-          "options": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "options_meta": {
-            "hda": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            },
-            "hdca": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            }
-          },
-          "pinned": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "refresh_on_change": true,
-          "tag": null,
-          "text_value": "Not available.",
-          "type": "data",
-          "value": {
-            "__class__": "ConnectedValue"
-          }
-        },
-        {
-          "argument": null,
-          "default_value": null,
-          "edam": {
-            "edam_data": [
-              "data_0006"
-            ],
-            "edam_formats": [
-              "format_1915"
-            ]
-          },
-          "extensions": [
-            "data"
-          ],
-          "help": "Database file ending with 'cs219.ffdata'.",
-          "help_format": "html",
-          "hidden": false,
-          "is_dynamic": false,
-          "label": "cs219 Data file",
-          "model_class": "DataToolParameter",
-          "multiple": false,
-          "name": "cs219_ffdata",
-          "optional": false,
-          "options": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "options_meta": {
-            "hda": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            },
-            "hdca": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            }
-          },
-          "pinned": {
-            "dce": [],
-            "hda": [],
-            "hdca": [],
-            "ldda": []
-          },
-          "refresh_on_change": true,
-          "tag": null,
-          "text_value": "Not available.",
-          "type": "data",
-          "value": {
-            "__class__": "ConnectedValue"
-          }
-        },
-        {
-          "argument": null,
-          "default_value": "hhsearch",
-          "display": "radio",
-          "help": "Select a search method. See help below for more information.",
-          "help_format": "html",
-          "hidden": false,
-          "is_dynamic": false,
-          "label": "Search Method",
-          "model_class": "SelectToolParameter",
-          "multiple": false,
-          "name": "method",
-          "optional": false,
-          "options": [
-            [
-              "HHsearch",
-              "hhsearch",
-              true
-            ],
-            [
-              "HHblits",
-              "hhblits",
-              false
-            ]
-          ],
           "refresh_on_change": false,
-          "text_value": "HHsearch",
-          "textable": true,
-          "type": "select",
-          "value": "hhsearch"
-        },
-        {
-          "area": false,
-          "argument": null,
-          "datalist": [],
-          "default_value": "0.001",
-          "help": "",
-          "help_format": "html",
-          "hidden": false,
-          "is_dynamic": false,
-          "label": "E-value cutoff for inclusion in result alignment. (-e)",
-          "max": 1.0,
-          "min": 0.0,
-          "model_class": "FloatToolParameter",
-          "name": "e",
-          "optional": false,
-          "refresh_on_change": false,
-          "text_value": "0.001",
-          "type": "float",
-          "value": "0.001"
+          "truevalue": "true",
+          "type": "boolean",
+          "value": false
         }
       ],
-      "is_workflow_compatible": true,
-      "job_credentials_context": null,
-      "job_id": null,
-      "job_remap": null,
-      "labels": [],
-      "license": null,
-      "message": "",
-      "method": "post",
-      "model_class": "Tool",
-      "name": "HHsearch",
       "output_connections": [
         {
-          "input_name": "inputs",
-          "input_step_index": 9,
+          "input_name": "when",
+          "input_step_index": 23,
           "output_name": "output",
           "output_step_index": 8
         }
       ],
-      "panel_section_id": "tool_toolshed.g2.bx.psu.edu/repos/guerler/hhsuite/hhsearch/0.1.0",
-      "panel_section_name": "HHsearch",
-      "post_job_actions": [],
       "replacement_parameters": [],
-      "requirements": [
-        {
-          "name": "hhsuite",
-          "version": "3.2.0"
-        }
-      ],
-      "sharable_url": "https://toolshed.g2.bx.psu.edu/view/guerler/hhsuite",
-      "state_inputs": {
-        "cs219_ffdata": {
-          "__class__": "ConnectedValue"
-        },
-        "cs219_ffindex": {
-          "__class__": "ConnectedValue"
-        },
-        "e": "0.001",
-        "hhm_ffdata": {
-          "__class__": "ConnectedValue"
-        },
-        "hhm_ffindex": {
-          "__class__": "ConnectedValue"
-        },
-        "input": {
-          "__class__": "ConnectedValue"
-        },
-        "method": "hhsearch"
-      },
       "step_index": 8,
-      "step_label": null,
-      "step_name": "HHsearch",
-      "step_type": "tool",
-      "step_version": "0.1.0",
-      "tool_errors": null,
-      "tool_shed_repository": {
-        "changeset_revision": "cec2aa4d6c0d",
-        "name": "hhsuite",
-        "owner": "guerler",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "version": "0.1.0",
-      "versions": [
-        "0.1.0"
-      ],
-      "warnings": null,
-      "when": null,
-      "xrefs": [
-        {
-          "type": "bio.tools",
-          "value": "hhsuite"
-        }
-      ]
+      "step_label": "Compute Cufflinks FPKM",
+      "step_name": "Input parameter",
+      "step_type": "parameter_input",
+      "step_version": null,
+      "when": null
     },
     {
-      "action": "/tool_runner/index",
-      "citations": true,
-      "config_file": "/cvmfs/test.galaxyproject.org/shed_tools/toolshed.g2.bx.psu.edu/repos/guerler/springsuite/860bd6f8f480/springsuite/spring_minz.xml",
-      "creator": null,
-      "credentials": [],
-      "description": "filter operation",
-      "display": true,
-      "edam_operations": [],
-      "edam_topics": [],
-      "enctype": "application/x-www-form-urlencoded",
-      "errors": {},
-      "form_style": "regular",
-      "has_parameters": true,
-      "help": "<p>This tool filters HH-search/HH-blits homology results through the protein interaction cross reference generated by SPRING. Putative interactions are identified by\nevaluating the min-Z score. The min-Z is the smaller of the two Z-scores for a pair of sequences matching an existing protein-protein complex structure.</p>\n",
-      "help_format": "restructuredtext",
-      "hidden": "",
-      "hidden_versions": [],
-      "history_id": "1affb3d848eeea7c",
-      "icon": null,
-      "id": "toolshed.g2.bx.psu.edu/repos/guerler/springsuite/spring_minz/0.1.0",
+      "annotation": "It could be a GTF with for example one entry for the chrM forward and one entry for the chrM reverse",
       "inputs": [
         {
-          "argument": null,
-          "collection_types": null,
-          "column_definitions": null,
-          "default_value": null,
-          "extensions": [
-            "txt"
+          "acceptable_extensions": [
+            "gff3",
+            "gff3.bz2",
+            "gff3.gz",
+            "gtf",
+            "gtf.gz"
           ],
-          "fields": null,
-          "help": "Homology search result of target/query profiles `hhr`.",
-          "help_format": "html",
-          "hidden": false,
-          "is_dynamic": false,
-          "label": "Target Profiles",
-          "model_class": "DataCollectionToolParameter",
-          "multiple": false,
-          "name": "targets",
-          "optional": false,
-          "options": {
-            "dce": [],
-            "hda": [],
-            "hdca": []
-          },
-          "options_meta": {
-            "hdca": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            }
-          },
-          "pinned": {
-            "dce": [],
-            "hda": [],
-            "hdca": []
-          },
-          "refresh_on_change": true,
-          "tag": null,
-          "text_value": "Not available.",
-          "type": "data_collection",
-          "value": {
-            "__class__": "RuntimeValue"
-          }
-        },
-        {
           "argument": null,
-          "collection_types": [
-            "list"
-          ],
-          "column_definitions": null,
-          "default_value": null,
-          "extensions": [
-            "txt"
-          ],
-          "fields": null,
-          "help": "Homology search results of input profiles `hhr`.",
-          "help_format": "html",
-          "hidden": false,
-          "is_dynamic": false,
-          "label": "Input Profiles",
-          "model_class": "DataCollectionToolParameter",
-          "multiple": false,
-          "name": "inputs",
-          "optional": false,
-          "options": {
-            "dce": [],
-            "hda": [],
-            "hdca": []
-          },
-          "options_meta": {
-            "hdca": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            }
-          },
-          "pinned": {
-            "dce": [],
-            "hda": [],
-            "hdca": []
-          },
-          "refresh_on_change": true,
-          "tag": null,
-          "text_value": "Not available.",
-          "type": "data_collection",
-          "value": {
-            "__class__": "ConnectedValue"
-          }
-        },
-        {
-          "argument": null,
-          "default_value": null,
           "edam": {
             "edam_data": [
-              "data_0006"
+              "data_1255",
+              "data_1255"
             ],
             "edam_formats": [
-              "format_2330"
+              "format_1975",
+              "format_2306"
             ]
           },
           "extensions": [
-            "txt"
+            "gff3",
+            "gtf"
           ],
-          "help": "Cross reference of interacting proteins `first_id metadata_id second_id`.",
+          "help": null,
           "help_format": "html",
           "hidden": false,
           "is_dynamic": false,
-          "label": "Cross Reference",
+          "label": "GTF with regions to exclude from FPKM normalization with Cufflinks",
           "model_class": "DataToolParameter",
           "multiple": false,
-          "name": "crossreference",
-          "optional": false,
+          "name": "input",
+          "optional": true,
           "options": {
             "dce": [],
             "hda": [],
             "hdca": [],
             "ldda": []
           },
-          "options_meta": {
-            "hda": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            },
-            "hdca": {
-              "has_more": false,
-              "limit": 50,
-              "offset": 0,
-              "total_estimate": 0
-            }
-          },
+          "options_meta": {},
           "pinned": {
             "dce": [],
             "hda": [],
@@ -1528,117 +577,66 @@
             "ldda": []
           },
           "refresh_on_change": true,
-          "tag": null,
-          "text_value": "Not available.",
+          "tag": "",
           "type": "data",
-          "value": {
-            "__class__": "ConnectedValue"
-          }
-        },
-        {
-          "area": false,
-          "argument": null,
-          "datalist": [],
-          "default_value": "10",
-          "help": "Matching interaction pairs with a score lower than this threshold will be excluded.",
-          "help_format": "html",
-          "hidden": false,
-          "is_dynamic": false,
-          "label": "min-Z score threshold",
-          "max": 100,
-          "min": 1,
-          "model_class": "IntegerToolParameter",
-          "name": "minscore",
-          "optional": false,
-          "refresh_on_change": false,
-          "text_value": "10",
-          "type": "integer",
-          "value": "10"
-        },
-        {
-          "area": false,
-          "argument": null,
-          "datalist": [],
-          "default_value": "6",
-          "help": "Specify the length of the identifier e.g. `1ACB_A` has length 6.",
-          "help_format": "html",
-          "hidden": false,
-          "is_dynamic": false,
-          "label": "Identifier length",
-          "max": 20,
-          "min": 1,
-          "model_class": "IntegerToolParameter",
-          "name": "idx",
-          "optional": false,
-          "refresh_on_change": false,
-          "text_value": "6",
-          "type": "integer",
-          "value": "6"
+          "value": null
         }
       ],
-      "is_workflow_compatible": true,
-      "job_credentials_context": null,
-      "job_id": null,
-      "job_remap": null,
-      "labels": [],
-      "license": null,
-      "message": "",
-      "messages": {
-        "targets": "No value found for 'Target Profiles'. Using default: '<galaxy.tools.parameters.workflow_utils.RuntimeValue object at 0x7fdf4cb79270>'."
-      },
-      "method": "post",
-      "model_class": "Tool",
-      "name": "SPRING min-Z",
-      "output_connections": [],
-      "panel_section_id": "tool_toolshed.g2.bx.psu.edu/repos/guerler/springsuite/spring_minz/0.1.0",
-      "panel_section_name": "SPRING min-Z",
-      "post_job_actions": [],
+      "output_connections": [
+        {
+          "input_name": "advanced_settings|mask_file",
+          "input_step_index": 23,
+          "output_name": "output",
+          "output_step_index": 9
+        }
+      ],
       "replacement_parameters": [],
-      "requirements": [],
-      "sharable_url": "https://toolshed.g2.bx.psu.edu/view/guerler/springsuite",
-      "state_inputs": {
-        "crossreference": {
-          "__class__": "ConnectedValue"
-        },
-        "idx": "6",
-        "inputs": {
-          "__class__": "ConnectedValue"
-        },
-        "minscore": "10",
-        "targets": {
-          "__class__": "RuntimeValue"
-        }
-      },
       "step_index": 9,
-      "step_label": null,
-      "step_name": "SPRING min-Z",
-      "step_type": "tool",
-      "step_version": "0.1.0",
-      "tool_errors": null,
-      "tool_shed_repository": {
-        "changeset_revision": "0ea00dce62ab",
-        "name": "springsuite",
-        "owner": "guerler",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "version": "0.1.0",
-      "versions": [
-        "0.1.0",
-        "0.1.1",
-        "0.1.2"
-      ],
-      "warnings": null,
-      "when": null,
-      "xrefs": [
+      "step_label": "GTF with regions to exclude from FPKM normalization with Cufflinks",
+      "step_name": "Input dataset",
+      "step_type": "data_input",
+      "step_version": null,
+      "when": null
+    },
+    {
+      "annotation": "Whether FPKM values should be computed with StringTie",
+      "inputs": [
         {
-          "type": "bio.tools",
-          "value": "spring"
+          "argument": null,
+          "falsevalue": "false",
+          "help": null,
+          "help_format": "html",
+          "hidden": false,
+          "is_dynamic": false,
+          "label": "Compute StringTie FPKM",
+          "model_class": "BooleanToolParameter",
+          "name": "input",
+          "optional": false,
+          "refresh_on_change": false,
+          "truevalue": "true",
+          "type": "boolean",
+          "value": false
         }
-      ]
+      ],
+      "output_connections": [
+        {
+          "input_name": "when",
+          "input_step_index": 22,
+          "output_name": "output",
+          "output_step_index": 10
+        }
+      ],
+      "replacement_parameters": [],
+      "step_index": 10,
+      "step_label": "Compute StringTie FPKM",
+      "step_name": "Input parameter",
+      "step_type": "parameter_input",
+      "step_version": null,
+      "when": null
     }
   ],
-  "version": 4,
-  "workflow_id": "509728dd2e69bcd0",
+  "version": 0,
+  "workflow_id": "9ae6b0bccf992b94",
   "workflow_resource_parameters": null,
-  "_fixture_note": "Captured from test.galaxyproject.org 26.1.rc1 via style=run&instance=true (history required). owner/history_id scrubbed; acceptable_extensions arrays subset to the first real entries for fixture size."
+  "_fixture_note": "Captured from test.galaxyproject.org 26.1.rc1 via style=run&instance=false (correct StoredWorkflow id resolution) for IWC rnaseq-pe. Reduced to INPUT steps only (the normalizer consumers; tool/subworkflow steps dropped for size); owner/history_id scrubbed; acceptable_extensions and parameter options subset to first real entries."
 }


### PR DESCRIPTION
Follow-up to #55. `_resolve_workflow_slots` called `style=run&instance=true`, but the `workflow_id` callers pass in is a StoredWorkflow id (what `show_workflow`/`list_workflows` return). `instance=true` reinterprets it as a Workflow-version id and silently resolves a *different* workflow -- so `get_workflow_input_template` and the `invoke_workflow` preflight could describe or validate the wrong workflow's inputs entirely (worst case: rejecting a valid run).

Confirmed on a live 26.1 server: for one id, `show_workflow` returns rnaseq-pe while `style=run&instance=true` returns an unrelated "Protein Interaction Protocol" workflow; `instance=false` returns rnaseq-pe correctly. `instance=false` matches `show_workflow`'s id semantics and the run-download the web client's own run form uses.

The committed `style=run` fixture had been captured with the buggy flag (so it was that protein workflow mislabeled as rnaseq) -- which is why tests didn't catch this: the unit tests mock `make_get_request`, so they can't see the `instance` semantics. Re-captured from the correct rnaseq-pe via `instance=false`, trimmed to the input steps the normalizer consumes. 173 tests green, mypy + ruff clean.
