### PR TITLE
Fix doubled /api in gi.url request paths

### DIFF
--- a/mcp-server-galaxy-py/src/galaxy_mcp/server.py
+++ b/mcp-server-galaxy-py/src/galaxy_mcp/server.py
@@ -261,7 +261,7 @@ def _get_datatypes_mapping(gi: GalaxyInstance) -> dict[str, Any]:
     key = getattr(gi, "base_url", None)
     if key in _DATATYPES_MAPPING_CACHE:
         return _DATATYPES_MAPPING_CACHE[key]
-    resp = gi.make_get_request(f"{gi.url}/api/datatypes/types_and_mapping?upload_only=false")
+    resp = gi.make_get_request(f"{gi.url}/datatypes/types_and_mapping?upload_only=false")
     _empty: dict[str, Any] = {"ext_to_class_name": {}, "class_to_classes": {}}
     if resp.status_code != 200:
         mapping: dict[str, Any] = _empty
@@ -2951,7 +2951,7 @@ def _resolve_workflow_slots(
     if history_id:
         params += f"&history_id={history_id}"
     try:
-        resp = gi.make_get_request(f"{gi.url}/api/workflows/{workflow_id}/download?{params}")
+        resp = gi.make_get_request(f"{gi.url}/workflows/{workflow_id}/download?{params}")
         if resp.status_code == 200:
             run_model = resp.json()
             slots = normalize_run_model(run_model)
@@ -3491,7 +3491,7 @@ def list_pages(
         if search is not None:
             params["search"] = search
 
-        response = gi.make_get_request(f"{gi.url}/api/pages", params=params)
+        response = gi.make_get_request(f"{gi.url}/pages", params=params)
         response.raise_for_status()
         pages = response.json()
         # total_matches is a response header, not part of the JSON body.
@@ -3547,7 +3547,7 @@ def get_page(page_id: str, include_rendered: bool = False) -> GalaxyResult:
     gi: GalaxyInstance = state["gi"]
 
     try:
-        response = gi.make_get_request(f"{gi.url}/api/pages/{page_id}")
+        response = gi.make_get_request(f"{gi.url}/pages/{page_id}")
         response.raise_for_status()
         page = _strip_rendered(response.json(), include_rendered)
         return GalaxyResult(
@@ -3612,7 +3612,7 @@ def create_page(
             payload["slug"] = slug
 
         page = _strip_rendered(
-            gi.make_post_request(f"{gi.url}/api/pages", payload=payload),
+            gi.make_post_request(f"{gi.url}/pages", payload=payload),
             include_rendered=False,
         )
         return GalaxyResult(
@@ -3663,7 +3663,7 @@ def update_page(
             payload["title"] = title
 
         page = _strip_rendered(
-            gi.make_put_request(f"{gi.url}/api/pages/{page_id}", payload=payload),
+            gi.make_put_request(f"{gi.url}/pages/{page_id}", payload=payload),
             include_rendered=False,
         )
         return GalaxyResult(
@@ -3699,7 +3699,7 @@ def list_page_revisions(page_id: str, sort_desc: bool = False) -> GalaxyResult:
 
     try:
         response = gi.make_get_request(
-            f"{gi.url}/api/pages/{page_id}/revisions",
+            f"{gi.url}/pages/{page_id}/revisions",
             params={"sort_desc": str(sort_desc).lower()},
         )
         response.raise_for_status()
@@ -3735,7 +3735,7 @@ def get_page_revision(page_id: str, revision_id: str) -> GalaxyResult:
     gi: GalaxyInstance = state["gi"]
 
     try:
-        response = gi.make_get_request(f"{gi.url}/api/pages/{page_id}/revisions/{revision_id}")
+        response = gi.make_get_request(f"{gi.url}/pages/{page_id}/revisions/{revision_id}")
         response.raise_for_status()
         return GalaxyResult(
             data=response.json(),
@@ -3766,9 +3766,7 @@ def revert_page_revision(page_id: str, revision_id: str) -> GalaxyResult:
     gi: GalaxyInstance = state["gi"]
 
     try:
-        revision = gi.make_post_request(
-            f"{gi.url}/api/pages/{page_id}/revisions/{revision_id}/revert"
-        )
+        revision = gi.make_post_request(f"{gi.url}/pages/{page_id}/revisions/{revision_id}/revert")
         return GalaxyResult(
             data=revision,
             success=True,

--- a/mcp-server-galaxy-py/tests/test_page_operations.py
+++ b/mcp-server-galaxy-py/tests/test_page_operations.py
@@ -22,7 +22,11 @@ from tests.test_helpers import (
     update_page_fn,
 )
 
-GALAXY_URL = "http://localhost:8080"
+# bioblend's GalaxyInstance.url is the API root (`<base>/api`), not the server
+# base URL -- mirror that here or these URL assertions guard a shape production
+# can never produce.
+GALAXY_BASE_URL = "http://localhost:8080"
+GALAXY_API_URL = f"{GALAXY_BASE_URL}/api"
 
 
 def _get_response(json_data, headers=None):
@@ -37,7 +41,7 @@ def _get_response(json_data, headers=None):
 class TestPageOperations:
     def setup_method(self):
         self.gi = Mock()
-        self.gi.url = GALAXY_URL
+        self.gi.url = GALAXY_API_URL
         galaxy_state["connected"] = True
         galaxy_state["gi"] = self.gi
 
@@ -65,7 +69,7 @@ class TestPageOperations:
         assert result.pagination.has_next is True
 
         args, kwargs = self.gi.make_get_request.call_args
-        assert args[0] == f"{GALAXY_URL}/api/pages"
+        assert args[0] == f"{GALAXY_API_URL}/pages"
         # REST index defaults (show_own/show_published) are wrong for an agent;
         # confirm we override them explicitly.
         params = kwargs["params"]
@@ -114,7 +118,7 @@ class TestPageOperations:
         assert result.data["content_editor"] == "raw markdown"
         # The large rendered form is dropped unless explicitly requested.
         assert "content" not in result.data
-        assert self.gi.make_get_request.call_args.args[0] == f"{GALAXY_URL}/api/pages/page1"
+        assert self.gi.make_get_request.call_args.args[0] == f"{GALAXY_API_URL}/pages/page1"
 
     def test_get_page_include_rendered(self):
         self.gi.make_get_request.return_value = _get_response(
@@ -147,7 +151,7 @@ class TestPageOperations:
         assert "content" not in result.data
 
         args, kwargs = self.gi.make_post_request.call_args
-        assert args[0] == f"{GALAXY_URL}/api/pages"
+        assert args[0] == f"{GALAXY_API_URL}/pages"
         payload = kwargs["payload"]
         assert payload["content_format"] == "markdown"
         assert payload["history_id"] == "hist1"
@@ -189,7 +193,7 @@ class TestPageOperations:
         assert result.success is True
         assert "content" not in result.data
         args, kwargs = self.gi.make_put_request.call_args
-        assert args[0] == f"{GALAXY_URL}/api/pages/page1"
+        assert args[0] == f"{GALAXY_API_URL}/pages/page1"
         payload = kwargs["payload"]
         assert payload["edit_source"] == "agent"
         assert payload["content"] == "# updated"
@@ -208,7 +212,7 @@ class TestPageOperations:
         assert result.count == 2
         assert result.data[1]["edit_source"] == "agent"
         args, kwargs = self.gi.make_get_request.call_args
-        assert args[0] == f"{GALAXY_URL}/api/pages/page1/revisions"
+        assert args[0] == f"{GALAXY_API_URL}/pages/page1/revisions"
         assert kwargs["params"]["sort_desc"] == "true"
 
     def test_get_page_revision_returns_content(self):
@@ -230,7 +234,7 @@ class TestPageOperations:
         assert result.data["edit_source"] == "user"
         assert (
             self.gi.make_get_request.call_args.args[0]
-            == f"{GALAXY_URL}/api/pages/page1/revisions/rev1"
+            == f"{GALAXY_API_URL}/pages/page1/revisions/rev1"
         )
 
     def test_revert_page_revision(self):
@@ -250,7 +254,7 @@ class TestPageOperations:
         assert result.data["content"] == "restored md"
         assert (
             self.gi.make_post_request.call_args.args[0]
-            == f"{GALAXY_URL}/api/pages/page1/revisions/rev1/revert"
+            == f"{GALAXY_API_URL}/pages/page1/revisions/rev1/revert"
         )
 
     def test_list_pages_not_connected(self):

--- a/mcp-server-galaxy-py/tests/test_page_operations.py
+++ b/mcp-server-galaxy-py/tests/test_page_operations.py
@@ -10,6 +10,7 @@ requests.Response; make_post_request / make_put_request return decoded JSON.
 from unittest.mock import Mock
 
 import pytest
+from bioblend.galaxy import GalaxyInstance
 
 from galaxy_mcp.server import galaxy_state
 from tests.test_helpers import (
@@ -27,6 +28,17 @@ from tests.test_helpers import (
 # can never produce.
 GALAXY_BASE_URL = "http://localhost:8080"
 GALAXY_API_URL = f"{GALAXY_BASE_URL}/api"
+
+
+def test_bioblend_url_is_the_api_root():
+    """Pin the contract the mocked fixture below imitates.
+
+    Every URL assertion in this module sets `gi.url` by hand, so it can only be
+    as honest as this assumption. GalaxyInstance only touches the network when
+    the URL has no scheme, so constructing one here stays offline.
+    """
+    gi = GalaxyInstance(url=GALAXY_BASE_URL, key="notakey")
+    assert gi.url == GALAXY_API_URL
 
 
 def _get_response(json_data, headers=None):

--- a/mcp-server-galaxy-py/tests/test_workflow_operations.py
+++ b/mcp-server-galaxy-py/tests/test_workflow_operations.py
@@ -380,7 +380,7 @@ class TestWorkflowOperations:
 def test_get_datatypes_mapping_caches_per_base_url():
     _DATATYPES_MAPPING_CACHE.clear()
     gi = Mock()
-    gi.base_url = "https://g.example/api"
+    gi.base_url = "https://g.example"
     gi.url = "https://g.example/api"
     resp = Mock()
     resp.status_code = 200
@@ -392,6 +392,12 @@ def test_get_datatypes_mapping_caches_per_base_url():
     _ = _get_datatypes_mapping(gi)
     assert m1["ext_to_class_name"]["bam"] == "B"
     assert gi.make_get_request.call_count == 1  # second call served from cache
+    # gi.url is already the API root; a doubled /api/api here 404s and the mapping
+    # silently degrades to empty, so pin the exact URL.
+    assert (
+        gi.make_get_request.call_args.args[0]
+        == "https://g.example/api/datatypes/types_and_mapping?upload_only=false"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -467,6 +473,9 @@ def test_resolve_slots_requests_instance_false():
     url = gi.make_get_request.call_args.args[0]
     assert "instance=false" in url
     assert "instance=true" not in url
+    # gi.url is already the API root -- a doubled /api/api 404s and this path
+    # quietly falls back to the .ga export instead of erroring.
+    assert url.startswith("https://g/api/workflows/wfid/download?")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
bioblend's `GalaxyInstance.url` is already the API root -- `galaxyclient.py` does `self.url = f"{self.base_url}/api"` -- so every `f"{gi.url}/api/..."` in `server.py` was building `/api/api/...`, which Galaxy rejects with `No route for /api/api/pages`.

All seven pages tools were affected (`list_pages`, `get_page`, `create_page`, `update_page`, `list_page_revisions`, `get_page_revision`, `revert_page_revision`), so the Pages/notebook surface was entirely non-functional through MCP. Two non-pages call sites had the identical defect but failed quietly instead of erroring: the datatypes class mapping degraded to an empty mapping on the 404, and the `style=run` workflow download was caught and fell through to the `.ga` export fallback. Nine call sites in total; the other `f"{gi.url}/..."` uses in the file were already correct.

This is a regression from c341fc4, which routed the pages tools through bioblend's thread-safe `make_*` helpers. The previous code used a base URL that did not include `/api`; the switch to `gi.url` kept the `/api` in the path without dropping it from the base. The helpers themselves are correct and are untouched here -- only the URL construction changed.

The tests didn't catch this because `test_page_operations.py` set `self.gi.url = "http://localhost:8080"`, with no `/api` suffix, and then asserted URLs relative to that same constant. All seven assertions passed against a shape a real `GalaxyInstance` cannot produce. The fixture now splits the server base from the API root and the assertions name the real wire URL, which turns all seven red against the old source. The two silently-degrading call sites get URL guards too, since neither surfaces a 404 on its own. A separate test constructs a real `GalaxyInstance` (offline -- bioblend only probes the network when the URL has no scheme) and asserts `url == base + "/api"`, so if bioblend ever changes that contract it fails there rather than silently invalidating every URL assertion in the module.

Reported in https://github.com/galaxyproject/loom/issues/420 -- a beta tester hit it asking for a Galaxy notebook. The same report mentions the page rendering as HTML rather than markdown; that was a side effect of the reporter's hand-rolled `curl` workaround (Galaxy's REST default is `html`), and `create_page` already sends `content_format: "markdown"` explicitly, so nothing is changed for it here.

Verified with the full suite (256 passed, 24 skipped), plus ruff check, ruff format, and mypy.
