### PR TITLE
Publish the Docker image to GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,71 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+  push:
+    branches: [main]
+    paths:
+      - "mcp-server-galaxy-py/**"
+      - ".github/workflows/docker-publish.yml"
+  pull_request:
+    paths:
+      - "mcp-server-galaxy-py/**"
+      - ".github/workflows/docker-publish.yml"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: galaxyproject/galaxy-mcp
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # No login on PRs from forks: the token is read-only there and we only
+      # build to validate the Dockerfile, never push.
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # latest=auto: a semver release tag also moves :latest (skipped for pre-releases).
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=edge,branch=main
+            type=ref,event=pr
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: mcp-server-galaxy-py
+          file: mcp-server-galaxy-py/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # arm64 covers Apple Silicon users running the server locally; build it
+          # only when we actually publish, since emulated builds are slow.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -71,13 +71,17 @@ uv run galaxy-mcp --transport streamable-http --host 0.0.0.0 --port 8000
 
 ## Container Usage
 
+Images are published to the GitHub Container Registry as
+[`ghcr.io/galaxyproject/galaxy-mcp`](https://github.com/galaxyproject/galaxy-mcp/pkgs/container/galaxy-mcp).
+Use `:latest` (default) or pin a release, e.g. `:1.9.0`.
+
 The published image defaults to stdio transport (no HTTP listener):
 
 ```bash
 docker run --rm -it \
   -e GALAXY_URL="https://usegalaxy.org/" \
   -e GALAXY_API_KEY="your-api-key" \
-  galaxyproject/galaxy-mcp
+  ghcr.io/galaxyproject/galaxy-mcp
 ```
 
 For OAuth + HTTP:
@@ -88,7 +92,7 @@ docker run --rm -it -p 8000:8000 \
   -e GALAXY_MCP_TRANSPORT="streamable-http" \
   -e GALAXY_MCP_PUBLIC_URL="https://mcp.example.com" \
   -e GALAXY_MCP_SESSION_SECRET="$(openssl rand -hex 32)" \
-  galaxyproject/galaxy-mcp
+  ghcr.io/galaxyproject/galaxy-mcp
 ```
 
 ## Connect to Claude Desktop

--- a/mcp-server-galaxy-py/.dockerignore
+++ b/mcp-server-galaxy-py/.dockerignore
@@ -1,0 +1,27 @@
+# Virtualenvs and tool caches -- never belong in the image
+.venv/
+.tox/
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+
+# Coverage / test artifacts
+.coverage
+htmlcov/
+
+# Local secrets and editor/agent state
+.env
+.env.*
+.claude/
+.aider*
+
+# Build outputs
+dist/
+build/
+*.egg-info/
+
+# VCS and CI (not needed at build time)
+.git/
+.github/

--- a/mcp-server-galaxy-py/DEVELOPMENT.md
+++ b/mcp-server-galaxy-py/DEVELOPMENT.md
@@ -219,6 +219,12 @@ The project uses GitHub Actions for CI/CD:
     - Builds and publishes to PyPI
     - Optionally publishes to Test PyPI first
 
+3. **Publish Docker image** (`docker-publish.yml`)
+    - On release: pushes `ghcr.io/galaxyproject/galaxy-mcp` tagged with the version (e.g. `1.9.0`, `1.9`) and moves `latest`
+    - On push to `main` (when the server or Dockerfile changes): updates the `edge` tag
+    - On PRs touching those paths: builds the image to validate the Dockerfile, without pushing
+    - Authenticates with the built-in `GITHUB_TOKEN` -- no registry secret required
+
 ### Local CI Simulation
 
 Run the full CI suite locally:
@@ -297,6 +303,8 @@ The draft is available at https://github.com/galaxyproject/galaxy-mcp/releases
 For automatic PyPI deployment:
 - `PYPI_API_TOKEN`: PyPI API token scoped to the galaxy-mcp project
 - Set at: https://github.com/galaxyproject/galaxy-mcp/settings/secrets/actions
+
+Docker publishing to GHCR needs no secret -- it uses the built-in `GITHUB_TOKEN`.
 
 ### Manual Publishing (Fallback)
 

--- a/mcp-server-galaxy-py/Dockerfile
+++ b/mcp-server-galaxy-py/Dockerfile
@@ -48,7 +48,6 @@ ENV GALAXY_URL="https://usegalaxy.org" \
     GALAXY_MCP_HOST="0.0.0.0" \
     GALAXY_MCP_PORT="8000"
 
-COPY --from=uv /root/.local /root/.local
 COPY --from=uv --chown=app:app /app/.venv /app/.venv
 
 # Place executables in the environment at the front of the path


### PR DESCRIPTION
The README's Container Usage section points at `galaxyproject/galaxy-mcp`, but that image was never published -- nothing in CI built or pushed it, so `docker run galaxyproject/galaxy-mcp` fails to pull. This wires up publishing.

While getting a local build to pass, I hit a latent Dockerfile bug: the final stage did `COPY --from=uv /root/.local /root/.local`, but that path doesn't exist in the uv builder (uv lives at `/usr/local/bin`, nothing installs to `/root/.local`), so the build errored with a checksum-not-found. Dropped it -- the runtime doesn't need uv, the entrypoint is the venv console script. Also added a `.dockerignore`.

New `docker-publish.yml` builds `mcp-server-galaxy-py/Dockerfile` and pushes `ghcr.io/galaxyproject/galaxy-mcp`: versioned + `latest` on release, `edge` on main, and a build-only validation pass on PRs so a broken Dockerfile can't slip through again. Auth is the built-in `GITHUB_TOKEN` -- no secrets. Multi-arch (amd64 + arm64) on publish.

Verified locally: image builds, stdio `--help` runs, HTTP transport binds :8000.