### PR TITLE
Accept JSON-string inputs/params in invoke_workflow

### DIFF
--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -3036,6 +3036,35 @@ def _enrich_supplied_inputs(gi: GalaxyInstance, inputs: dict[str, Any]) -> dict[
     return enriched
 
 
+def _coerce_optional_json_dict(
+    value: dict[str, Any] | str | None, name: str
+) -> dict[str, Any] | None:
+    """Coerce an optional dict argument that may arrive as a JSON string.
+
+    Agents and some MCP clients pass nested arguments as a JSON string rather
+    than a real object. Accept that at the call boundary so downstream code sees
+    a dict: a blank string becomes None, a JSON object becomes a dict, and
+    anything else (invalid JSON, or JSON that isn't an object) raises a clear,
+    field-named error instead of failing obscurely deeper in.
+    """
+    if value is None or isinstance(value, dict):
+        return value
+    if not value.strip():
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as e:
+        raise ValueError(
+            f"{name} must be a JSON object string or a dict, but got invalid JSON: {e}"
+        ) from e
+    if not isinstance(parsed, dict):
+        raise ValueError(
+            f"{name} must be a JSON object (a mapping), but the string parsed to "
+            f"{type(parsed).__name__}."
+        )
+    return parsed
+
+
 @mcp.tool(tags={"workflows", "write", "extended"})
 def invoke_workflow(
     workflow_id: str,
@@ -3069,11 +3098,12 @@ def invoke_workflow(
     """
     state = ensure_connected()
 
+    inputs = _coerce_optional_json_dict(inputs, "inputs")
+    params = _coerce_optional_json_dict(params, "params")
+
     try:
         gi: GalaxyInstance = state["gi"]
 
-        inputs = json.loads(inputs) if isinstance(inputs, str) else inputs
-        params = json.loads(params) if isinstance(params, str) else params
         # Preflight: validate supplied inputs against the workflow's slots.
         if inputs:
             try:

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -3039,8 +3039,8 @@ def _enrich_supplied_inputs(gi: GalaxyInstance, inputs: dict[str, Any]) -> dict[
 @mcp.tool(tags={"workflows", "write", "extended"})
 def invoke_workflow(
     workflow_id: str,
-    inputs: dict[str, Any] | None = None,
-    params: dict[str, Any] | None = None,
+    inputs: dict[str, Any] | str | None = None,
+    params: dict[str, Any] | str | None = None,
     history_id: str | None = None,
     history_name: str | None = None,
     inputs_by: str = "step_index",

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -3072,6 +3072,8 @@ def invoke_workflow(
     try:
         gi: GalaxyInstance = state["gi"]
 
+        inputs = json.loads(inputs) if isinstance(inputs, str) else inputs
+        params = json.loads(params) if isinstance(params, str) else params
         # Preflight: validate supplied inputs against the workflow's slots.
         if inputs:
             try:

--- a/mcp-server-galaxy-py/tests/test_workflow_operations.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_operations.py
@@ -8,6 +8,7 @@ import pytest
 
 from galaxy_mcp.server import (
     _DATATYPES_MAPPING_CACHE,
+    _coerce_optional_json_dict,
     _get_datatypes_mapping,
     _resolve_workflow_slots,
     galaxy_state,
@@ -756,3 +757,30 @@ def test_template_returns_when_show_workflow_fails(mock_galaxy_instance):
     assert result.data["guide"]["provenance"]["version"] is None
     strand = next(s for s in result.data["slots"] if s["label"] == "Strandedness")
     assert strand["options"]
+
+
+class TestCoerceOptionalJsonDict:
+    """invoke_workflow accepts JSON-string inputs/params; coercion guards the edges."""
+
+    def test_json_object_string_becomes_dict(self):
+        assert _coerce_optional_json_dict('{"0": {"id": "abc", "src": "hda"}}', "inputs") == {
+            "0": {"id": "abc", "src": "hda"}
+        }
+
+    def test_dict_passes_through_unchanged(self):
+        d = {"0": {"id": "abc", "src": "hda"}}
+        assert _coerce_optional_json_dict(d, "inputs") is d
+
+    def test_none_and_blank_become_none(self):
+        assert _coerce_optional_json_dict(None, "inputs") is None
+        assert _coerce_optional_json_dict("", "params") is None
+        assert _coerce_optional_json_dict("   ", "params") is None
+
+    def test_non_dict_json_raises_named_error(self):
+        for bad in ("[]", "true", "123"):
+            with pytest.raises(ValueError, match="params must be a JSON object"):
+                _coerce_optional_json_dict(bad, "params")
+
+    def test_invalid_json_raises_named_error(self):
+        with pytest.raises(ValueError, match="inputs must be a JSON object"):
+            _coerce_optional_json_dict("{not valid json", "inputs")


### PR DESCRIPTION
## Description
`invoke_workflow` declares `inputs` and `params` as `dict | None`. For that union, FastMCP omits `"type": "object"` from the tool's JSON schema, so MCP clients that serialize arguments from the schema type send these as JSON **strings**, and the server rejects them with a pydantic `dict_type` error. `run_tool` (typed `inputs: dict`) emits `"type": "object"` and is unaffected.

This coerces a JSON-string `inputs`/`params` into a dict at the start of `invoke_workflow`, so both a real dict and a JSON string are accepted. Backward compatible: an existing dict passes through unchanged.

Fixes #72.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
## Testing
Verified manually: invoking a workflow with `inputs` passed as a JSON string now parses and submits the invocation; passing a dict behaves exactly as before. Happy to add a unit test for the coercion if you'd prefer one.