### PR TITLE
Harden the release skill: macOS awk bug, draft handling, deploy-run race

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -47,9 +47,11 @@ Abort cleanly on any failure, with a specific message.
 
 ```bash
 gh auth status
-# Canonical remote = whichever remote pushes to galaxyproject/galaxy-mcp (don't assume "upstream"):
-CANON=$(git remote -v | awk '$3=="(push)" && $2 ~ /[:/]galaxyproject\/galaxy-mcp(\.git)?$/ {print $1; exit}')
-test -n "$CANON"
+# Canonical remote = whichever remote pushes to galaxyproject/galaxy-mcp (don't assume "upstream").
+# Use grep, NOT awk: a `[:/]` bracket in awk is read as a POSIX class on macOS/BSD awk and aborts
+# with "nonterminated character class", leaving CANON empty and cascading into `/main` errors later.
+CANON=$(git remote -v | grep '(push)' | grep -E 'galaxyproject/galaxy-mcp(\.git)? ' | head -1 | awk '{print $1}')
+test -n "$CANON" || { echo "ERROR: no remote points at galaxyproject/galaxy-mcp -- add one and retry"; exit 1; }
 git fetch "$CANON" --tags
 # main must be green before releasing:
 gh run list --repo galaxyproject/galaxy-mcp --branch main --workflow "Python Tests" -L 1 \
@@ -120,30 +122,51 @@ git push "$CANON" HEAD:main
 
 ## Phase 4 -- Curated release body
 
-Write the approved notes to a file. The stale release-drafter draft is tagged wrong
-(e.g. `v1.6.1`); the simplest reliable path is to delete it and create the real release
-fresh in Gate 2.
+Write the approved notes to a file and look up the draft tag **fresh**. Don't delete the
+draft and don't hard-code its tag: release-drafter recomputes the *same* draft object on
+every push to main, so its tag drifts between when you start the cut and when you publish
+(seen live: a `v1.7.1` draft was renamed to `v1.8.1` mid-cut). At Gate 2 we retag and
+publish that existing draft in place -- no delete, which also sidesteps a permission
+classifier that (rightly) won't auto-approve deleting a release the agent didn't create.
 
 ```bash
 printf '%s\n' "$APPROVED_NOTES" > /tmp/gmcp-notes.md
-gh release delete <draft-tag> --repo galaxyproject/galaxy-mcp --yes   # remove the mislabeled draft (no real tag exists yet)
+# Resolve the draft tag now, by lookup -- never a literal like v1.7.1 (it moves):
+DRAFT_TAG=$(gh release list --repo galaxyproject/galaxy-mcp \
+  --json tagName,isDraft -q '[.[]|select(.isDraft)][0].tagName')   # may be empty if no draft exists
 ```
 
 ## Phase 5 -- GATE 2: publish release -> PyPI  (STOP)
 
 ⛔ **Hard stop.** Publishing fires `python-release.yml`, which **uploads
 `galaxy-mcp $NEW` to PyPI -- this cannot be undone.** Main must already carry `$NEW`
-(Gate 1). Wait for an explicit "go". On go:
+(Gate 1). Wait for an explicit "go". The "go" authorizes a single publish action -- one
+command, no bundled delete (a bundled `delete && create` gets the whole line denied). On go:
 
 ```bash
-gh release create "v$NEW" --repo galaxyproject/galaxy-mcp \
-  --target main --title "v$NEW" --notes-file /tmp/gmcp-notes.md   # creates tag v$NEW at main HEAD, fires deploy
+if [ -n "$DRAFT_TAG" ]; then
+  # Retag the existing draft to v$NEW and publish it in place -- applies our curated notes,
+  # creates tag v$NEW at main, fires the deploy. No delete needed; the draft tag's drift is moot.
+  gh release edit "$DRAFT_TAG" --repo galaxyproject/galaxy-mcp \
+    --tag "v$NEW" --target main --title "v$NEW" --notes-file /tmp/gmcp-notes.md --draft=false
+else
+  # No draft existed -- create the release fresh.
+  gh release create "v$NEW" --repo galaxyproject/galaxy-mcp \
+    --target main --title "v$NEW" --notes-file /tmp/gmcp-notes.md
+fi
 ```
 
-Watch the deploy; STOP and report if it fails:
+Watch the deploy; STOP and report if it fails. The run may not exist the instant publish
+returns, so poll briefly for it rather than a single racy lookup:
 
 ```bash
