### PR TITLE
Set up npm publishing for the galaxy-agent-tools packages

### DIFF
--- a/.github/workflows/agent-tools-release.yml
+++ b/.github/workflows/agent-tools-release.yml
@@ -1,0 +1,60 @@
+name: Agent Tools (TS) Release
+
+# Publishes the @galaxyproject/galaxy-{ops,cli,mcp} packages to npm.
+# Trigger by pushing a tag like `ts-v0.1.0` (or run manually). Requires an
+# `NPM_TOKEN` repo secret with publish rights to the @galaxyproject org.
+
+on:
+  push:
+    tags:
+      - "ts-v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # required for npm provenance
+
+defaults:
+  run:
+    working-directory: galaxy-agent-tools
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: galaxy-agent-tools/package.json
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: galaxy-agent-tools/pnpm-lock.yaml
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm -r typecheck
+
+      - name: Test
+        run: pnpm -r test
+
+      - name: Build
+        run: pnpm -r build
+
+      # Publishes galaxy-ops first, then the surfaces (pnpm resolves the order and
+      # rewrites `workspace:*` deps to the concrete version). Re-running on an
+      # already-published version is a no-op error, which is the desired guard.
+      - name: Publish to npm
+        run: pnpm -r publish --access public --provenance --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/agent-tools-release.yml
+++ b/.github/workflows/agent-tools-release.yml
@@ -1,8 +1,10 @@
 name: Agent Tools (TS) Release
 
 # Publishes the @galaxyproject/galaxy-{ops,cli,mcp} packages to npm.
-# Trigger by pushing a tag like `ts-v0.1.0` (or run manually). Requires an
-# `NPM_TOKEN` repo secret with publish rights to the @galaxyproject org.
+# Trigger by pushing a tag like `ts-v0.1.0` (or run manually). Auth is via npm
+# trusted publishing (OIDC) -- no NPM_TOKEN. Each package needs a trusted publisher
+# configured on npmjs.com (org: galaxyproject, repo: galaxy-mcp, workflow filename:
+# agent-tools-release.yml).
 
 on:
   push:
@@ -12,7 +14,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write # required for npm provenance
+  id-token: write # required for OIDC trusted publishing (and provenance)
 
 defaults:
   run:
@@ -50,11 +52,17 @@ jobs:
       - name: Build
         run: pnpm -r build
 
-      # Publishes galaxy-ops first, then the surfaces (pnpm resolves the order and
-      # rewrites `workspace:*` deps to the concrete version). Re-running on an
-      # already-published version is a no-op error, which is the desired guard.
-      - name: Publish to npm
-        run: pnpm -r publish --access public --provenance --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"
+      # Trusted publishing (OIDC), no NPM_TOKEN: pnpm packs each package -- which
+      # rewrites `workspace:*` to the concrete version inside the tarball -- then npm
+      # (>= 11.5.1) does the OIDC-authenticated upload and auto-generates provenance.
+      # We publish with npm, not `pnpm publish`, because pnpm's OIDC support is not
+      # yet reliable. galaxy-ops goes first so the surfaces' dependency already exists.
+      - name: Publish to npm (trusted publishing)
+        run: |
+          set -euo pipefail
+          npm install -g npm@latest   # trusted publishing needs npm >= 11.5.1
+          for pkg in galaxy-ops galaxy-cli galaxy-mcp; do
+            tgz="$(cd "packages/$pkg" && pnpm pack --pack-destination "$RUNNER_TEMP" | tail -1)"
+            echo "Publishing $tgz"
+            npm publish "$tgz" --access public
+          done

