### PR TITLE
Add a run guide + resolved parameter options to get_workflow_input_template

### DIFF
--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -2928,9 +2928,11 @@ def get_workflow_details(workflow_id: str, version: int | None = None) -> Galaxy
 
 def _resolve_workflow_slots(
     gi: GalaxyInstance, workflow_id: str, history_id: str | None = None
-) -> tuple[list[dict[str, Any]], str]:
+) -> tuple[list[dict[str, Any]], str, dict[str, Any] | None]:
     """Resolve a workflow's input slots. Primary: style=run (webapp's source),
-    behind our normalizer. Fallback: the .ga export. Returns (slots, provenance).
+    behind our normalizer. Fallback: the .ga export. Returns
+    (slots, provenance, run_model) -- run_model is the parsed style=run dict when
+    that path was used, else None.
     """
     # instance=false: workflow_id here is a StoredWorkflow id (what show_workflow /
     # list_workflows hand back). instance=true reinterprets it as a Workflow-version
@@ -2942,13 +2944,14 @@ def _resolve_workflow_slots(
     try:
         resp = gi.make_get_request(f"{gi.url}/api/workflows/{workflow_id}/download?{params}")
         if resp.status_code == 200:
-            slots = normalize_run_model(resp.json())
+            run_model = resp.json()
+            slots = normalize_run_model(run_model)
             if slots:
-                return slots, "style=run"
+                return slots, "style=run", run_model
     except Exception as e:  # noqa: BLE001 -- fall back on any style=run failure
         logger.info("style=run unavailable for %s (%s); falling back to .ga", workflow_id, e)
     definition = gi.workflows.export_workflow_dict(workflow_id)
-    return normalize_ga_steps(definition), "ga-fallback"
+    return normalize_ga_steps(definition), "ga-fallback", None
 
 
 @mcp.tool(tags={"workflows", "read", "extended"})
@@ -2963,7 +2966,7 @@ def get_workflow_input_template(workflow_id: str, history_id: str | None = None)
     state = ensure_connected()
     gi: GalaxyInstance = state["gi"]
     try:
-        slots, provenance = _resolve_workflow_slots(gi, workflow_id, history_id)
+        slots, provenance, run_model = _resolve_workflow_slots(gi, workflow_id, history_id)
         try:
             definition = gi.workflows.export_workflow_dict(workflow_id)
             warnings = find_legacy_warnings(definition)
@@ -3052,7 +3055,7 @@ def invoke_workflow(
         # Preflight: validate supplied inputs against the workflow's slots.
         if inputs:
             try:
-                slots, _prov = _resolve_workflow_slots(gi, workflow_id, history_id)
+                slots, _prov, _run = _resolve_workflow_slots(gi, workflow_id, history_id)
                 mapping = _get_datatypes_mapping(gi)
                 supplied = _enrich_supplied_inputs(gi, inputs)
                 verdict = validate_inputs(slots, supplied, mapping)
@@ -3098,7 +3101,7 @@ def invoke_workflow(
     except Exception as e:
         hint = ""
         with contextlib.suppress(Exception):
-            slots, _ = _resolve_workflow_slots(gi, workflow_id, history_id)
+            slots, _, _ = _resolve_workflow_slots(gi, workflow_id, history_id)
             hint = "\n\nWorkflow input slots:\n" + json.dumps(
                 build_workflow_input_template(slots)["slots"], indent=2, default=str
             )

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -39,6 +39,7 @@ from galaxy_mcp.tool_inputs import (
 )
 from galaxy_mcp.workflow_inputs import (
     _clean_readme_summary,
+    build_guide,
     build_workflow_input_template,
     find_legacy_warnings,
     normalize_ga_steps,
@@ -2955,13 +2956,18 @@ def _resolve_workflow_slots(
 
 
 @mcp.tool(tags={"workflows", "read", "extended"})
-def get_workflow_input_template(workflow_id: str, history_id: str | None = None) -> GalaxyResult:
-    """Return a ready-to-fill template of a workflow's input slots.
+def get_workflow_input_template(
+    workflow_id: str, history_id: str | None = None, verbose: bool = False
+) -> GalaxyResult:
+    """Return a ready-to-fill template plus a run guide for a workflow.
 
     Call this before invoke_workflow. Each slot lists its label, expected source
-    (hda/hdca), accepted datatypes, and collection type so you map datasets to
-    the right inputs. Fill `inputs_template` (keyed by step_index) and invoke
-    with `inputs_by="step_index|step_uuid"`. `warnings` flags legacy patterns.
+    (hda/hdca), accepted datatypes, collection type, and -- for parameters --
+    selectable `options` (including resolved reference-genome values when a
+    history_id is given). `guide` carries a short description and provenance.
+    Fill `inputs_template` (keyed by step_index) and invoke with
+    `inputs_by="step_index|step_uuid"`. Pass `verbose=True` for the full readme
+    and uncapped option lists. `warnings` flags legacy patterns.
     """
     state = ensure_connected()
     gi: GalaxyInstance = state["gi"]
@@ -2972,7 +2978,14 @@ def get_workflow_input_template(workflow_id: str, history_id: str | None = None)
             warnings = find_legacy_warnings(definition)
         except Exception:  # noqa: BLE001 -- warnings are best-effort
             warnings = []
-        template = build_workflow_input_template(slots, warnings=warnings)
+        try:
+            workflow_show = gi.workflows.show_workflow(workflow_id=workflow_id)
+        except Exception:  # noqa: BLE001 -- guide docs are best-effort
+            workflow_show = {}
+        guide = build_guide(workflow_show, run_model, verbose)
+        template = build_workflow_input_template(
+            slots, warnings=warnings, guide=guide, verbose=verbose
+        )
         return GalaxyResult(
             data=template,
             success=True,

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -2963,10 +2963,12 @@ def get_workflow_input_template(
 
     Call this before invoke_workflow. Each slot lists its label, expected source
     (hda/hdca), accepted datatypes, collection type, and -- for parameters --
-    selectable `options` (including resolved reference-genome values when a
-    history_id is given; on the legacy .ga export path options are static and
-    reference genomes resolve at run time -- see `guide.notes`). `guide` carries
-    a short description and provenance.
+    selectable `options` as [{label, value}]. On the `style=run` path these are
+    Galaxy-resolved: reference-genome dbkeys come from the server regardless of
+    history, and passing `history_id` additionally surfaces that history's
+    compatible datasets as candidates. The legacy .ga fallback carries only the
+    static restrictions baked into the workflow -- no server- or history-resolved
+    values -- see `guide.notes`. `guide` carries a short description and provenance.
     Fill `inputs_template` (keyed by step_index) and invoke with
     `inputs_by="step_index|step_uuid"`. Pass `verbose=True` for the full readme
     and uncapped option lists. `warnings` flags legacy patterns.

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -2964,7 +2964,9 @@ def get_workflow_input_template(
     Call this before invoke_workflow. Each slot lists its label, expected source
     (hda/hdca), accepted datatypes, collection type, and -- for parameters --
     selectable `options` (including resolved reference-genome values when a
-    history_id is given). `guide` carries a short description and provenance.
+    history_id is given; on the legacy .ga export path options are static and
+    reference genomes resolve at run time -- see `guide.notes`). `guide` carries
+    a short description and provenance.
     Fill `inputs_template` (keyed by step_index) and invoke with
     `inputs_by="step_index|step_uuid"`. Pass `verbose=True` for the full readme
     and uncapped option lists. `warnings` flags legacy patterns.
@@ -2972,6 +2974,9 @@ def get_workflow_input_template(
     state = ensure_connected()
     gi: GalaxyInstance = state["gi"]
     try:
+        # Three independent best-effort reads of the same workflow: the run model
+        # (_resolve_workflow_slots), the .ga export (legacy warnings), and
+        # show_workflow (guide docs).
         slots, provenance, run_model = _resolve_workflow_slots(gi, workflow_id, history_id)
         try:
             definition = gi.workflows.export_workflow_dict(workflow_id)

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -38,6 +38,7 @@ from galaxy_mcp.tool_inputs import (
     summarize_tool_inputs,
 )
 from galaxy_mcp.workflow_inputs import (
+    _clean_readme_summary,
     build_workflow_input_template,
     find_legacy_warnings,
     normalize_ga_steps,
@@ -2347,34 +2348,6 @@ def get_iwc_workflows() -> GalaxyResult:
         return _fetch_iwc_workflows()
     except Exception as e:
         raise ValueError(f"Failed to fetch IWC workflows: {str(e)}") from e
-
-
-def _clean_readme_summary(readme: str, max_length: int = 300) -> str:
-    """Extract a clean summary from a readme, stripping markdown headers."""
-    if not readme:
-        return ""
-
-    lines = readme.split("\n")
-    clean_lines: list[str] = []
-
-    for line in lines:
-        # Skip markdown headers
-        if line.strip().startswith("#"):
-            continue
-        # Skip empty lines at the start
-        if not clean_lines and not line.strip():
-            continue
-        clean_lines.append(line)
-
-    text = " ".join(clean_lines)
-    # Normalize whitespace
-    text = " ".join(text.split())
-
-    if len(text) > max_length:
-        # Truncate at word boundary
-        text = text[: max_length - 3].rsplit(" ", 1)[0] + "..."
-
-    return text
 
 
 def _extract_tool_names_from_steps(steps: dict) -> list[str]:

--- a/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
@@ -53,13 +53,13 @@ def _options_from_triples(raw: Any) -> list[dict]:
     out: list[dict] = []
     for item in raw:
         if isinstance(item, (list, tuple)) and len(item) >= 2:
-            out.append({"label": item[0], "value": item[1]})
+            out.append({"label": str(item[0]), "value": str(item[1])})
     return out
 
 
 def _options_from_restrictions(raw: Any) -> list[dict]:
     """.ga enumerated params carry a flat list of allowed string values."""
-    return [{"label": v, "value": v} for v in raw] if isinstance(raw, list) else []
+    return [{"label": str(v), "value": str(v)} for v in raw] if isinstance(raw, list) else []
 
 
 _SORT_SENTINEL = 10**9  # sorts non-numeric step keys to the end without crashing
@@ -146,7 +146,11 @@ def normalize_ga_steps(definition: dict[str, Any]) -> list[dict[str, Any]]:
                 collection_type=state.get("collection_type"),
                 parameter_type=state.get("parameter_type"),
                 optional=bool(state.get("optional", False)),
-                options=_options_from_restrictions(state.get("restrictions")),
+                options=(
+                    _options_from_restrictions(state.get("restrictions"))
+                    if input_type == "parameter"
+                    else []
+                ),
             )
         )
     return slots
@@ -234,7 +238,9 @@ def normalize_run_model(run_dict: dict[str, Any]) -> list[dict[str, Any]]:
                 collection_type=ctype,
                 parameter_type=param.get("parameter_type") or step.get("parameter_type"),
                 optional=bool(param.get("optional", False)),
-                options=_options_from_triples(param.get("options")),
+                options=(
+                    _options_from_triples(param.get("options")) if input_type == "parameter" else []
+                ),
             )
         )
     return slots
@@ -525,10 +531,15 @@ def build_guide(
     readme = workflow_show.get("readme") or ""
     help_text = workflow_show.get("help") or ""
     annotation = workflow_show.get("annotation") or ""
-    if readme:
-        summary = readme if verbose else _clean_readme_summary(readme)
-    elif help_text:
-        summary = help_text if verbose else _clean_readme_summary(help_text)
+    # Pick the first source whose cleaned form has real prose (a headers-only
+    # readme cleans to ""), then render it per verbose. annotation is the last resort.
+    chosen_raw = ""
+    for text in (readme, help_text):
+        if _clean_readme_summary(text).strip():
+            chosen_raw = text
+            break
+    if chosen_raw:
+        summary = chosen_raw if verbose else _clean_readme_summary(chosen_raw)
     else:
         summary = annotation
 

--- a/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
@@ -481,3 +481,43 @@ def build_workflow_input_template(
         "inputs_by": "step_index|step_uuid",
         "warnings": warnings or [],
     }
+
+
+def build_guide(
+    workflow_show: dict[str, Any], run_model: dict[str, Any] | None, verbose: bool
+) -> dict[str, Any]:
+    """Assemble the model-facing run guide from a show_workflow dict.
+
+    summary: full readme when verbose, else a cleaned summary; falls back
+    readme -> help -> annotation. provenance: version + TRS source (always),
+    plus freshness flags from style=run when available. When run_model is None
+    (the .ga fallback path), parameter options weren't resolved -- note it.
+    """
+    readme = workflow_show.get("readme") or ""
+    help_text = workflow_show.get("help") or ""
+    annotation = workflow_show.get("annotation") or ""
+    if readme:
+        summary = readme if verbose else _clean_readme_summary(readme)
+    elif help_text:
+        summary = help_text if verbose else _clean_readme_summary(help_text)
+    else:
+        summary = annotation
+
+    src_meta = workflow_show.get("source_metadata") or {}
+    provenance: dict[str, Any] = {
+        "version": workflow_show.get("version"),
+        "source": {"trs_id": src_meta.get("trs_tool_id"), "trs_url": src_meta.get("trs_url")},
+    }
+    if run_model is not None:
+        provenance["freshness"] = {
+            "has_upgrade_messages": run_model.get("has_upgrade_messages"),
+            "step_version_changes": run_model.get("step_version_changes") or [],
+        }
+
+    guide: dict[str, Any] = {"summary": summary, "annotation": annotation, "provenance": provenance}
+    if run_model is None:
+        guide["notes"] = [
+            "Parameter options (e.g. reference genome) resolve at run time; "
+            "call again with a history_id for resolved values."
+        ]
+    return guide

--- a/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
@@ -467,20 +467,49 @@ def _placeholder_for(slot: dict[str, Any]) -> Any:
     return "<value>"
 
 
+_OPTIONS_INLINE_CAP = 25  # inline option sets at or below this size in full
+_OPTIONS_SAMPLE = 15  # otherwise show this many + a note (unless verbose)
+
+
+def _display_slot(slot: dict[str, Any], verbose: bool) -> dict[str, Any]:
+    """Per-slot display shaping: drop the giant acceptable_extensions, and cap
+    large option sets (keeping option_count) unless verbose. Empty options are
+    dropped so data/collection slots stay clean.
+    """
+    out = {k: v for k, v in slot.items() if k != "acceptable_extensions"}
+    options = out.get("options") or []
+    if not options:
+        out.pop("options", None)
+        return out
+    out["option_count"] = len(options)
+    if not verbose and len(options) > _OPTIONS_INLINE_CAP:
+        out["options"] = options[:_OPTIONS_SAMPLE]
+        out["options_note"] = (
+            f"showing {_OPTIONS_SAMPLE} of {len(options)}; pass verbose=true for the full list, "
+            f"or supply a value matching an installed option."
+        )
+    return out
+
+
 def build_workflow_input_template(
-    slots: list[dict[str, Any]], warnings: list[dict[str, Any]] | None = None
+    slots: list[dict[str, Any]],
+    warnings: list[dict[str, Any]] | None = None,
+    guide: dict[str, Any] | None = None,
+    verbose: bool = False,
 ) -> dict[str, Any]:
     """Assemble the model-facing template: a ready-to-fill skeleton keyed by
-    step_index, the per-slot constraint summary, the invoke key hint, and any
-    legacy warnings.
+    step_index, the per-slot constraint summary (with capped options), the
+    invoke key hint, any legacy warnings, and -- when provided -- the run guide.
     """
-    display_slots = [{k: v for k, v in s.items() if k != "acceptable_extensions"} for s in slots]
-    return {
+    result: dict[str, Any] = {
         "inputs_template": {str(s["step_index"]): _placeholder_for(s) for s in slots},
-        "slots": display_slots,
+        "slots": [_display_slot(s, verbose) for s in slots],
         "inputs_by": "step_index|step_uuid",
         "warnings": warnings or [],
     }
+    if guide is not None:
+        result["guide"] = guide
+    return result
 
 
 def build_guide(

--- a/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
@@ -46,6 +46,22 @@ def _clean_readme_summary(readme: str, max_length: int = 300) -> str:
     return text
 
 
+def _options_from_triples(raw: Any) -> list[dict]:
+    """style=run param options come as [label, value, selected] triples."""
+    if not isinstance(raw, list):
+        return []
+    out: list[dict] = []
+    for item in raw:
+        if isinstance(item, (list, tuple)) and len(item) >= 2:
+            out.append({"label": item[0], "value": item[1]})
+    return out
+
+
+def _options_from_restrictions(raw: Any) -> list[dict]:
+    """.ga enumerated params carry a flat list of allowed string values."""
+    return [{"label": v, "value": v} for v in raw] if isinstance(raw, list) else []
+
+
 _SORT_SENTINEL = 10**9  # sorts non-numeric step keys to the end without crashing
 
 _INPUT_TYPE_MAP = {
@@ -130,6 +146,7 @@ def normalize_ga_steps(definition: dict[str, Any]) -> list[dict[str, Any]]:
                 collection_type=state.get("collection_type"),
                 parameter_type=state.get("parameter_type"),
                 optional=bool(state.get("optional", False)),
+                options=_options_from_restrictions(state.get("restrictions")),
             )
         )
     return slots
@@ -146,8 +163,9 @@ def _make_slot(
     collection_type: str | None,
     parameter_type: str | None,
     optional: bool,
+    options: list,
 ) -> dict[str, Any]:
-    """Build the 10-key slot contract dict shared by both normalizers."""
+    """Build the slot contract dict shared by both normalizers."""
     return {
         "step_index": step_index,
         "step_uuid": step_uuid,
@@ -159,6 +177,7 @@ def _make_slot(
         "collection_type": collection_type,
         "parameter_type": parameter_type,
         "optional": optional,
+        "options": options,
     }
 
 
@@ -215,6 +234,7 @@ def normalize_run_model(run_dict: dict[str, Any]) -> list[dict[str, Any]]:
                 collection_type=ctype,
                 parameter_type=param.get("parameter_type") or step.get("parameter_type"),
                 optional=bool(param.get("optional", False)),
+                options=_options_from_triples(param.get("options")),
             )
         )
     return slots

--- a/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/workflow_inputs.py
@@ -27,6 +27,25 @@ def _as_list(value: Any) -> list:
     return [value]
 
 
+def _clean_readme_summary(readme: str, max_length: int = 300) -> str:
+    """Extract a clean summary from a readme, stripping markdown headers."""
+    if not readme:
+        return ""
+    lines = readme.split("\n")
+    clean_lines: list[str] = []
+    for line in lines:
+        if line.strip().startswith("#"):
+            continue
+        if not clean_lines and not line.strip():
+            continue
+        clean_lines.append(line)
+    text = " ".join(clean_lines)
+    text = " ".join(text.split())
+    if len(text) > max_length:
+        text = text[: max_length - 3].rsplit(" ", 1)[0] + "..."
+    return text
+
+
 _SORT_SENTINEL = 10**9  # sorts non-numeric step keys to the end without crashing
 
 _INPUT_TYPE_MAP = {

--- a/mcp-server-galaxy-py/tests/test_workflow_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_inputs.py
@@ -110,6 +110,7 @@ def test_normalize_ga_steps_data_input_restricted():
         "collection_type": None,
         "parameter_type": None,
         "optional": False,
+        "options": [],
     }
 
 
@@ -158,6 +159,7 @@ def test_normalize_run_model_returns_slot_contract():
             "collection_type",
             "parameter_type",
             "optional",
+            "options",
         }
         assert s["input_type"] in {"data", "data_collection", "parameter"}
         assert isinstance(s["accepted_formats"], list)
@@ -590,3 +592,62 @@ def test_clean_readme_summary_strips_headers_and_truncates():
 
 def test_clean_readme_summary_empty():
     assert _clean_readme_summary("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Task 2 (run-guide): options field on the slot contract
+# ---------------------------------------------------------------------------
+
+from pathlib import Path  # noqa: E402
+
+
+def test_ga_enumerated_restrictions_become_options():
+    ga = {
+        "steps": {
+            "0": {
+                "type": "parameter_input",
+                "label": "Strand",
+                "tool_state": '{"parameter_type": "text", "restrictions": ["fwd", "rev"]}',
+            }
+        }
+    }
+    s = normalize_ga_steps(ga)[0]
+    assert s["options"] == [{"label": "fwd", "value": "fwd"}, {"label": "rev", "value": "rev"}]
+
+
+def test_ga_data_input_has_empty_options():
+    ga = {"steps": {"0": {"type": "data_input", "label": "in", "tool_state": "{}"}}}
+    assert normalize_ga_steps(ga)[0]["options"] == []
+
+
+def test_run_model_options_from_triples():
+    # the real style=run shape: inputs[0].options is a list of [label, value, selected]
+    run = {
+        "steps": [
+            {
+                "step_type": "parameter_input",
+                "step_index": 0,
+                "step_label": "Strand",
+                "inputs": [{"options": [["forward", "fwd", False], ["reverse", "rev", True]]}],
+            }
+        ]
+    }
+    s = normalize_run_model(run)[0]
+    assert s["options"] == [
+        {"label": "forward", "value": "fwd"},
+        {"label": "reverse", "value": "rev"},
+    ]
+
+
+def test_run_model_real_fixture_has_strandedness_options():
+    fixture = Path(__file__).parent / "testdata" / "wf_style_run_rnaseq.json"
+    slots = normalize_run_model(_json.loads(fixture.read_text()))
+    strand = next(s for s in slots if s["label"] == "Strandedness")
+    assert {o["value"] for o in strand["options"]} == {
+        "stranded - forward",
+        "stranded - reverse",
+        "unstranded",
+    }
+    ref = next(s for s in slots if s["label"] == "Reference genome")
+    assert ref["options"]
+    assert all("value" in o for o in ref["options"])

--- a/mcp-server-galaxy-py/tests/test_workflow_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_inputs.py
@@ -759,3 +759,79 @@ def test_template_includes_guide_when_provided():
     g = {"summary": "x", "provenance": {"version": 1}}
     t = build_workflow_input_template([_param_slot([])], guide=g)
     assert t["guide"] == g
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 (new): options must only appear on parameter inputs
+# ---------------------------------------------------------------------------
+
+
+def test_ga_data_input_ignores_stray_restrictions():
+    ga = {
+        "steps": {
+            "0": {"type": "data_input", "label": "in", "tool_state": '{"restrictions": ["x", "y"]}'}
+        }
+    }
+    assert normalize_ga_steps(ga)[0]["options"] == []
+
+
+def test_run_data_input_ignores_list_options():
+    run = {
+        "steps": [
+            {
+                "step_type": "data_input",
+                "step_index": 0,
+                "step_label": "in",
+                "inputs": [{"options": [["a", "a", False]]}],
+            }
+        ]
+    }
+    assert normalize_run_model(run)[0]["options"] == []
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 (new): build_guide summary must fall through a headers-only readme
+# ---------------------------------------------------------------------------
+
+
+def test_build_guide_skips_headers_only_readme_for_help():
+    g = build_guide(
+        {
+            "version": 1,
+            "annotation": "ann",
+            "readme": "# Title\n## Sub",
+            "help": "Real help text here.",
+        },
+        None,
+        verbose=False,
+    )
+    assert "Real help text" in g["summary"]
+
+
+def test_build_guide_headers_only_readme_no_help_uses_annotation():
+    g = build_guide(
+        {"version": 1, "annotation": "Just an annotation", "readme": "# Only headers", "help": ""},
+        None,
+        verbose=False,
+    )
+    assert g["summary"] == "Just an annotation"
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 (new): option label/value must be string-coerced
+# ---------------------------------------------------------------------------
+
+
+def test_options_values_are_stringified():
+    run = {
+        "steps": [
+            {
+                "step_type": "parameter_input",
+                "step_index": 0,
+                "step_label": "p",
+                "inputs": [{"options": [["one", 1, False], ["two", 2, True]]}],
+            }
+        ]
+    }
+    opts = normalize_run_model(run)[0]["options"]
+    assert opts == [{"label": "one", "value": "1"}, {"label": "two", "value": "2"}]

--- a/mcp-server-galaxy-py/tests/test_workflow_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_inputs.py
@@ -2,6 +2,9 @@ import json as _json
 from pathlib import Path
 
 from galaxy_mcp.workflow_inputs import (
+    _clean_readme_summary,
+    _collection_type_compatible,
+    build_guide,
     build_workflow_input_template,
     find_legacy_warnings,
     normalize_ga_steps,
@@ -310,8 +313,6 @@ def test_build_template_skeleton_and_slots():
 # Fix 1: _collection_type_compatible -- segment comparison, not raw suffix
 # ---------------------------------------------------------------------------
 
-from galaxy_mcp.workflow_inputs import _collection_type_compatible  # noqa: E402
-
 
 def test_collection_type_compatible_list_does_not_satisfy_paired():
     # "list" does not end with ":paired"; the bare-suffix check wrongly passed before the fix
@@ -579,8 +580,6 @@ def test_build_template_omits_acceptable_extensions_from_display_slots():
 # Task 1 (run-guide): _clean_readme_summary moved to the pure module
 # ---------------------------------------------------------------------------
 
-from galaxy_mcp.workflow_inputs import _clean_readme_summary  # noqa: E402
-
 
 def test_clean_readme_summary_strips_headers_and_truncates():
     md = "# Title\n\nThis workflow does X.\n## Details\nThen Y."
@@ -597,8 +596,6 @@ def test_clean_readme_summary_empty():
 # ---------------------------------------------------------------------------
 # Task 2 (run-guide): options field on the slot contract
 # ---------------------------------------------------------------------------
-
-from pathlib import Path  # noqa: E402
 
 
 def test_ga_enumerated_restrictions_become_options():
@@ -656,8 +653,6 @@ def test_run_model_real_fixture_has_strandedness_options():
 # ---------------------------------------------------------------------------
 # Task 3 (run-guide): build_guide assembles the model-facing run guide
 # ---------------------------------------------------------------------------
-
-from galaxy_mcp.workflow_inputs import build_guide  # noqa: E402
 
 WF_SHOW = {
     "version": 12,

--- a/mcp-server-galaxy-py/tests/test_workflow_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_inputs.py
@@ -702,3 +702,60 @@ def test_build_guide_falls_back_to_annotation_when_no_readme():
         verbose=False,
     )
     assert g["summary"] == "Just an annotation"
+
+
+# ---------------------------------------------------------------------------
+# Task 4 (run-guide): option-capping + guide in build_workflow_input_template
+# ---------------------------------------------------------------------------
+
+
+def _param_slot(options):
+    return {
+        "step_index": 0,
+        "step_uuid": None,
+        "label": "Genome",
+        "input_type": "parameter",
+        "src": None,
+        "accepted_formats": [],
+        "acceptable_extensions": [],
+        "collection_type": None,
+        "parameter_type": "text",
+        "optional": False,
+        "options": options,
+    }
+
+
+def test_template_inlines_small_option_sets():
+    opts = [{"label": f"g{i}", "value": str(i)} for i in range(5)]
+    t = build_workflow_input_template([_param_slot(opts)])
+    s = t["slots"][0]
+    assert s["options"] == opts
+    assert s["option_count"] == 5
+    assert "options_note" not in s
+
+
+def test_template_caps_large_option_sets_unless_verbose():
+    opts = [{"label": f"g{i}", "value": str(i)} for i in range(100)]
+    s = build_workflow_input_template([_param_slot(opts)])["slots"][0]
+    assert len(s["options"]) == 15
+    assert s["option_count"] == 100
+    assert "options_note" in s
+    # verbose returns the full list
+    sv = build_workflow_input_template([_param_slot(opts)], verbose=True)["slots"][0]
+    assert len(sv["options"]) == 100
+    assert "options_note" not in sv
+
+
+def test_template_drops_empty_options_and_strips_acceptable_extensions():
+    slot = _param_slot([])
+    slot["acceptable_extensions"] = ["a", "b"]
+    s = build_workflow_input_template([slot])["slots"][0]
+    assert "options" not in s  # empty -> dropped from display
+    assert "option_count" not in s
+    assert "acceptable_extensions" not in s  # still stripped (from #55)
+
+
+def test_template_includes_guide_when_provided():
+    g = {"summary": "x", "provenance": {"version": 1}}
+    t = build_workflow_input_template([_param_slot([])], guide=g)
+    assert t["guide"] == g

--- a/mcp-server-galaxy-py/tests/test_workflow_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_inputs.py
@@ -571,3 +571,22 @@ def test_build_template_omits_acceptable_extensions_from_display_slots():
     tmpl = build_workflow_input_template(slots)
     assert "acceptable_extensions" not in tmpl["slots"][0]
     assert tmpl["slots"][0]["accepted_formats"] == ["txt"]
+
+
+# ---------------------------------------------------------------------------
+# Task 1 (run-guide): _clean_readme_summary moved to the pure module
+# ---------------------------------------------------------------------------
+
+from galaxy_mcp.workflow_inputs import _clean_readme_summary  # noqa: E402
+
+
+def test_clean_readme_summary_strips_headers_and_truncates():
+    md = "# Title\n\nThis workflow does X.\n## Details\nThen Y."
+    out = _clean_readme_summary(md, max_length=40)
+    assert "#" not in out
+    assert out.startswith("This workflow does X.")
+    assert len(out) <= 40
+
+
+def test_clean_readme_summary_empty():
+    assert _clean_readme_summary("") == ""

--- a/mcp-server-galaxy-py/tests/test_workflow_inputs.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_inputs.py
@@ -651,3 +651,54 @@ def test_run_model_real_fixture_has_strandedness_options():
     ref = next(s for s in slots if s["label"] == "Reference genome")
     assert ref["options"]
     assert all("value" in o for o in ref["options"])
+
+
+# ---------------------------------------------------------------------------
+# Task 3 (run-guide): build_guide assembles the model-facing run guide
+# ---------------------------------------------------------------------------
+
+from galaxy_mcp.workflow_inputs import build_guide  # noqa: E402
+
+WF_SHOW = {
+    "version": 12,
+    "annotation": "RNA-seq for paired-end data",
+    "readme": "# RNA-Seq\n\nThis runs adapter trimming then alignment then quantification. " * 10,
+    "help": "",
+    "source_metadata": {
+        "trs_tool_id": "#workflow/.../rnaseq-pe/main",
+        "trs_url": "https://dockstore/x",
+    },
+}
+RUN_MODEL = {"has_upgrade_messages": False, "step_version_changes": []}
+
+
+def test_build_guide_summary_is_short_by_default():
+    g = build_guide(WF_SHOW, RUN_MODEL, verbose=False)
+    assert len(g["summary"]) <= 300
+    assert g["annotation"] == "RNA-seq for paired-end data"
+    assert g["provenance"]["version"] == 12
+    assert g["provenance"]["source"]["trs_id"] == "#workflow/.../rnaseq-pe/main"
+    assert g["provenance"]["freshness"] == {
+        "has_upgrade_messages": False,
+        "step_version_changes": [],
+    }
+
+
+def test_build_guide_verbose_returns_full_readme():
+    g = build_guide(WF_SHOW, RUN_MODEL, verbose=True)
+    assert len(g["summary"]) > 300  # full readme, not truncated
+
+
+def test_build_guide_without_run_model_omits_freshness_and_adds_note():
+    g = build_guide(WF_SHOW, None, verbose=False)
+    assert "freshness" not in g["provenance"]
+    assert any("history_id" in n for n in g.get("notes", []))
+
+
+def test_build_guide_falls_back_to_annotation_when_no_readme():
+    g = build_guide(
+        {"version": 1, "annotation": "Just an annotation", "readme": "", "help": ""},
+        None,
+        verbose=False,
+    )
+    assert g["summary"] == "Just an annotation"

--- a/mcp-server-galaxy-py/tests/test_workflow_operations.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_operations.py
@@ -740,3 +740,19 @@ def test_template_verbose_returns_full_readme(mock_galaxy_instance):
     with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
         result = get_workflow_input_template_fn("wfid", history_id="h1", verbose=True)
     assert len(result.data["guide"]["summary"]) > 300
+
+
+def test_template_returns_when_show_workflow_fails(mock_galaxy_instance):
+    # show_workflow is best-effort: if it raises, the tool still returns a template
+    # (with a degraded guide), and options still come from the run model.
+    mock_galaxy_instance.url = "https://g/api"
+    mock_galaxy_instance.make_get_request.return_value = _run_resp_with_param()
+    mock_galaxy_instance.workflows.export_workflow_dict.return_value = {"steps": {}}
+    mock_galaxy_instance.workflows.show_workflow.side_effect = Exception("boom")
+    with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+        result = get_workflow_input_template_fn("wfid", history_id="h1")
+    assert result.success is True
+    assert "guide" in result.data
+    assert result.data["guide"]["provenance"]["version"] is None
+    strand = next(s for s in result.data["slots"] if s["label"] == "Strandedness")
+    assert strand["options"]

--- a/mcp-server-galaxy-py/tests/test_workflow_operations.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_operations.py
@@ -414,8 +414,9 @@ def test_resolve_slots_uses_style_run_when_ok():
         ]
     }
     gi.make_get_request.return_value = resp
-    slots, provenance = _resolve_workflow_slots(gi, "wfid")
+    slots, provenance, run_model = _resolve_workflow_slots(gi, "wfid")
     assert provenance == "style=run"
+    assert run_model is not None
     assert slots[0]["accepted_formats"] == ["tabular"]
     assert slots[0]["label"] == "barcodes"
 
@@ -437,8 +438,9 @@ def test_resolve_slots_falls_back_to_ga_on_missing_tools_500():
             }
         }
     }
-    slots, provenance = _resolve_workflow_slots(gi, "wfid")
+    slots, provenance, run_model = _resolve_workflow_slots(gi, "wfid")
     assert provenance == "ga-fallback"
+    assert run_model is None
     assert slots[0]["accepted_formats"] == ["tabular"]
 
 
@@ -619,3 +621,46 @@ def test_invoke_reject_resolves_slots_only_once(mock_galaxy_instance):
     assert len(download_calls) == 1, (
         f"Expected 1 'download' call (slot resolution), got {len(download_calls)}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Task 5: _resolve_workflow_slots returns the raw run model
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_slots_returns_run_model_on_style_run():
+    gi = Mock()
+    gi.url = "https://g/api"
+    resp = Mock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "has_upgrade_messages": False,
+        "steps": [
+            {
+                "step_type": "data_input",
+                "step_index": 0,
+                "step_label": "in",
+                "inputs": [{"extensions": ["tabular"], "optional": False}],
+            }
+        ],
+    }
+    gi.make_get_request.return_value = resp
+    slots, provenance, run_model = _resolve_workflow_slots(gi, "wfid")
+    assert provenance == "style=run"
+    assert run_model is not None
+    assert run_model["has_upgrade_messages"] is False
+
+
+def test_resolve_slots_run_model_none_on_ga_fallback():
+    gi = Mock()
+    gi.url = "https://g/api"
+    bad = Mock()
+    bad.status_code = 500
+    bad.text = "x"
+    gi.make_get_request.return_value = bad
+    gi.workflows.export_workflow_dict.return_value = {
+        "steps": {"0": {"type": "data_input", "label": "in", "tool_state": "{}"}}
+    }
+    slots, provenance, run_model = _resolve_workflow_slots(gi, "wfid")
+    assert provenance == "ga-fallback"
+    assert run_model is None

--- a/mcp-server-galaxy-py/tests/test_workflow_operations.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_operations.py
@@ -489,6 +489,12 @@ def test_get_workflow_input_template_tool(mock_galaxy_instance):
     }
     mock_galaxy_instance.make_get_request.return_value = run_resp
     mock_galaxy_instance.workflows.export_workflow_dict.return_value = {"steps": {}}
+    mock_galaxy_instance.workflows.show_workflow.return_value = {
+        "version": 1,
+        "annotation": "",
+        "readme": "",
+        "help": "",
+    }
     with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
         result = get_workflow_input_template_fn("wfid")
     assert result.success is True
@@ -664,3 +670,73 @@ def test_resolve_slots_run_model_none_on_ga_fallback():
     slots, provenance, run_model = _resolve_workflow_slots(gi, "wfid")
     assert provenance == "ga-fallback"
     assert run_model is None
+
+
+# ---------------------------------------------------------------------------
+# Task 6: get_workflow_input_template gains verbose, the guide, and options
+# ---------------------------------------------------------------------------
+
+
+def _wf_show():
+    return {
+        "version": 7,
+        "annotation": "RNA-seq PE",
+        "readme": "# RNA-Seq\n\nTrim, align, quantify. " * 30,
+        "help": "",
+        "source_metadata": {
+            "trs_tool_id": "#workflow/.../rnaseq-pe/main",
+            "trs_url": "https://dockstore/x",
+        },
+    }
+
+
+def _run_resp_with_param():
+    r = Mock()
+    r.status_code = 200
+    r.json.return_value = {
+        "has_upgrade_messages": False,
+        "step_version_changes": [],
+        "steps": [
+            {
+                "step_type": "parameter_input",
+                "step_index": 0,
+                "step_label": "Strandedness",
+                "inputs": [
+                    {
+                        "options": [
+                            ["stranded - forward", "stranded - forward", False],
+                            ["unstranded", "unstranded", False],
+                        ]
+                    }
+                ],
+            }
+        ],
+    }
+    return r
+
+
+def test_template_includes_guide_and_options(mock_galaxy_instance):
+    mock_galaxy_instance.url = "https://g/api"
+    mock_galaxy_instance.make_get_request.return_value = _run_resp_with_param()
+    mock_galaxy_instance.workflows.export_workflow_dict.return_value = {"steps": {}}
+    mock_galaxy_instance.workflows.show_workflow.return_value = _wf_show()
+    with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+        result = get_workflow_input_template_fn("wfid", history_id="h1")
+    assert result.success is True
+    g = result.data["guide"]
+    assert g["summary"]
+    assert len(g["summary"]) <= 300
+    assert g["provenance"]["source"]["trs_id"] == "#workflow/.../rnaseq-pe/main"
+    assert g["provenance"]["freshness"]["has_upgrade_messages"] is False
+    strand = next(s for s in result.data["slots"] if s["label"] == "Strandedness")
+    assert {o["value"] for o in strand["options"]} == {"stranded - forward", "unstranded"}
+
+
+def test_template_verbose_returns_full_readme(mock_galaxy_instance):
+    mock_galaxy_instance.url = "https://g/api"
+    mock_galaxy_instance.make_get_request.return_value = _run_resp_with_param()
+    mock_galaxy_instance.workflows.export_workflow_dict.return_value = {"steps": {}}
+    mock_galaxy_instance.workflows.show_workflow.return_value = _wf_show()
+    with patch.dict(galaxy_state, {"connected": True, "gi": mock_galaxy_instance}):
+        result = get_workflow_input_template_fn("wfid", history_id="h1", verbose=True)
+    assert len(result.data["guide"]["summary"]) > 300

--- a/mcp-server-galaxy-py/tests/test_workflow_operations.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_operations.py
@@ -630,7 +630,7 @@ def test_invoke_reject_resolves_slots_only_once(mock_galaxy_instance):
 
 
 # ---------------------------------------------------------------------------
-# Task 5: _resolve_workflow_slots returns the raw run model
+# Task 5 (run-guide): _resolve_workflow_slots returns the raw run model
 # ---------------------------------------------------------------------------
 
 
@@ -673,7 +673,7 @@ def test_resolve_slots_run_model_none_on_ga_fallback():
 
 
 # ---------------------------------------------------------------------------
-# Task 6: get_workflow_input_template gains verbose, the guide, and options
+# Task 6 (run-guide): get_workflow_input_template gains verbose, the guide, and options
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Follow-up to #55/#57. When an agent fetches a workflow's inputs it now also gets what it needs to actually *fill* them -- the human guidance and the valid parameter values -- without dumping the bloated run payload.

`get_workflow_input_template(workflow_id, history_id=None, verbose=False)` gains:
- **`guide`** -- a short summary (cleaned readme/help, or full on `verbose=True`) plus provenance (`version`, TRS source link, freshness flags), all from `show_workflow`.
- **per-parameter `options`** -- selectable values as `[{label, value}]`. For `style=run` these are Galaxy's resolved options, including the actual installed reference-genome dbkeys (which an agent otherwise has to guess, since a "Reference genome" param looks like free text). Enumerated params (strandedness, booleans) come through the same way; the `.ga` fallback supplies static restrictions only. Large option sets (genomes can be hundreds) are capped at 25 inline / 15 + `option_count` + a note by default, full on `verbose=True`.

Motivation came out of the galaxy-skills discussion (#24): per-workflow knowledge ("what genome / which params") was getting encoded as skills, which rot and bloat context. The better home is the workflow itself, fetched on demand -- which is most of what `show_workflow`/`style=run` already return; this just composes it into the pre-run call.

All existing fields (`inputs_template`, `slots`, `inputs_by`, `warnings`) are unchanged; the three new reads (run model, `.ga`, `show_workflow`) are each best-effort, so the tool still returns a usable template if any fails. Logic lives in the pure `workflow_inputs.py` (mirrors #55); `server.py` just wires it. 198 tests pass, mypy + ruff clean.
