### PR TITLE
Run user-defined tools through POST /api/tools (restores 26.0 compatibility)

### DIFF
--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -3302,11 +3302,14 @@ def delete_user_tool(uuid: str) -> GalaxyResult:
 
 @mcp.tool(tags={"tools", "write", "extended"})
 def run_user_tool(history_id: str, tool_uuid: str, inputs: dict[str, Any]) -> GalaxyResult:
-    """Run a user-defined tool via the Galaxy jobs API.
+    """Run a user-defined tool via the standard Galaxy tools API.
 
-    User-defined tools cannot be run via the standard run_tool() endpoint.
-    This function uses POST /api/jobs with the tool UUID, matching how
-    the Galaxy UI submits user-defined tool jobs.
+    Submits the UDT with POST /api/tools carrying the tool UUID. This
+    synchronous endpoint runs user-defined tools on every Galaxy that
+    supports them and needs no Celery -- unlike the newer POST /api/jobs
+    tool-request path, which is Celery-only and 500s for UDTs on 26.0.
+    It returns the job and output dataset handles immediately; the job
+    then runs asynchronously on the cluster (poll it for state).
 
     Args:
         history_id: Galaxy history ID where outputs will be placed.
@@ -3342,16 +3345,17 @@ def run_user_tool(history_id: str, tool_uuid: str, inputs: dict[str, Any]) -> Ga
             raise ValueError(f"No user-defined tool found with UUID '{tool_uuid}'")
         tool_version = tool_info.get("representation", {}).get("version", "0.1.0")
 
+        # POST /api/tools resolves the UDT by uuid and runs it synchronously.
+        # tool_id and tool_uuid are mutually exclusive here -- send only the uuid.
         payload = {
-            "tool_id": tool_id,
+            "history_id": history_id,
             "tool_uuid": tool_uuid,
             "tool_version": tool_version,
-            "history_id": history_id,
             "inputs": inputs,
-            "use_cached_jobs": False,
+            "input_format": "legacy",
         }
