### PR TITLE
Make authorization codes single-use (fixes replay)

### DIFF
--- a/mcp-server-galaxy-py/src/galaxy_mcp/auth.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/auth.py
@@ -166,6 +166,9 @@ class GalaxyOAuthProvider(OAuthProvider):
         self._galaxy_url = galaxy_url if galaxy_url.endswith("/") else f"{galaxy_url}/"
         self._transactions: dict[str, AuthorizationTransaction] = {}
         self._clients: dict[str, OAuthClientInformationFull] = {}
+        # Spent authorization codes (sha256 -> expiry) so a code can't be
+        # replayed within its TTL. Pruned on use; never grows past one lifetime.
+        self._spent_auth_codes: dict[str, float] = {}
         self._fernet = Fernet(self._derive_key(session_secret))
         self._client_registry_path = (
             Path(client_registry_path).expanduser() if client_registry_path else None
@@ -256,10 +259,32 @@ class GalaxyOAuthProvider(OAuthProvider):
         if client.client_id is None or payload["client_id"] != client.client_id:
             raise GalaxyAuthenticationError("Authorization code issued for a different client.")
 
+        self._consume_authorization_code(authorization_code.code, payload["exp"])
+
         galaxy_payload = payload["galaxy"]
         return self._issue_tokens(
             client_id=client.client_id, scopes=payload["scopes"], galaxy_payload=galaxy_payload
         )
+
+    def _consume_authorization_code(self, code: str, expires_at: float) -> None:
+        """Enforce single-use for authorization codes (RFC 6749 4.1.2 / 10.5).
+
+        Codes are stateless encrypted blobs, so single-use needs a little state:
+        a bounded set of spent code hashes kept only until each code would have
+        expired anyway. Pruning on every call keeps it from growing past the
+        codes seen within one auth-code lifetime. The check-then-insert is
+        synchronous, so it is atomic on the event loop -- two concurrent replays
+        of the same code can't both succeed.
+        """
+        now = time.time()
+        for spent, exp in list(self._spent_auth_codes.items()):
+            if exp <= now:
+                del self._spent_auth_codes[spent]
+
+        code_id = hashlib.sha256(code.encode("utf-8")).hexdigest()
+        if code_id in self._spent_auth_codes:
+            raise GalaxyAuthenticationError("Authorization code has already been used.")
+        self._spent_auth_codes[code_id] = expires_at
 
     @override
     async def load_refresh_token(

--- a/mcp-server-galaxy-py/tests/test_oauth_code_replay.py
+++ b/mcp-server-galaxy-py/tests/test_oauth_code_replay.py
@@ -1,0 +1,98 @@
+"""Regression tests: authorization codes must be single-use (RFC 6749 4.1.2 / 10.5).
+
+A code is a stateless encrypted blob, so without server-side bookkeeping it could
+be exchanged for tokens repeatedly until expiry. These tests pin the single-use
+behavior of `exchange_authorization_code`.
+"""
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from galaxy_mcp.auth import GalaxyAuthenticationError, GalaxyOAuthProvider
+
+REDIRECT_URI = "https://example.test/callback"
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def provider():
+    return GalaxyOAuthProvider(
+        base_url="https://mcp.test",
+        galaxy_url="https://galaxy.test/",
+        session_secret="unit-test-secret",
+        client_registry_path=None,
+    )
+
+
+def _code(provider, *, client_id="client-1", exp_offset=300):
+    return provider._encrypt_payload(
+        {
+            "typ": "authorization_code",
+            "client_id": client_id,
+            "scopes": ["galaxy:full"],
+            "exp": int(time.time()) + exp_offset,
+            "code_challenge": "test-challenge",
+            "code_challenge_method": "S256",
+            "redirect_uri": REDIRECT_URI,
+            "redirect_uri_provided_explicitly": True,
+            "galaxy": {
+                "url": "https://galaxy.test/",
+                "api_key": "k",
+                "username": "u",
+                "user_email": None,
+            },
+            "nonce": "test-nonce",
+        }
+    )
+
+
+def test_authorization_code_cannot_be_replayed(provider):
+    code = _code(provider)
+    client = SimpleNamespace(client_id="client-1")
+
+    # First exchange succeeds and issues a token.
+    tokens = _run(provider.exchange_authorization_code(client, SimpleNamespace(code=code)))
+    assert tokens.access_token
+
+    # Re-presenting the same code must be rejected, not re-issue tokens.
+    with pytest.raises(GalaxyAuthenticationError):
+        _run(provider.exchange_authorization_code(client, SimpleNamespace(code=code)))
+
+
+def test_distinct_codes_both_exchange(provider):
+    # The spent-code set must not produce false positives for different codes.
+    client = SimpleNamespace(client_id="client-1")
+    first = _run(
+        provider.exchange_authorization_code(client, SimpleNamespace(code=_code(provider)))
+    )
+    second = _run(
+        provider.exchange_authorization_code(client, SimpleNamespace(code=_code(provider)))
+    )
+    assert first.access_token
+    assert second.access_token
+
+
+def test_expired_spent_entries_are_pruned(provider):
+    # An already-expired code is rejected on the expiry check before it can be
+    # recorded, and stale spent entries don't accumulate: exchanging a fresh code
+    # leaves only its own hash behind.
+    expired = _code(provider, exp_offset=-10)
+    with pytest.raises(GalaxyAuthenticationError):
+        _run(
+            provider.exchange_authorization_code(
+                SimpleNamespace(client_id="client-1"), SimpleNamespace(code=expired)
+            )
+        )
+
+    _run(
+        provider.exchange_authorization_code(
+            SimpleNamespace(client_id="client-1"), SimpleNamespace(code=_code(provider))
+        )
+    )
+    assert len(provider._spent_auth_codes) == 1


### PR DESCRIPTION
Closes #68.

Authorization codes are stateless encrypted blobs and nothing tracked whether one had been spent, so the same code could be exchanged for tokens repeatedly within its 5-minute TTL. RFC 6749 §4.1.2 / §10.5 require codes to be single-use.

**Fix:** `exchange_authorization_code` now records a sha256 of each spent code (with its expiry) in a small in-memory set and rejects any code it has already seen, raising an error the MCP token handler maps to `invalid_grant`. The set is pruned on every call, so it never grows beyond the codes seen within one auth-code lifetime, and the check-then-insert is synchronous (atomic on the event loop -- two concurrent replays can't both win).

This keeps the provider's stateless-by-default posture: the state is in-memory, per-process, and bounded -- consistent with the existing model where tokens are already volatile when no session secret is set. It does **not** address the related no-op `revoke_token` (a separate limitation of the stateless design).

Tests: a new `test_oauth_code_replay.py` asserts a replayed code is rejected, distinct codes still both exchange (no false positives), and the spent set stays pruned. Full suite green (201 passed), mypy + ruff clean.