### PR TITLE
Add Galaxy Pages (notebook/report) tools

### DIFF
--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -411,6 +411,14 @@ vetted Interactive Workflow Composer (IWC) workflow, then
 
 User-defined tools (created via `create_user_tool`) are run with
 `run_user_tool`, not `run_tool` -- they use a different Galaxy endpoint.
+
+Pages are Galaxy-flavored markdown documents: a history-attached page is a
+"Notebook", a standalone page a "Report". Manage them with `list_pages`,
+`get_page`, `create_page`, and `update_page`; inspect edit history via
+`list_page_revisions` / `get_page_revision` / `revert_page_revision`. Page
+content embeds datasets through directives that use ENCODED ids (e.g.
+`history_dataset_display(history_dataset_id=f2db41e1fa331b3e)`), which you get
+from `get_history_contents` / `get_dataset_details`.
 """
 
 _CODE_MODE_INSTRUCTIONS = """\

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -3379,6 +3379,399 @@ def run_user_tool(history_id: str, tool_uuid: str, inputs: dict[str, Any]) -> Ga
         ) from e
 
 
+# ==================== Pages (notebooks and reports) ====================
+#
+# A Galaxy "Page" is the notebook/report. A page attached to a history is a
+# "Notebook"; a standalone page is a "Report". Content is Galaxy-flavored
+# markdown with directives referencing ENCODED ids (e.g.
+# history_dataset_display(history_dataset_id=f2db41e1fa331b3e)). bioblend hands
+# back encoded ids already, so -- unlike the in-Galaxy MCP -- there is no
+# encode/decode dance: content_editor is read, edited, and POSTed back as-is.
+
+
+def _pages_connection() -> tuple[str, str]:
+    """Return (base_url, api_key) for direct REST calls to Galaxy's /api/pages*.
+
+    bioblend exposes no Pages API, so the page tools call the REST layer
+    directly -- the same approach get_job_details uses. Talking to requests
+    (rather than a bioblend helper) also lets list_pages read the total_matches
+    response header.
+    """
+    state = ensure_connected()
+    base_url = state["url"] or normalized_galaxy_url or ""
+    api_key = state["api_key"]
+    if not base_url or not api_key:
+        raise ValueError("Galaxy connection is missing URL or API key information.")
+    return base_url, api_key
+
+
+def _strip_rendered(page: dict[str, Any], include_rendered: bool) -> dict[str, Any]:
+    """Drop the large expanded-render ``content``, keeping editable ``content_editor``.
+
+    Mirrors the in-Galaxy MCP behavior: callers edit and POST back
+    content_editor; the rendered content is only worth its size when explicitly
+    requested.
+    """
+    if not include_rendered:
+        page.pop("content", None)
+    return page
+
+
+@mcp.tool(tags={"pages", "read", "extended"})
+def list_pages(
+    history_id: str | None = None,
+    search: str | None = None,
+    limit: int = 100,
+    offset: int = 0,
+    show_published: bool = False,
+    show_shared: bool = False,
+) -> GalaxyResult:
+    """List Galaxy pages (markdown documents) viewable by the user.
+
+    A page attached to a history is a "Galaxy Notebook"; a standalone page is
+    a "Report". Pass history_id to list only that history's notebooks.
+
+    Args:
+        history_id: Encoded history id. When set, returns only notebooks
+            attached to that history.
+        search: Freetext filter over title/content.
+        limit: Max pages to return (default 100).
+        offset: Pagination offset.
+        show_published: Also include pages published by other users (default False).
+        show_shared: Also include pages shared with the user (default False).
+
+    Returns:
+        GalaxyResult with the page summaries (encoded id, title, history_id,
+        latest_revision_id) in data, count, and pagination whose total_items is
+        the server's total_matches.
+
+    NEXT STEPS:
+    - Read one: get_page(page_id)
+    - Create a notebook: create_page(history_id=...)
+    """
+    base_url, api_key = _pages_connection()
+
+    try:
+        # REST index defaults (show_own and show_published both True) are wrong
+        # for an agent, so set every visibility flag explicitly.
+        params: dict[str, Any] = {
+            "limit": limit,
+            "offset": offset,
+            "show_own": "true",
+            "show_published": str(show_published).lower(),
+            "show_shared": str(show_shared).lower(),
+        }
+        if history_id is not None:
+            params["history_id"] = history_id
+        if search is not None:
+            params["search"] = search
+
+        response = requests.get(
+            f"{base_url}api/pages", headers={"x-api-key": api_key}, params=params, timeout=30
+        )
+        response.raise_for_status()
+        pages = response.json()
+        # total_matches is a response header, not part of the JSON body.
+        total_matches = int(response.headers.get("total_matches", len(pages)))
+
+        has_next = (offset + len(pages)) < total_matches
+        has_previous = offset > 0
+        pagination = PaginationInfo(
+            total_items=total_matches,
+            returned_items=len(pages),
+            limit=limit,
+            offset=offset,
+            has_next=has_next,
+            has_previous=has_previous,
+            next_offset=offset + limit if has_next else None,
+            previous_offset=max(0, offset - limit) if has_previous else None,
+        )
+
+        return GalaxyResult(
+            data=pages,
+            count=len(pages),
+            pagination=pagination,
+            success=True,
+            message=f"Retrieved {len(pages)} pages",
+        )
+    except Exception as e:
+        raise ValueError(format_error("List pages", e, {"history_id": history_id})) from e
+
+
+@mcp.tool(tags={"pages", "read", "extended"})
+def get_page(page_id: str, include_rendered: bool = False) -> GalaxyResult:
+    """Get a page and the content of its latest revision.
+
+    Returns `content_editor`: the editable Galaxy-flavored markdown, with
+    ENCODED ids in directives (e.g. `history_dataset_id=f2db41e1fa331b3e`).
+    This is the form to edit and pass back to update_page.
+
+    Args:
+        page_id: Encoded id of the page (from list_pages / create_page).
+        include_rendered: When True, also return `content` -- the
+            embed-expanded render form (inlined dataset previews). Can be
+            large; omit unless you need the rendered output.
+
+    Returns:
+        GalaxyResult with page details including `content_editor`, metadata, and
+        `edit_source` of the latest revision in data.
+
+    NEXT STEPS:
+    - Edit it: update_page(page_id, content=...)
+    - See history: list_page_revisions(page_id)
+    """
+    base_url, api_key = _pages_connection()
+
+    try:
+        response = requests.get(
+            f"{base_url}api/pages/{page_id}", headers={"x-api-key": api_key}, timeout=30
+        )
+        response.raise_for_status()
+        page = _strip_rendered(response.json(), include_rendered)
+        return GalaxyResult(
+            data=page,
+            success=True,
+            message=f"Retrieved page '{page_id}'",
+        )
+    except Exception as e:
+        raise ValueError(format_error("Get page", e, {"page_id": page_id})) from e
+
+
+@mcp.tool(tags={"pages", "write", "extended"})
+def create_page(
+    history_id: str | None = None,
+    title: str | None = None,
+    content: str | None = None,
+    annotation: str | None = None,
+    slug: str | None = None,
+) -> GalaxyResult:
+    """Create a markdown page (Galaxy Notebook or Report).
+
+    Pass history_id to create a history-attached notebook (title auto-fills
+    from the history if omitted). Omit history_id to create a standalone
+    report -- reports REQUIRE both a title and a unique slug
+    (lowercase/digits/hyphens).
+
+    Content is Galaxy-flavored markdown. To embed a dataset, use a directive
+    with the ENCODED dataset id, e.g.
+    `history_dataset_display(history_dataset_id=f2db41e1fa331b3e)` or
+    `history_dataset_collection_display(history_dataset_collection_id=...)`.
+    Get encoded ids from get_history_contents / get_dataset_details.
+
+    Args:
+        history_id: Encoded history id to attach the page to (notebook).
+        title: Page title.
+        content: Initial markdown content.
+        annotation: Optional annotation attached to the page.
+        slug: URL slug (required for standalone reports).
+
+    Returns:
+        GalaxyResult with the created page details including encoded id and
+        content_editor in data.
+
+    NEXT STEPS:
+    - Edit it: update_page(page_id, content=...)
+    """
+    base_url, api_key = _pages_connection()
+
+    try:
+        # REST defaults content_format to html; the page tools speak markdown.
+        payload: dict[str, Any] = {"content_format": "markdown"}
+        if history_id is not None:
+            payload["history_id"] = history_id
+        if title is not None:
+            payload["title"] = title
+        if content is not None:
+            payload["content"] = content
+        if annotation is not None:
+            payload["annotation"] = annotation
+        if slug is not None:
+            payload["slug"] = slug
+
+        response = requests.post(
+            f"{base_url}api/pages", headers={"x-api-key": api_key}, json=payload, timeout=30
+        )
+        response.raise_for_status()
+        page = _strip_rendered(response.json(), include_rendered=False)
+        return GalaxyResult(
+            data=page,
+            success=True,
+            message=f"Created page '{page.get('id', '')}'",
+        )
+    except Exception as e:
+        raise ValueError(format_error("Create page", e, {"history_id": history_id})) from e
+
+
+@mcp.tool(tags={"pages", "write", "extended"})
+def update_page(
+    page_id: str,
+    content: str | None = None,
+    title: str | None = None,
+) -> GalaxyResult:
+    """Update a page, creating a new revision when content changes.
+
+    Content is Galaxy-flavored markdown using ENCODED ids in directives
+    (e.g. `history_dataset_id=f2db41e1fa331b3e`) -- never raw integer ids or
+    HIDs. Get encoded ids from get_history_contents / get_dataset_details.
+    Edits made through this tool are recorded with edit_source="agent".
+
+    Args:
+        page_id: Encoded id of the page.
+        content: New markdown content. Omit to leave content unchanged.
+        title: New title. Omit to leave unchanged.
+
+    Returns:
+        GalaxyResult with the updated page details including content_editor in data.
+
+    NEXT STEPS:
+    - Inspect revisions: list_page_revisions(page_id)
+    - Roll back: revert_page_revision(page_id, revision_id)
+    """
+    base_url, api_key = _pages_connection()
+
+    try:
+        # edit_source attributes the revision to the agent, not a human user.
+        payload: dict[str, Any] = {"edit_source": "agent"}
+        if content is not None:
+            payload["content"] = content
+        if title is not None:
+            payload["title"] = title
+
+        response = requests.put(
+            f"{base_url}api/pages/{page_id}",
+            headers={"x-api-key": api_key},
+            json=payload,
+            timeout=30,
+        )
+        response.raise_for_status()
+        page = _strip_rendered(response.json(), include_rendered=False)
+        return GalaxyResult(
+            data=page,
+            success=True,
+            message=f"Updated page '{page_id}'",
+        )
+    except Exception as e:
+        raise ValueError(format_error("Update page", e, {"page_id": page_id})) from e
+
+
+@mcp.tool(tags={"pages", "read", "extended"})
+def list_page_revisions(page_id: str, sort_desc: bool = False) -> GalaxyResult:
+    """List the revision history of a page.
+
+    Each revision carries an `edit_source` ("user", "agent", or "restore")
+    recording who made the edit.
+
+    Args:
+        page_id: Encoded id of the page.
+        sort_desc: Newest-first when True (default oldest-first).
+
+    Returns:
+        GalaxyResult with the revisions (encoded id, page_id, edit_source,
+        timestamps) in data and count.
+
+    NEXT STEPS:
+    - Read a revision: get_page_revision(page_id, revision_id)
+    - Roll back: revert_page_revision(page_id, revision_id)
+    """
+    base_url, api_key = _pages_connection()
+
+    try:
+        response = requests.get(
+            f"{base_url}api/pages/{page_id}/revisions",
+            headers={"x-api-key": api_key},
+            params={"sort_desc": str(sort_desc).lower()},
+            timeout=30,
+        )
+        response.raise_for_status()
+        revisions = response.json()
+        return GalaxyResult(
+            data=revisions,
+            count=len(revisions),
+            success=True,
+            message=f"Retrieved {len(revisions)} revisions for page '{page_id}'",
+        )
+    except Exception as e:
+        raise ValueError(format_error("List page revisions", e, {"page_id": page_id})) from e
+
+
+@mcp.tool(tags={"pages", "read", "extended"})
+def get_page_revision(
+    page_id: str, revision_id: str, include_rendered: bool = False
+) -> GalaxyResult:
+    """Get the content of a single page revision.
+
+    Mirrors get_page: returns `content_editor` (the editable Galaxy-flavored
+    markdown with ENCODED ids in directives) -- the form to compare against
+    get_page or pass back to update_page.
+
+    Args:
+        page_id: Encoded id of the page.
+        revision_id: Encoded id of the revision (from list_page_revisions).
+        include_rendered: When True, also return `content` -- the
+            embed-expanded render form. Can be large; omit unless needed.
+
+    Returns:
+        GalaxyResult with the revision details including `content_editor`,
+        `edit_source`, and timestamps in data.
+    """
+    base_url, api_key = _pages_connection()
+
+    try:
+        response = requests.get(
+            f"{base_url}api/pages/{page_id}/revisions/{revision_id}",
+            headers={"x-api-key": api_key},
+            timeout=30,
+        )
+        response.raise_for_status()
+        revision = _strip_rendered(response.json(), include_rendered)
+        return GalaxyResult(
+            data=revision,
+            success=True,
+            message=f"Retrieved revision '{revision_id}' of page '{page_id}'",
+        )
+    except Exception as e:
+        raise ValueError(
+            format_error("Get page revision", e, {"page_id": page_id, "revision_id": revision_id})
+        ) from e
+
+
+@mcp.tool(tags={"pages", "write", "extended"})
+def revert_page_revision(page_id: str, revision_id: str) -> GalaxyResult:
+    """Roll a page back to an earlier revision.
+
+    Creates a NEW revision from the target revision's content, recorded with
+    edit_source="restore" (the history is append-only -- nothing is deleted).
+
+    Args:
+        page_id: Encoded id of the page.
+        revision_id: Encoded id of the revision to restore.
+
+    Returns:
+        GalaxyResult with the new restored revision's details in data.
+    """
+    base_url, api_key = _pages_connection()
+
+    try:
+        response = requests.post(
+            f"{base_url}api/pages/{page_id}/revisions/{revision_id}/revert",
+            headers={"x-api-key": api_key},
+            timeout=30,
+        )
+        response.raise_for_status()
+        revision = _strip_rendered(response.json(), include_rendered=False)
+        return GalaxyResult(
+            data=revision,
+            success=True,
+            message=f"Reverted page '{page_id}' to revision '{revision_id}'",
+        )
+    except Exception as e:
+        raise ValueError(
+            format_error(
+                "Revert page revision", e, {"page_id": page_id, "revision_id": revision_id}
+            )
+        ) from e
+
+
 def run_http_server(
     *,
     host: str | None = None,

--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -3397,22 +3397,6 @@ def run_user_tool(history_id: str, tool_uuid: str, inputs: dict[str, Any]) -> Ga
 # encode/decode dance: content_editor is read, edited, and POSTed back as-is.
 
 
-def _pages_connection() -> tuple[str, str]:
-    """Return (base_url, api_key) for direct REST calls to Galaxy's /api/pages*.
-
-    bioblend exposes no Pages API, so the page tools call the REST layer
-    directly -- the same approach get_job_details uses. Talking to requests
-    (rather than a bioblend helper) also lets list_pages read the total_matches
-    response header.
-    """
-    state = ensure_connected()
-    base_url = state["url"] or normalized_galaxy_url or ""
-    api_key = state["api_key"]
-    if not base_url or not api_key:
-        raise ValueError("Galaxy connection is missing URL or API key information.")
-    return base_url, api_key
-
-
 def _strip_rendered(page: dict[str, Any], include_rendered: bool) -> dict[str, Any]:
     """Drop the large expanded-render ``content``, keeping editable ``content_editor``.
 
@@ -3457,7 +3441,8 @@ def list_pages(
     - Read one: get_page(page_id)
     - Create a notebook: create_page(history_id=...)
     """
-    base_url, api_key = _pages_connection()
+    state = ensure_connected()
+    gi: GalaxyInstance = state["gi"]
 
     try:
         # REST index defaults (show_own and show_published both True) are wrong
@@ -3474,9 +3459,7 @@ def list_pages(
         if search is not None:
             params["search"] = search
 
-        response = requests.get(
-            f"{base_url}api/pages", headers={"x-api-key": api_key}, params=params, timeout=30
-        )
+        response = gi.make_get_request(f"{gi.url}/api/pages", params=params)
         response.raise_for_status()
         pages = response.json()
         # total_matches is a response header, not part of the JSON body.
@@ -3528,12 +3511,11 @@ def get_page(page_id: str, include_rendered: bool = False) -> GalaxyResult:
     - Edit it: update_page(page_id, content=...)
     - See history: list_page_revisions(page_id)
     """
-    base_url, api_key = _pages_connection()
+    state = ensure_connected()
+    gi: GalaxyInstance = state["gi"]
 
     try:
-        response = requests.get(
-            f"{base_url}api/pages/{page_id}", headers={"x-api-key": api_key}, timeout=30
-        )
+        response = gi.make_get_request(f"{gi.url}/api/pages/{page_id}")
         response.raise_for_status()
         page = _strip_rendered(response.json(), include_rendered)
         return GalaxyResult(
@@ -3580,7 +3562,8 @@ def create_page(
     NEXT STEPS:
     - Edit it: update_page(page_id, content=...)
     """
-    base_url, api_key = _pages_connection()
+    state = ensure_connected()
+    gi: GalaxyInstance = state["gi"]
 
     try:
         # REST defaults content_format to html; the page tools speak markdown.
@@ -3596,11 +3579,10 @@ def create_page(
         if slug is not None:
             payload["slug"] = slug
 
-        response = requests.post(
-            f"{base_url}api/pages", headers={"x-api-key": api_key}, json=payload, timeout=30
+        page = _strip_rendered(
+            gi.make_post_request(f"{gi.url}/api/pages", payload=payload),
+            include_rendered=False,
         )
-        response.raise_for_status()
-        page = _strip_rendered(response.json(), include_rendered=False)
         return GalaxyResult(
             data=page,
             success=True,
@@ -3621,7 +3603,9 @@ def update_page(
     Content is Galaxy-flavored markdown using ENCODED ids in directives
     (e.g. `history_dataset_id=f2db41e1fa331b3e`) -- never raw integer ids or
     HIDs. Get encoded ids from get_history_contents / get_dataset_details.
-    Edits made through this tool are recorded with edit_source="agent".
+    Edits made through this tool are recorded with edit_source="agent". This does
+    not change the page's content_format, so editing a page originally authored
+    as HTML with markdown content can mislabel it.
 
     Args:
         page_id: Encoded id of the page.
@@ -3635,7 +3619,8 @@ def update_page(
     - Inspect revisions: list_page_revisions(page_id)
     - Roll back: revert_page_revision(page_id, revision_id)
     """
-    base_url, api_key = _pages_connection()
+    state = ensure_connected()
+    gi: GalaxyInstance = state["gi"]
 
     try:
         # edit_source attributes the revision to the agent, not a human user.
@@ -3645,14 +3630,10 @@ def update_page(
         if title is not None:
             payload["title"] = title
 
-        response = requests.put(
-            f"{base_url}api/pages/{page_id}",
-            headers={"x-api-key": api_key},
-            json=payload,
-            timeout=30,
+        page = _strip_rendered(
+            gi.make_put_request(f"{gi.url}/api/pages/{page_id}", payload=payload),
+            include_rendered=False,
         )
-        response.raise_for_status()
-        page = _strip_rendered(response.json(), include_rendered=False)
         return GalaxyResult(
             data=page,
             success=True,
@@ -3681,14 +3662,13 @@ def list_page_revisions(page_id: str, sort_desc: bool = False) -> GalaxyResult:
     - Read a revision: get_page_revision(page_id, revision_id)
     - Roll back: revert_page_revision(page_id, revision_id)
     """
-    base_url, api_key = _pages_connection()
+    state = ensure_connected()
+    gi: GalaxyInstance = state["gi"]
 
     try:
-        response = requests.get(
-            f"{base_url}api/pages/{page_id}/revisions",
-            headers={"x-api-key": api_key},
+        response = gi.make_get_request(
+            f"{gi.url}/api/pages/{page_id}/revisions",
             params={"sort_desc": str(sort_desc).lower()},
-            timeout=30,
         )
         response.raise_for_status()
         revisions = response.json()
@@ -3703,37 +3683,30 @@ def list_page_revisions(page_id: str, sort_desc: bool = False) -> GalaxyResult:
 
 
 @mcp.tool(tags={"pages", "read", "extended"})
-def get_page_revision(
-    page_id: str, revision_id: str, include_rendered: bool = False
-) -> GalaxyResult:
+def get_page_revision(page_id: str, revision_id: str) -> GalaxyResult:
     """Get the content of a single page revision.
 
-    Mirrors get_page: returns `content_editor` (the editable Galaxy-flavored
-    markdown with ENCODED ids in directives) -- the form to compare against
-    get_page or pass back to update_page.
+    Returns the revision's `content`: the editable Galaxy-flavored markdown with
+    ENCODED ids in directives -- the form to diff against get_page or pass back
+    to update_page. Note: a revision exposes its editable markdown as `content`;
+    revisions have no separate `content_editor` field (unlike get_page).
 
     Args:
         page_id: Encoded id of the page.
         revision_id: Encoded id of the revision (from list_page_revisions).
-        include_rendered: When True, also return `content` -- the
-            embed-expanded render form. Can be large; omit unless needed.
 
     Returns:
-        GalaxyResult with the revision details including `content_editor`,
-        `edit_source`, and timestamps in data.
+        GalaxyResult with the revision details including `content`, `edit_source`,
+        and timestamps in data.
     """
-    base_url, api_key = _pages_connection()
+    state = ensure_connected()
+    gi: GalaxyInstance = state["gi"]
 
     try:
-        response = requests.get(
-            f"{base_url}api/pages/{page_id}/revisions/{revision_id}",
-            headers={"x-api-key": api_key},
-            timeout=30,
-        )
+        response = gi.make_get_request(f"{gi.url}/api/pages/{page_id}/revisions/{revision_id}")
         response.raise_for_status()
-        revision = _strip_rendered(response.json(), include_rendered)
         return GalaxyResult(
-            data=revision,
+            data=response.json(),
             success=True,
             message=f"Retrieved revision '{revision_id}' of page '{page_id}'",
         )
@@ -3757,16 +3730,13 @@ def revert_page_revision(page_id: str, revision_id: str) -> GalaxyResult:
     Returns:
         GalaxyResult with the new restored revision's details in data.
     """
-    base_url, api_key = _pages_connection()
+    state = ensure_connected()
+    gi: GalaxyInstance = state["gi"]
 
     try:
-        response = requests.post(
-            f"{base_url}api/pages/{page_id}/revisions/{revision_id}/revert",
-            headers={"x-api-key": api_key},
-            timeout=30,
+        revision = gi.make_post_request(
+            f"{gi.url}/api/pages/{page_id}/revisions/{revision_id}/revert"
         )
-        response.raise_for_status()
-        revision = _strip_rendered(response.json(), include_rendered=False)
         return GalaxyResult(
             data=revision,
             success=True,

--- a/mcp-server-galaxy-py/tests/test_helpers.py
+++ b/mcp-server-galaxy-py/tests/test_helpers.py
@@ -12,6 +12,7 @@ from galaxy_mcp.server import (
     cancel_workflow_invocation,
     connect,
     create_history,
+    create_page,
     create_user_tool,
     delete_user_tool,
     download_dataset,
@@ -26,6 +27,8 @@ from galaxy_mcp.server import (
     get_iwc_workflow_details,
     get_iwc_workflows,
     get_job_details,
+    get_page,
+    get_page_revision,
     get_server_info,
     get_tool_citations,
     get_tool_details,
@@ -38,15 +41,19 @@ from galaxy_mcp.server import (
     import_workflow_from_iwc,
     invoke_workflow,
     list_history_ids,
+    list_page_revisions,
+    list_pages,
     list_user_tools,
     list_workflows,
     recommend_iwc_workflows,
+    revert_page_revision,
     run_tool,
     run_user_tool,
     search_iwc_workflows,
     search_tools_by_keywords,
     search_tools_by_name,
     update_history,
+    update_page,
     upload_file,
     upload_file_from_url,
 )
@@ -86,8 +93,14 @@ get_workflow_input_template_fn = get_function(get_workflow_input_template)
 import_workflow_from_iwc_fn = get_function(import_workflow_from_iwc)
 invoke_workflow_fn = get_function(invoke_workflow)
 list_history_ids_fn = get_function(list_history_ids)
+list_page_revisions_fn = get_function(list_page_revisions)
+list_pages_fn = get_function(list_pages)
 list_workflows_fn = get_function(list_workflows)
+create_page_fn = get_function(create_page)
+get_page_fn = get_function(get_page)
+get_page_revision_fn = get_function(get_page_revision)
 recommend_iwc_workflows_fn = get_function(recommend_iwc_workflows)
+revert_page_revision_fn = get_function(revert_page_revision)
 run_tool_fn = get_function(run_tool)
 create_user_tool_fn = get_function(create_user_tool)
 delete_user_tool_fn = get_function(delete_user_tool)
@@ -96,6 +109,7 @@ run_user_tool_fn = get_function(run_user_tool)
 search_iwc_workflows_fn = get_function(search_iwc_workflows)
 search_tools_fn = get_function(search_tools_by_name)
 update_history_fn = get_function(update_history)
+update_page_fn = get_function(update_page)
 upload_file_fn = get_function(upload_file)
 upload_file_from_url_fn = get_function(upload_file_from_url)
 
@@ -129,8 +143,14 @@ __all__ = [
     "import_workflow_from_iwc_fn",
     "invoke_workflow_fn",
     "list_history_ids_fn",
+    "list_page_revisions_fn",
+    "list_pages_fn",
     "list_workflows_fn",
+    "create_page_fn",
+    "get_page_fn",
+    "get_page_revision_fn",
     "recommend_iwc_workflows_fn",
+    "revert_page_revision_fn",
     "run_tool_fn",
     "create_user_tool_fn",
     "delete_user_tool_fn",
@@ -139,6 +159,7 @@ __all__ = [
     "search_iwc_workflows_fn",
     "search_tools_fn",
     "update_history_fn",
+    "update_page_fn",
     "upload_file_fn",
     "upload_file_from_url_fn",
     "galaxy_state",

--- a/mcp-server-galaxy-py/tests/test_page_operations.py
+++ b/mcp-server-galaxy-py/tests/test_page_operations.py
@@ -1,0 +1,271 @@
+"""Tests for Galaxy Pages (notebook/report) operations.
+
+The page tools talk to Galaxy's /api/pages* REST endpoints directly (bioblend
+has no Pages API), so the HTTP layer is stubbed with the `responses` library --
+mirroring tests/test_job_operations.py.
+"""
+
+import json
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+import responses
+
+from galaxy_mcp.server import galaxy_state
+from tests.test_helpers import (
+    create_page_fn,
+    get_page_fn,
+    get_page_revision_fn,
+    list_page_revisions_fn,
+    list_pages_fn,
+    revert_page_revision_fn,
+    update_page_fn,
+)
+
+BASE_URL = "http://localhost:8080/"
+
+
+class TestPageOperations:
+    def setup_method(self):
+        galaxy_state["connected"] = True
+        galaxy_state["gi"] = type("MockGI", (), {})()
+        galaxy_state["url"] = BASE_URL
+        galaxy_state["api_key"] = "test_key"
+
+    def teardown_method(self):
+        galaxy_state["connected"] = False
+        galaxy_state["gi"] = None
+
+    @responses.activate
+    def test_list_pages(self):
+        responses.add(
+            responses.GET,
+            f"{BASE_URL}api/pages",
+            json=[
+                {"id": "page1", "title": "Notebook 1", "history_id": "hist1"},
+                {"id": "page2", "title": "Report 2", "history_id": None},
+            ],
+            headers={"total_matches": "5"},
+            status=200,
+        )
+
+        result = list_pages_fn(limit=2, offset=0)
+
+        assert result.success is True
+        assert result.count == 2
+        assert result.data[0]["id"] == "page1"
+        # total_matches header is surfaced through pagination metadata
+        assert result.pagination is not None
+        assert result.pagination.total_items == 5
+        assert result.pagination.has_next is True
+
+        # REST index defaults (show_own/show_published) are wrong for an agent;
+        # confirm we override them explicitly.
+        query = parse_qs(urlparse(responses.calls[0].request.url).query)
+        assert query["show_own"] == ["true"]
+        assert query["show_published"] == ["false"]
+        assert query["show_shared"] == ["false"]
+
+    @responses.activate
+    def test_list_pages_history_filter(self):
+        responses.add(
+            responses.GET,
+            f"{BASE_URL}api/pages",
+            json=[{"id": "page1", "title": "Notebook 1", "history_id": "hist1"}],
+            headers={"total_matches": "1"},
+            status=200,
+        )
+
+        result = list_pages_fn(history_id="hist1", show_published=True)
+
+        assert result.count == 1
+        query = parse_qs(urlparse(responses.calls[0].request.url).query)
+        assert query["history_id"] == ["hist1"]
+        assert query["show_published"] == ["true"]
+
+    @responses.activate
+    def test_get_page_strips_rendered_by_default(self):
+        responses.add(
+            responses.GET,
+            f"{BASE_URL}api/pages/page1",
+            json={
+                "id": "page1",
+                "title": "Notebook 1",
+                "content": "<rendered html>",
+                "content_editor": "raw markdown",
+                "edit_source": "agent",
+            },
+            status=200,
+        )
+
+        result = get_page_fn("page1")
+
+        assert result.success is True
+        assert result.data["content_editor"] == "raw markdown"
+        # The large rendered form is dropped unless explicitly requested.
+        assert "content" not in result.data
+
+    @responses.activate
+    def test_get_page_include_rendered(self):
+        responses.add(
+            responses.GET,
+            f"{BASE_URL}api/pages/page1",
+            json={
+                "id": "page1",
+                "title": "Notebook 1",
+                "content": "<rendered html>",
+                "content_editor": "raw markdown",
+            },
+            status=200,
+        )
+
+        result = get_page_fn("page1", include_rendered=True)
+
+        assert result.data["content"] == "<rendered html>"
+        assert result.data["content_editor"] == "raw markdown"
+
+    @responses.activate
+    def test_create_notebook(self):
+        responses.add(
+            responses.POST,
+            f"{BASE_URL}api/pages",
+            json={
+                "id": "page1",
+                "title": "My History",
+                "content": "<rendered>",
+                "content_editor": "# notes",
+            },
+            status=200,
+        )
+
+        result = create_page_fn(history_id="hist1", content="# notes")
+
+        assert result.success is True
+        assert result.data["id"] == "page1"
+        # create returns the editable form, not the rendered one
+        assert "content" not in result.data
+
+        sent = json.loads(responses.calls[0].request.body)
+        assert sent["content_format"] == "markdown"
+        assert sent["history_id"] == "hist1"
+        assert sent["content"] == "# notes"
+
+    @responses.activate
+    def test_create_report(self):
+        responses.add(
+            responses.POST,
+            f"{BASE_URL}api/pages",
+            json={"id": "page9", "title": "My Report", "content_editor": ""},
+            status=200,
+        )
+
+        result = create_page_fn(title="My Report", slug="my-report")
+
+        assert result.data["id"] == "page9"
+        sent = json.loads(responses.calls[0].request.body)
+        assert sent["title"] == "My Report"
+        assert sent["slug"] == "my-report"
+        assert "history_id" not in sent
+
+    @responses.activate
+    def test_create_report_missing_slug_error(self):
+        # Standalone reports require a unique slug; Galaxy rejects the request.
+        responses.add(
+            responses.POST,
+            f"{BASE_URL}api/pages",
+            json={"err_msg": "Slug is required for standalone pages"},
+            status=400,
+        )
+
+        with pytest.raises(ValueError, match="Create page failed"):
+            create_page_fn(title="My Report")
+
+    @responses.activate
+    def test_update_page_attributes_to_agent(self):
+        responses.add(
+            responses.PUT,
+            f"{BASE_URL}api/pages/page1",
+            json={
+                "id": "page1",
+                "title": "Notebook 1",
+                "content": "<rendered>",
+                "content_editor": "# updated",
+            },
+            status=200,
+        )
+
+        result = update_page_fn("page1", content="# updated")
+
+        assert result.success is True
+        assert "content" not in result.data
+        sent = json.loads(responses.calls[0].request.body)
+        assert sent["edit_source"] == "agent"
+        assert sent["content"] == "# updated"
+
+    @responses.activate
+    def test_list_page_revisions(self):
+        responses.add(
+            responses.GET,
+            f"{BASE_URL}api/pages/page1/revisions",
+            json=[
+                {"id": "rev1", "page_id": "page1", "edit_source": "user"},
+                {"id": "rev2", "page_id": "page1", "edit_source": "agent"},
+            ],
+            status=200,
+        )
+
+        result = list_page_revisions_fn("page1", sort_desc=True)
+
+        assert result.success is True
+        assert result.count == 2
+        assert result.data[1]["edit_source"] == "agent"
+        query = parse_qs(urlparse(responses.calls[0].request.url).query)
+        assert query["sort_desc"] == ["true"]
+
+    @responses.activate
+    def test_get_page_revision_strips_rendered(self):
+        responses.add(
+            responses.GET,
+            f"{BASE_URL}api/pages/page1/revisions/rev1",
+            json={
+                "id": "rev1",
+                "page_id": "page1",
+                "content": "<rendered>",
+                "content_editor": "raw md",
+                "edit_source": "user",
+            },
+            status=200,
+        )
+
+        result = get_page_revision_fn("page1", "rev1")
+
+        assert result.success is True
+        assert "content" not in result.data
+        assert result.data["edit_source"] == "user"
+
+    @responses.activate
+    def test_revert_page_revision(self):
+        responses.add(
+            responses.POST,
+            f"{BASE_URL}api/pages/page1/revisions/rev1/revert",
+            json={
+                "id": "rev3",
+                "page_id": "page1",
+                "content": "<rendered>",
+                "content_editor": "restored md",
+                "edit_source": "restore",
+            },
+            status=200,
+        )
+
+        result = revert_page_revision_fn("page1", "rev1")
+
+        assert result.success is True
+        assert result.data["id"] == "rev3"
+        assert result.data["edit_source"] == "restore"
+        assert "content" not in result.data
+
+    def test_list_pages_not_connected(self):
+        galaxy_state["connected"] = False
+        with pytest.raises(ValueError, match="Not connected to Galaxy"):
+            list_pages_fn()

--- a/mcp-server-galaxy-py/tests/test_page_operations.py
+++ b/mcp-server-galaxy-py/tests/test_page_operations.py
@@ -1,15 +1,15 @@
 """Tests for Galaxy Pages (notebook/report) operations.
 
-The page tools talk to Galaxy's /api/pages* REST endpoints directly (bioblend
-has no Pages API), so the HTTP layer is stubbed with the `responses` library --
-mirroring tests/test_job_operations.py.
+The page tools call Galaxy's /api/pages* REST endpoints through bioblend's
+thread-safe make_get_request / make_post_request / make_put_request helpers
+(which carry the configured User-Agent and the _gi_lock), so the tests mock
+those methods on the injected GalaxyInstance. make_get_request returns a
+requests.Response; make_post_request / make_put_request return decoded JSON.
 """
 
-import json
-from urllib.parse import parse_qs, urlparse
+from unittest.mock import Mock
 
 import pytest
-import responses
 
 from galaxy_mcp.server import galaxy_state
 from tests.test_helpers import (
@@ -22,31 +22,36 @@ from tests.test_helpers import (
     update_page_fn,
 )
 
-BASE_URL = "http://localhost:8080/"
+GALAXY_URL = "http://localhost:8080"
+
+
+def _get_response(json_data, headers=None):
+    """Fake requests.Response as returned by gi.make_get_request."""
+    resp = Mock()
+    resp.json.return_value = json_data
+    resp.headers = headers or {}
+    resp.raise_for_status.return_value = None
+    return resp
 
 
 class TestPageOperations:
     def setup_method(self):
+        self.gi = Mock()
+        self.gi.url = GALAXY_URL
         galaxy_state["connected"] = True
-        galaxy_state["gi"] = type("MockGI", (), {})()
-        galaxy_state["url"] = BASE_URL
-        galaxy_state["api_key"] = "test_key"
+        galaxy_state["gi"] = self.gi
 
     def teardown_method(self):
         galaxy_state["connected"] = False
         galaxy_state["gi"] = None
 
-    @responses.activate
     def test_list_pages(self):
-        responses.add(
-            responses.GET,
-            f"{BASE_URL}api/pages",
-            json=[
+        self.gi.make_get_request.return_value = _get_response(
+            [
                 {"id": "page1", "title": "Notebook 1", "history_id": "hist1"},
                 {"id": "page2", "title": "Report 2", "history_id": None},
             ],
             headers={"total_matches": "5"},
-            status=200,
         )
 
         result = list_pages_fn(limit=2, offset=0)
@@ -59,43 +64,48 @@ class TestPageOperations:
         assert result.pagination.total_items == 5
         assert result.pagination.has_next is True
 
+        args, kwargs = self.gi.make_get_request.call_args
+        assert args[0] == f"{GALAXY_URL}/api/pages"
         # REST index defaults (show_own/show_published) are wrong for an agent;
         # confirm we override them explicitly.
-        query = parse_qs(urlparse(responses.calls[0].request.url).query)
-        assert query["show_own"] == ["true"]
-        assert query["show_published"] == ["false"]
-        assert query["show_shared"] == ["false"]
+        params = kwargs["params"]
+        assert params["show_own"] == "true"
+        assert params["show_published"] == "false"
+        assert params["show_shared"] == "false"
+        assert params["limit"] == 2
 
-    @responses.activate
     def test_list_pages_history_filter(self):
-        responses.add(
-            responses.GET,
-            f"{BASE_URL}api/pages",
-            json=[{"id": "page1", "title": "Notebook 1", "history_id": "hist1"}],
+        self.gi.make_get_request.return_value = _get_response(
+            [{"id": "page1", "title": "Notebook 1", "history_id": "hist1"}],
             headers={"total_matches": "1"},
-            status=200,
         )
 
         result = list_pages_fn(history_id="hist1", show_published=True)
 
         assert result.count == 1
-        query = parse_qs(urlparse(responses.calls[0].request.url).query)
-        assert query["history_id"] == ["hist1"]
-        assert query["show_published"] == ["true"]
+        params = self.gi.make_get_request.call_args.kwargs["params"]
+        assert params["history_id"] == "hist1"
+        assert params["show_published"] == "true"
 
-    @responses.activate
+    def test_list_pages_total_matches_defaults_when_header_absent(self):
+        # Galaxy always sets the header, but the tool must not crash without it.
+        self.gi.make_get_request.return_value = _get_response([{"id": "page1"}, {"id": "page2"}])
+
+        result = list_pages_fn(limit=50)
+
+        assert result.count == 2
+        assert result.pagination.total_items == 2
+        assert result.pagination.has_next is False
+
     def test_get_page_strips_rendered_by_default(self):
-        responses.add(
-            responses.GET,
-            f"{BASE_URL}api/pages/page1",
-            json={
+        self.gi.make_get_request.return_value = _get_response(
+            {
                 "id": "page1",
                 "title": "Notebook 1",
                 "content": "<rendered html>",
                 "content_editor": "raw markdown",
                 "edit_source": "agent",
-            },
-            status=200,
+            }
         )
 
         result = get_page_fn("page1")
@@ -104,19 +114,16 @@ class TestPageOperations:
         assert result.data["content_editor"] == "raw markdown"
         # The large rendered form is dropped unless explicitly requested.
         assert "content" not in result.data
+        assert self.gi.make_get_request.call_args.args[0] == f"{GALAXY_URL}/api/pages/page1"
 
-    @responses.activate
     def test_get_page_include_rendered(self):
-        responses.add(
-            responses.GET,
-            f"{BASE_URL}api/pages/page1",
-            json={
+        self.gi.make_get_request.return_value = _get_response(
+            {
                 "id": "page1",
                 "title": "Notebook 1",
                 "content": "<rendered html>",
                 "content_editor": "raw markdown",
-            },
-            status=200,
+            }
         )
 
         result = get_page_fn("page1", include_rendered=True)
@@ -124,19 +131,13 @@ class TestPageOperations:
         assert result.data["content"] == "<rendered html>"
         assert result.data["content_editor"] == "raw markdown"
 
-    @responses.activate
     def test_create_notebook(self):
-        responses.add(
-            responses.POST,
-            f"{BASE_URL}api/pages",
-            json={
-                "id": "page1",
-                "title": "My History",
-                "content": "<rendered>",
-                "content_editor": "# notes",
-            },
-            status=200,
-        )
+        self.gi.make_post_request.return_value = {
+            "id": "page1",
+            "title": "My History",
+            "content": "<rendered>",
+            "content_editor": "# notes",
+        }
 
         result = create_page_fn(history_id="hist1", content="# notes")
 
@@ -145,73 +146,60 @@ class TestPageOperations:
         # create returns the editable form, not the rendered one
         assert "content" not in result.data
 
-        sent = json.loads(responses.calls[0].request.body)
-        assert sent["content_format"] == "markdown"
-        assert sent["history_id"] == "hist1"
-        assert sent["content"] == "# notes"
+        args, kwargs = self.gi.make_post_request.call_args
+        assert args[0] == f"{GALAXY_URL}/api/pages"
+        payload = kwargs["payload"]
+        assert payload["content_format"] == "markdown"
+        assert payload["history_id"] == "hist1"
+        assert payload["content"] == "# notes"
 
-    @responses.activate
     def test_create_report(self):
-        responses.add(
-            responses.POST,
-            f"{BASE_URL}api/pages",
-            json={"id": "page9", "title": "My Report", "content_editor": ""},
-            status=200,
-        )
+        self.gi.make_post_request.return_value = {
+            "id": "page9",
+            "title": "My Report",
+            "content_editor": "",
+        }
 
         result = create_page_fn(title="My Report", slug="my-report")
 
         assert result.data["id"] == "page9"
-        sent = json.loads(responses.calls[0].request.body)
-        assert sent["title"] == "My Report"
-        assert sent["slug"] == "my-report"
-        assert "history_id" not in sent
+        payload = self.gi.make_post_request.call_args.kwargs["payload"]
+        assert payload["title"] == "My Report"
+        assert payload["slug"] == "my-report"
+        assert "history_id" not in payload
 
-    @responses.activate
     def test_create_report_missing_slug_error(self):
-        # Standalone reports require a unique slug; Galaxy rejects the request.
-        responses.add(
-            responses.POST,
-            f"{BASE_URL}api/pages",
-            json={"err_msg": "Slug is required for standalone pages"},
-            status=400,
-        )
+        # Standalone reports require a unique slug; Galaxy rejects the request and
+        # bioblend's make_post_request raises on the non-200.
+        self.gi.make_post_request.side_effect = Exception("Unexpected HTTP status code: 400")
 
         with pytest.raises(ValueError, match="Create page failed"):
             create_page_fn(title="My Report")
 
-    @responses.activate
     def test_update_page_attributes_to_agent(self):
-        responses.add(
-            responses.PUT,
-            f"{BASE_URL}api/pages/page1",
-            json={
-                "id": "page1",
-                "title": "Notebook 1",
-                "content": "<rendered>",
-                "content_editor": "# updated",
-            },
-            status=200,
-        )
+        self.gi.make_put_request.return_value = {
+            "id": "page1",
+            "title": "Notebook 1",
+            "content": "<rendered>",
+            "content_editor": "# updated",
+        }
 
         result = update_page_fn("page1", content="# updated")
 
         assert result.success is True
         assert "content" not in result.data
-        sent = json.loads(responses.calls[0].request.body)
-        assert sent["edit_source"] == "agent"
-        assert sent["content"] == "# updated"
+        args, kwargs = self.gi.make_put_request.call_args
+        assert args[0] == f"{GALAXY_URL}/api/pages/page1"
+        payload = kwargs["payload"]
+        assert payload["edit_source"] == "agent"
+        assert payload["content"] == "# updated"
 
-    @responses.activate
     def test_list_page_revisions(self):
-        responses.add(
-            responses.GET,
-            f"{BASE_URL}api/pages/page1/revisions",
-            json=[
+        self.gi.make_get_request.return_value = _get_response(
+            [
                 {"id": "rev1", "page_id": "page1", "edit_source": "user"},
                 {"id": "rev2", "page_id": "page1", "edit_source": "agent"},
-            ],
-            status=200,
+            ]
         )
 
         result = list_page_revisions_fn("page1", sort_desc=True)
@@ -219,51 +207,51 @@ class TestPageOperations:
         assert result.success is True
         assert result.count == 2
         assert result.data[1]["edit_source"] == "agent"
-        query = parse_qs(urlparse(responses.calls[0].request.url).query)
-        assert query["sort_desc"] == ["true"]
+        args, kwargs = self.gi.make_get_request.call_args
+        assert args[0] == f"{GALAXY_URL}/api/pages/page1/revisions"
+        assert kwargs["params"]["sort_desc"] == "true"
 
-    @responses.activate
-    def test_get_page_revision_strips_rendered(self):
-        responses.add(
-            responses.GET,
-            f"{BASE_URL}api/pages/page1/revisions/rev1",
-            json={
+    def test_get_page_revision_returns_content(self):
+        # A revision's editable markdown lives in `content` (no content_editor),
+        # and unlike get_page it is NOT stripped.
+        self.gi.make_get_request.return_value = _get_response(
+            {
                 "id": "rev1",
                 "page_id": "page1",
-                "content": "<rendered>",
-                "content_editor": "raw md",
+                "content": "raw md",
                 "edit_source": "user",
-            },
-            status=200,
+            }
         )
 
         result = get_page_revision_fn("page1", "rev1")
 
         assert result.success is True
-        assert "content" not in result.data
+        assert result.data["content"] == "raw md"
         assert result.data["edit_source"] == "user"
-
-    @responses.activate
-    def test_revert_page_revision(self):
-        responses.add(
-            responses.POST,
-            f"{BASE_URL}api/pages/page1/revisions/rev1/revert",
-            json={
-                "id": "rev3",
-                "page_id": "page1",
-                "content": "<rendered>",
-                "content_editor": "restored md",
-                "edit_source": "restore",
-            },
-            status=200,
+        assert (
+            self.gi.make_get_request.call_args.args[0]
+            == f"{GALAXY_URL}/api/pages/page1/revisions/rev1"
         )
+
+    def test_revert_page_revision(self):
+        self.gi.make_post_request.return_value = {
+            "id": "rev3",
+            "page_id": "page1",
+            "content": "restored md",
+            "edit_source": "restore",
+        }
 
         result = revert_page_revision_fn("page1", "rev1")
 
         assert result.success is True
         assert result.data["id"] == "rev3"
         assert result.data["edit_source"] == "restore"
-        assert "content" not in result.data
+        # restored revision content is returned, not stripped
+        assert result.data["content"] == "restored md"
+        assert (
+            self.gi.make_post_request.call_args.args[0]
+            == f"{GALAXY_URL}/api/pages/page1/revisions/rev1/revert"
+        )
 
     def test_list_pages_not_connected(self):
         galaxy_state["connected"] = False

--- a/mcp-server-galaxy-py/tests/test_tool_tags.py
+++ b/mcp-server-galaxy-py/tests/test_tool_tags.py
@@ -9,7 +9,17 @@ def test_every_tool_is_tagged():
     """Every registered tool should have one domain, access, and tier tag."""
     from galaxy_mcp.server import mcp
 
-    domains = {"connection", "histories", "datasets", "jobs", "tools", "workflows", "iwc", "user"}
+    domains = {
+        "connection",
+        "histories",
+        "datasets",
+        "jobs",
+        "tools",
+        "workflows",
+        "iwc",
+        "user",
+        "pages",
+    }
     access = {"read", "write"}
     tiers = {"core", "extended", "niche"}
 


### PR DESCRIPTION
Adds the 7 Pages tools from John's in-Galaxy MCP work (galaxyproject/galaxy#22906) to the standalone server: `list_pages`, `get_page`, `create_page`, `update_page`, `list_page_revisions`, `get_page_revision`, `revert_page_revision`. A history-attached page is a Notebook; a standalone one is a Report.

bioblend has no Pages API, so these hit Galaxy's `/api/pages*` REST endpoints through the thread-safe `gi.make_*` helpers -- so they pick up the `_gi_lock` and the `User-Agent` like every other tool -- return `GalaxyResult`, and are tagged `{pages, read|write, extended}` to slot into the existing tag/middleware scheme. Short pages paragraph added to the server `instructions`.

Behavior mirrors the in-Galaxy version: `content_editor` by default with `include_rendered` to opt into the rendered `content`, `edit_source="agent"` on updates, `content_format="markdown"` on create, explicit visibility flags on the index, `total_matches` surfaced via pagination. One deliberate divergence: a revision's editable markdown is in `content` (revisions have no `content_editor`), so `get_page_revision`/`revert_page_revision` return it instead of stripping to nothing -- the in-Galaxy version has the same generic stripper and probably wants the same fix.

Tests mock the bioblend `make_*` methods; full suite + mypy + ruff green.

Follow-ups (separate, not in this PR):

- **Enhancing the agent-facing surface.** These 7 tools nudge the server toward ~45 tools, which is where a flat catalog starts to cost tokens and degrade tool selection. There's a broader effort planned to address that: converging the two Galaxy MCP servers on one contract, moving procedural guidance into the `instructions`/skills knowledge layer (and trimming verbose docstrings), and an eval-driven decision on the default exposure mode (flat vs a gated `core` tier + a discovery escape hatch). These pages tools are tagged `extended` precisely so they slot into whichever exposure model wins.
- **In-Galaxy parity gaps** worth porting here next: `get_job_status`, `get_invocation_details`, and the file-source tools.