-RUN=$(gh run list --repo galaxyproject/galaxy-mcp --workflow "Release Python Package" -L 1 --json databaseId -q '.[0].databaseId')
+for i in $(seq 1 10); do
+  RUN=$(gh run list --repo galaxyproject/galaxy-mcp --workflow "Release Python Package" \
+    --event release -L 1 --json databaseId -q '.[0].databaseId')
+  [ -n "$RUN" ] && break
+  sleep 3
+done
+test -n "$RUN" || { echo "deploy run not found yet -- check the Actions tab"; exit 1; }
 gh run watch --repo galaxyproject/galaxy-mcp "$RUN" --exit-status
 # Confirm it actually landed on PyPI:
 curl -s https://pypi.org/pypi/galaxy-mcp/json | python3 -c "import sys,json;print(json.load(sys.stdin)['info']['version'])"   # expect $NEW
@@ -178,6 +201,7 @@ Clean up (from the primary checkout): `git worktree remove ../gmcp-release && gi
 - About to push the bump or publish the release without an explicit "go" this turn -> STOP, show, wait.
 - About to push to your fork (`origin`) instead of `$CANON` (galaxyproject) -> wrong remote.
 - Took release-drafter's patch version (e.g. `v1.6.1`) when `main` says `1.7.0.dev0` -> use the `.dev0` marker; the draft mislabeled it.
+- Hard-coded the draft tag (e.g. `v1.7.1`) or bundled `delete && create` for the publish -> the tag drifts and a bundled delete gets the whole line denied. Look the draft tag up fresh and retag-publish in place.
 - `sed`-ed the version in `uv.lock` -> it also rewrote other deps pinned at that version. Use `uv lock`.
 - Cutting in the primary checkout (maybe a feature branch) instead of a worktree off `$CANON/main`.
 - Deploy failed but moving on -> never assume PyPI got it; verify via the PyPI JSON.
@@ -188,6 +212,7 @@ Clean up (from the primary checkout): `git worktree remove ../gmcp-release && gi
 | Mistake | Fix |
 |---|---|
 | Wrong version (drafter's patch) | Drop `.dev0` from `main`'s version; that's the intent |
+| Hard-coded / deleted the drafter draft | Look up the draft tag fresh; retag-publish it in place (`gh release edit --draft=false`) |
 | `sed` on `uv.lock` | `uv lock` regenerates only the self-version line |
 | Forgot `__init__.py` / `uv.lock` | Bump all three version files together |
 | Pushed to the fork | Push to `$CANON` (galaxyproject/galaxy-mcp) |

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -122,18 +122,17 @@ git push "$CANON" HEAD:main
 
 ## Phase 4 -- Curated release body
 
-Write the approved notes to a file and look up the draft tag **fresh**. Don't delete the
-draft and don't hard-code its tag: release-drafter recomputes the *same* draft object on
-every push to main, so its tag drifts between when you start the cut and when you publish
-(seen live: a `v1.7.1` draft was renamed to `v1.8.1` mid-cut). At Gate 2 we retag and
-publish that existing draft in place -- no delete, which also sidesteps a permission
-classifier that (rightly) won't auto-approve deleting a release the agent didn't create.
+Write the approved notes to a file. Don't delete the release-drafter draft and don't
+hard-code its tag: release-drafter recomputes the *same* draft object on every push to
+main, so its tag drifts between when you start the cut and when you publish (seen live: a
+`v1.7.1` draft was renamed to `v1.8.1` mid-cut). At Gate 2 -- in the same shell as the
+publish, so it can't go stale across the stop -- we resolve the draft tag fresh, then
+retag and publish that existing draft in place. No delete, which also sidesteps a
+permission classifier that (rightly) won't auto-approve deleting a release the agent
+didn't create.
 
 ```bash
-printf '%s\n' "$APPROVED_NOTES" > /tmp/gmcp-notes.md
-# Resolve the draft tag now, by lookup -- never a literal like v1.7.1 (it moves):
-DRAFT_TAG=$(gh release list --repo galaxyproject/galaxy-mcp \
-  --json tagName,isDraft -q '[.[]|select(.isDraft)][0].tagName')   # may be empty if no draft exists
+printf '%s\n' "$APPROVED_NOTES" > /tmp/gmcp-notes.md   # the notes FILE persists across the Gate 2 stop; the draft tag is resolved fresh at the gate (below)
 ```
 
 ## Phase 5 -- GATE 2: publish release -> PyPI  (STOP)
@@ -144,9 +143,13 @@ DRAFT_TAG=$(gh release list --repo galaxyproject/galaxy-mcp \
 command, no bundled delete (a bundled `delete && create` gets the whole line denied). On go:
 
 ```bash
+# Resolve the draft tag fresh HERE -- same shell as the publish, so drift across the gate
+# can't bite and the var is guaranteed set. Never a literal like v1.7.1. Empty if no draft.
+DRAFT_TAG=$(gh release list --repo galaxyproject/galaxy-mcp \
+  --json tagName,isDraft -q '[.[]|select(.isDraft)][0].tagName')
 if [ -n "$DRAFT_TAG" ]; then
   # Retag the existing draft to v$NEW and publish it in place -- applies our curated notes,
-  # creates tag v$NEW at main, fires the deploy. No delete needed; the draft tag's drift is moot.
+  # creates tag v$NEW at main, fires the deploy. No delete needed.
   gh release edit "$DRAFT_TAG" --repo galaxyproject/galaxy-mcp \
     --tag "v$NEW" --target main --title "v$NEW" --notes-file /tmp/gmcp-notes.md --draft=false
 else
@@ -157,12 +160,15 @@ fi
 ```
 
 Watch the deploy; STOP and report if it fails. The run may not exist the instant publish
-returns, so poll briefly for it rather than a single racy lookup:
+returns, so poll for it -- **filtered to this release's tag** (`--branch "v$NEW"`). Without
+that filter a bare `-L 1` returns the *previous* release's already-green run instantly, the
+loop breaks on iteration 1, and you'd watch the wrong (passing) run while the real deploy is
+still building:
 
 ```bash
 for i in $(seq 1 10); do
   RUN=$(gh run list --repo galaxyproject/galaxy-mcp --workflow "Release Python Package" \
-    --event release -L 1 --json databaseId -q '.[0].databaseId')
+    --event release --branch "v$NEW" -L 1 --json databaseId -q '.[0].databaseId')
   [ -n "$RUN" ] && break
   sleep 3
 done


### PR DESCRIPTION
Three fixes to `.claude/skills/release/SKILL.md`, all surfaced while cutting v1.8.0:

- **Phase 0 CANON detection broke on macOS.** The `awk '... $2 ~ /[:/]galaxyproject.../'` snippet uses a `[:/]` bracket that BSD/macOS awk reads as a POSIX character class, so it aborts with "nonterminated character class" and leaves `CANON` empty -- which then cascades into `git worktree add ... /main` -> "invalid reference: /main" several lines later. Replaced with a grep pipeline that works on macOS and Linux, plus a loud guard so an empty CANON aborts immediately instead of cascading.

- **Draft handling was fragile.** The skill said to delete the release-drafter draft and create the release fresh. Two problems: release-drafter recomputes the *same* draft object on every push to main, so the tag drifts mid-cut (a `v1.7.1` draft became `v1.8.1` between starting and publishing), and a bundled `delete && create` gets denied wholesale by the agent permission classifier. Now we look the draft tag up fresh (never hard-coded) and retag-publish it in place with `gh release edit --tag v$NEW --draft=false`, falling back to `gh release create` only if no draft exists. One un-bundled, gated publish action, no delete.

- **Phase 5 could race the deploy run.** The `gh run list ... -L 1` lookup ran immediately after publishing, before the run necessarily existed. It now polls briefly (and filters `--event release`) before watching.

No change to what actually gets released -- just removes the manual workarounds these steps needed during the 1.8.0 cut.