### PR TITLE
Skip Release Drafter on fork PRs instead of failing them

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,12 @@ permissions:
 
 jobs:
   update_release_draft:
+    # Skip on PRs from forks: those runs get a read-only GITHUB_TOKEN, so the
+    # release-creation step always 403s. Still runs on push to main, same-repo
+    # PRs, and manual dispatch.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
The `update_release_draft` job runs on `pull_request`, but PRs from forks get a read-only `GITHUB_TOKEN` that the job's `permissions:` block can't elevate (a GitHub security rule for fork-triggered runs). So release-drafter builds the release payload fine and then 403s at "Creating new release" -- every fork PR shows a red X, even though the draft updates correctly on push to `main`. The failing run is pure noise; the draft itself is fine.

This guards the job to skip `pull_request` events that aren't from the base repo, so fork PRs show *skipped* instead of *failed*. It still runs on push to `main`, same-repo PRs, and manual dispatch.

The condition has to allow non-PR events explicitly:

```yaml
if: >-
  github.event_name != 'pull_request' ||
  github.event.pull_request.head.repo.full_name == github.repository
```

A bare `github.event.pull_request.head.repo.full_name == github.repository` would also skip the push-to-`main` run (no `pull_request` context on a push → the comparison is false), which would stop the draft from updating on merge -- hence the `github.event_name != 'pull_request' ||` prefix.