--- a/galaxy-agent-tools/packages/galaxy-cli/README.md
+++ b/galaxy-agent-tools/packages/galaxy-cli/README.md
@@ -1,0 +1,48 @@
+# @galaxyproject/galaxy-cli
+
+Galaxy agent operations on the command line. One subcommand per operation --
+histories, datasets, tools, workflows, and the IWC catalog -- with table / JSON
+output and meaningful exit codes. Built on
+[`@galaxyproject/galaxy-ops`](https://www.npmjs.com/package/@galaxyproject/galaxy-ops).
+
+## Install
+
+```bash
+npm install -g @galaxyproject/galaxy-cli   # provides the `galaxy-cli` command
+# or run without installing:
+npx @galaxyproject/galaxy-cli --help
+```
+
+Requires Node.js `>=22.19`.
+
+## Usage
+
+Set your [Galaxy](https://galaxyproject.org/) connection, then run a command:
+
+```bash
+export GALAXY_URL=https://usegalaxy.org/
+export GALAXY_API_KEY=your-api-key
+
+galaxy-cli get_user
+galaxy-cli --format json get_histories --name rnaseq
+galaxy-cli get_workflow_input_template <workflowId>
+galaxy-cli invoke_workflow <workflowId> --inputs @inputs.json --history-name "WF run"
+```
+
+Credentials resolve from (first match wins): `--url`/`--api-key` flags, the
+`GALAXY_URL`/`GALAXY_API_KEY` environment variables, a `.env` file in the current
+directory, or a planemo profile (`--profile <name>`). Output is a table by
+default; `--format json` prints the full result envelope for scripting. Exit
+codes follow `sysexits.h` conventions (e.g. `77` for auth failures).
+
+Run `galaxy-cli --help`, or `galaxy-cli <command> --help`, for the full list of
+commands and their arguments.
+
+## Documentation
+
+See the [galaxy-agent-tools workspace README](https://github.com/galaxyproject/galaxy-mcp/tree/main/galaxy-agent-tools#readme)
+for the full operation list, output formats, and exit-code reference.
+
+## License
+
+[MIT](https://github.com/galaxyproject/galaxy-mcp/blob/main/LICENSE)

--- a/galaxy-agent-tools/packages/galaxy-cli/package.json
+++ b/galaxy-agent-tools/packages/galaxy-cli/package.json
@@ -1,7 +1,22 @@
 {
   "name": "@galaxyproject/galaxy-cli",
-  "version": "0.0.0",
+  "version": "0.1.0",
+  "description": "Command-line interface for Galaxy agent operations -- histories, datasets, tools, workflows, and the IWC catalog.",
+  "license": "MIT",
+  "author": "Galaxy Project",
+  "homepage": "https://github.com/galaxyproject/galaxy-mcp/tree/main/galaxy-agent-tools/packages/galaxy-cli#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/galaxyproject/galaxy-mcp.git",
+    "directory": "galaxy-agent-tools/packages/galaxy-cli"
+  },
+  "bugs": "https://github.com/galaxyproject/galaxy-mcp/issues",
+  "keywords": ["galaxy", "bioinformatics", "cli", "galaxy-project"],
   "type": "module",
+  "engines": { "node": ">=22.19" },
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": { "galaxy-cli": "./dist/index.js" },
   "files": ["dist"],
   "scripts": {

--- a/galaxy-agent-tools/packages/galaxy-mcp/README.md
+++ b/galaxy-agent-tools/packages/galaxy-mcp/README.md
@@ -1,0 +1,48 @@
+# @galaxyproject/galaxy-mcp
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server (Node) that
+exposes [Galaxy](https://galaxyproject.org/) agent operations -- histories,
+datasets, tools, workflows, and the IWC catalog -- as MCP tools over stdio. Built
+on [`@galaxyproject/galaxy-ops`](https://www.npmjs.com/package/@galaxyproject/galaxy-ops).
+
+## Install / run
+
+```bash
+GALAXY_URL=https://usegalaxy.org/ GALAXY_API_KEY=your-api-key \
+  npx @galaxyproject/galaxy-mcp
+# -> "galaxy-mcp: connected on stdio"
+```
+
+Requires Node.js `>=22.19`. The server reads `GALAXY_URL` and `GALAXY_API_KEY`
+from the environment and speaks MCP over stdio.
+
+## Use with an MCP client
+
+For example, in Claude Desktop's `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "galaxy": {
+      "command": "npx",
+      "args": ["-y", "@galaxyproject/galaxy-mcp"],
+      "env": {
+        "GALAXY_URL": "https://usegalaxy.org/",
+        "GALAXY_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+Every operation is registered as an MCP tool; read-only operations are flagged
+with `readOnlyHint`.
+
+## Documentation
+
+See the [galaxy-agent-tools workspace README](https://github.com/galaxyproject/galaxy-mcp/tree/main/galaxy-agent-tools#readme)
+for the full list of operations exposed as tools.
+
+## License
+
+[MIT](https://github.com/galaxyproject/galaxy-mcp/blob/main/LICENSE)

--- a/galaxy-agent-tools/packages/galaxy-mcp/package.json
+++ b/galaxy-agent-tools/packages/galaxy-mcp/package.json
@@ -1,7 +1,22 @@
 {
   "name": "@galaxyproject/galaxy-mcp",
-  "version": "0.0.0",
+  "version": "0.1.0",
+  "description": "Model Context Protocol (MCP) server exposing Galaxy agent operations as tools over stdio.",
+  "license": "MIT",
+  "author": "Galaxy Project",
+  "homepage": "https://github.com/galaxyproject/galaxy-mcp/tree/main/galaxy-agent-tools/packages/galaxy-mcp#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/galaxyproject/galaxy-mcp.git",
+    "directory": "galaxy-agent-tools/packages/galaxy-mcp"
+  },
+  "bugs": "https://github.com/galaxyproject/galaxy-mcp/issues",
+  "keywords": ["galaxy", "bioinformatics", "mcp", "model-context-protocol", "galaxy-project"],
   "type": "module",
+  "engines": { "node": ">=22.19" },
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": { "galaxy-mcp": "./dist/index.js" },
   "files": ["dist"],
   "scripts": {

--- a/galaxy-agent-tools/packages/galaxy-ops/README.md
+++ b/galaxy-agent-tools/packages/galaxy-ops/README.md
@@ -1,0 +1,51 @@
+# @galaxyproject/galaxy-ops
+
+The framework-free TypeScript core for Galaxy agent operations. It provides a
+typed [Galaxy](https://galaxyproject.org/) API client (built on `openapi-fetch`
+and the official `@galaxyproject/galaxy-api-client` types), an operation
+registry, a typed error model, and run/poll orchestration for tool runs and
+workflow invocations.
+
+This package has no dependency on any CLI or MCP framework -- it's the shared
+core behind [`@galaxyproject/galaxy-cli`](https://www.npmjs.com/package/@galaxyproject/galaxy-cli)
+and [`@galaxyproject/galaxy-mcp`](https://www.npmjs.com/package/@galaxyproject/galaxy-mcp),
+and you can use it directly to script Galaxy from TypeScript.
+
+## Install
+
+```bash
+npm install @galaxyproject/galaxy-ops
+```
+
+Requires Node.js `>=22.19`.
+
+## Usage
+
+```ts
+import { createGalaxyContext, getUser, getHistories } from "@galaxyproject/galaxy-ops";
+
+const ctx = createGalaxyContext({
+  baseUrl: "https://usegalaxy.org/",
+  apiKey: process.env.GALAXY_API_KEY!,
+});
+
+const me = await getUser({}, ctx);
+console.log(`Hello, ${me.username}`);
+
+const histories = await getHistories({ limit: 10 }, ctx);
+```
+
+Each operation is a small function `(input, ctx) => Promise<data>` that returns
+typed data or throws a typed `GalaxyError`. For the surface-style envelope
+(`{ data, success, message, errorKind }`) used by the CLI and MCP server, wrap a
+registered op with `runWithEnvelope`; iterate `allOperations` to enumerate the
+full set.
+
+## Documentation
+
+See the [galaxy-agent-tools workspace README](https://github.com/galaxyproject/galaxy-mcp/tree/main/galaxy-agent-tools#readme)
+for the full operation list and design.
+
+## License
+
+[MIT](https://github.com/galaxyproject/galaxy-mcp/blob/main/LICENSE)

--- a/galaxy-agent-tools/packages/galaxy-ops/package.json
+++ b/galaxy-agent-tools/packages/galaxy-ops/package.json
@@ -1,7 +1,21 @@
 {
   "name": "@galaxyproject/galaxy-ops",
-  "version": "0.0.0",
+  "version": "0.1.0",
+  "description": "Framework-free TypeScript core for Galaxy agent operations: a typed Galaxy API client, an operation registry, and run/poll orchestration.",
+  "license": "MIT",
+  "author": "Galaxy Project",
+  "homepage": "https://github.com/galaxyproject/galaxy-mcp/tree/main/galaxy-agent-tools/packages/galaxy-ops#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/galaxyproject/galaxy-mcp.git",
+    "directory": "galaxy-agent-tools/packages/galaxy-ops"
+  },
+  "bugs": "https://github.com/galaxyproject/galaxy-mcp/issues",
+  "keywords": ["galaxy", "bioinformatics", "galaxy-project"],
   "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
Sets up npm publishing for the three TypeScript packages so they're installable (`npm i` / `npx @galaxyproject/galaxy-cli`).

What's here:

- Bumps `galaxy-ops`, `galaxy-cli`, and `galaxy-mcp` to **0.1.0** and adds the npm metadata (`publishConfig.access=public`, `license`, `repository`, `description`, `engines`).
- A tag-triggered release workflow (`.github/workflows/agent-tools-release.yml`): on a `ts-v*` tag it installs, typechecks, tests, builds, and publishes via **npm trusted publishing (OIDC)** -- no `NPM_TOKEN` secret. pnpm packs each package (rewriting `workspace:*` to the concrete version inside the tarball) and npm (>= 11.5.1) does the OIDC-authenticated upload, with provenance generated automatically. (pnpm's own OIDC support isn't reliable yet, so npm does the actual publish.)
- Per-package READMEs so the npm package pages aren't blank.

**Before the workflow can publish:** configure a **trusted publisher** on npmjs.com for each of `@galaxyproject/galaxy-ops`, `galaxy-cli`, and `galaxy-mcp` -- org `galaxyproject`, repo `galaxy-mcp`, workflow filename `agent-tools-release.yml`.

Note: `0.1.0` was already published manually; this wires up repeatable, secret-free releases for future versions (push a `ts-v<version>` tag).