-        job_url = f"{gi.url}/jobs"
-        result = gi.make_post_request(job_url, payload=payload)
+        tools_url = f"{gi.url}/tools"
+        result = gi.make_post_request(tools_url, payload=payload)
 
         return GalaxyResult(
             data=result,

--- a/mcp-server-galaxy-py/tests/test_helpers.py
+++ b/mcp-server-galaxy-py/tests/test_helpers.py
@@ -12,6 +12,8 @@ from galaxy_mcp.server import (
     cancel_workflow_invocation,
     connect,
     create_history,
+    create_user_tool,
+    delete_user_tool,
     download_dataset,
     ensure_connected,
     galaxy_state,
@@ -36,6 +38,7 @@ from galaxy_mcp.server import (
     import_workflow_from_iwc,
     invoke_workflow,
     list_history_ids,
+    list_user_tools,
     list_workflows,
     recommend_iwc_workflows,
     run_tool,
@@ -86,6 +89,9 @@ list_history_ids_fn = get_function(list_history_ids)
 list_workflows_fn = get_function(list_workflows)
 recommend_iwc_workflows_fn = get_function(recommend_iwc_workflows)
 run_tool_fn = get_function(run_tool)
+create_user_tool_fn = get_function(create_user_tool)
+delete_user_tool_fn = get_function(delete_user_tool)
+list_user_tools_fn = get_function(list_user_tools)
 run_user_tool_fn = get_function(run_user_tool)
 search_iwc_workflows_fn = get_function(search_iwc_workflows)
 search_tools_fn = get_function(search_tools_by_name)
@@ -126,6 +132,9 @@ __all__ = [
     "list_workflows_fn",
     "recommend_iwc_workflows_fn",
     "run_tool_fn",
+    "create_user_tool_fn",
+    "delete_user_tool_fn",
+    "list_user_tools_fn",
     "run_user_tool_fn",
     "search_iwc_workflows_fn",
     "search_tools_fn",

--- a/mcp-server-galaxy-py/tests/test_user_tool_operations.py
+++ b/mcp-server-galaxy-py/tests/test_user_tool_operations.py
@@ -1,0 +1,86 @@
+"""Tests for user-defined tool (UDT) operations."""
+
+from unittest.mock import patch
+
+import pytest
+
+from .test_helpers import galaxy_state, run_user_tool_fn
+
+
+class TestRunUserTool:
+    """run_user_tool submits UDTs via the portable synchronous tools endpoint."""
+
+    def _gi(self, mock_galaxy_instance):
+        gi = mock_galaxy_instance
+        gi.url = "http://localhost:8080/api"
+        gi.make_get_request.return_value.json.return_value = {
+            "tool_id": "my_udt_tool_id",
+            "representation": {"version": "1.2.3"},
+        }
+        gi.make_post_request.return_value = {
+            "outputs": [{"id": "out_1", "name": "result"}],
+            "jobs": [{"id": "job_1", "state": "new"}],
+        }
+        return gi
+
+    def test_run_user_tool_posts_to_tools_endpoint(self, mock_galaxy_instance):
+        """Submits via POST /api/tools with tool_uuid -- never the 26.0-broken /api/jobs path."""
+        gi = self._gi(mock_galaxy_instance)
+        uuid = "8a049c53-f4f2-4fdd-a9a6-a2560494e0ec"
+        inputs = {"msg": "hello"}
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": gi}):
+            result = run_user_tool_fn("hist_1", uuid, inputs)
+
+        assert result.success is True
+        gi.make_post_request.assert_called_once()
+        posted_url = gi.make_post_request.call_args.args[0]
+        posted_payload = gi.make_post_request.call_args.kwargs["payload"]
+
+        assert posted_url == "http://localhost:8080/api/tools"
+        assert "/jobs" not in posted_url
+        assert posted_payload["tool_uuid"] == uuid
+        # tool_id and tool_uuid are mutually exclusive on /api/tools; send only the uuid
+        assert "tool_id" not in posted_payload
+        assert posted_payload["history_id"] == "hist_1"
+        assert posted_payload["inputs"] == inputs
+        assert posted_payload["input_format"] == "legacy"
+        assert "use_cached_jobs" not in posted_payload
+
+    def test_run_user_tool_resolves_version_from_unprivileged_tools(self, mock_galaxy_instance):
+        """tool_version is resolved from the UDT record and forwarded in the submission."""
+        gi = self._gi(mock_galaxy_instance)
+        uuid = "abc"
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": gi}):
+            run_user_tool_fn("hist_1", uuid, {})
+
+        gi.make_get_request.assert_called_once_with(
+            "http://localhost:8080/api/unprivileged_tools/abc"
+        )
+        assert gi.make_post_request.call_args.kwargs["payload"]["tool_version"] == "1.2.3"
+
+    def test_run_user_tool_missing_tool_raises(self, mock_galaxy_instance):
+        """A UUID with no resolvable tool yields a clear error, no submission attempted."""
+        gi = self._gi(mock_galaxy_instance)
+        gi.make_get_request.return_value.json.return_value = {}
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": gi}):
+            with pytest.raises(ValueError, match="Run user tool failed"):
+                run_user_tool_fn("hist_1", "missing", {})
+        gi.make_post_request.assert_not_called()
+
+    def test_run_user_tool_error(self, mock_galaxy_instance):
+        """Submission failures are surfaced as a Run user tool error."""
+        gi = self._gi(mock_galaxy_instance)
+        gi.make_post_request.side_effect = Exception("boom")
+
+        with patch.dict(galaxy_state, {"connected": True, "gi": gi}):
+            with pytest.raises(ValueError, match="Run user tool failed"):
+                run_user_tool_fn("hist_1", "abc", {})
+
+    def test_run_user_tool_not_connected(self):
+        """Fails fast when not connected."""
+        with patch.dict(galaxy_state, {"connected": False}):
+            with pytest.raises(Exception):
+                run_user_tool_fn("hist_1", "abc", {})


### PR DESCRIPTION
`run_user_tool` submitted UDTs via the typed `POST /api/jobs` tool-request endpoint. That path is **Celery-only** (`enable_celery_tasks` is off by default on self-hosted Galaxy) and **500s for UDTs on Galaxy 26.0** (the `ToolSource tool_dir=None` bug) -- so running a user-defined tool failed outright on 26.0 and on any server without a Celery worker.

This switches `run_user_tool` to the synchronous **`POST /api/tools`** path carrying the `tool_uuid` (drops the mutually-exclusive `tool_id`, sends `input_format: "legacy"`). That's the endpoint Galaxy core itself treats as the UDT execution path -- `tools_service._create` resolves `tool_uuid` via `get_unprivileged_tool_or_none` -- so it runs user tools on **any Galaxy that supports them**, needs no Celery, and returns job + output dataset handles immediately (the job then runs asynchronously on the cluster). It also lines UDT execution up with how normal `run_tool` already submits.

This is deliberately the **compatible endpoint for all UDT runs**, not a per-server feature-detected choice between `/api/tools` and `/api/jobs`.

**Effect:** restores UDT execution on 26.0 (and Celery-off servers); unchanged on 26.1.

**Verification:**
- End-to-end on test.galaxyproject.org (26.1) -- a real UDT job runs to `ok`.
- New `test_user_tool_operations.py` asserts the submission targets `/api/tools` with `tool_uuid` (not `tool_id`), `input_format: "legacy"`, version resolved from `/unprivileged_tools/{uuid}`, plus the missing-tool / submission-error / not-connected paths.
- Full suite green, mypy + ruff clean.
- **Not yet run e2e against a 26.0 server** -- the 26.0 fix is inferred from `/api/tools` + `tool_uuid` resolution being present and stable there.

Draft until the 26.0 e2e confirmation is done (or we agree the 26.1 verification + inference is enough).
